### PR TITLE
feat/queue-management

### DIFF
--- a/src/components/aside-panel.tsx
+++ b/src/components/aside-panel.tsx
@@ -1,5 +1,175 @@
-import { Card } from "@/components/ui/card";
+import { CheckCircle2, ListX, Video } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from '@/components/ui/context-menu';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { cn } from '@/lib/utils';
+import { usePlayerStore } from '@/stores/player-store';
+import { type QueueItem, useQueueStore } from '@/stores/queue-store';
+
+type TabValue = 'queue' | 'notes' | 'themes';
+
+const TABS: { value: TabValue; label: string }[] = [
+  { value: 'queue', label: 'Queue' },
+  { value: 'notes', label: 'Notes' },
+  { value: 'themes', label: 'Themes' },
+];
 
 export function AsidePanel() {
-	return <Card className="w-full h-full">three</Card>;
+  const { queue, removeFromQueue, markPlayed, togglePlayed, loadFromDb } = useQueueStore();
+  const loadFile = usePlayerStore((s) => s.loadFile);
+
+  const [activeTab, setActiveTab] = useState<TabValue>('queue');
+  const [indicatorStyle, setIndicatorStyle] = useState({ left: 0, width: 0 });
+  const [ready, setReady] = useState(false);
+  const navRef = useRef<HTMLDivElement>(null);
+  const triggerRefs = useRef<Map<TabValue, HTMLButtonElement>>(new Map());
+
+  useEffect(() => {
+    loadFromDb();
+  }, [loadFromDb]);
+
+  useEffect(() => {
+    const activeBtn = triggerRefs.current.get(activeTab);
+    const nav = navRef.current;
+    if (!activeBtn || !nav) return;
+
+    const navRect = nav.getBoundingClientRect();
+    const btnRect = activeBtn.getBoundingClientRect();
+
+    setIndicatorStyle({
+      left: btnRect.left - navRect.left,
+      width: btnRect.width,
+    });
+    setReady(true);
+  }, [activeTab]);
+
+  return (
+    <Card className="flex flex-col w-full h-full overflow-hidden">
+      <Tabs
+        value={activeTab}
+        onValueChange={(v) => setActiveTab(v as TabValue)}
+        className="flex flex-col h-full"
+      >
+        <div ref={navRef} className="relative border-b border-border shrink-0">
+          <TabsList
+            variant="line"
+            className="w-full justify-start rounded-none border-none px-2 h-10"
+          >
+            {TABS.map((tab) => (
+              <TabsTrigger
+                key={tab.value}
+                value={tab.value}
+                ref={(el: HTMLButtonElement | null) => {
+                  if (el) triggerRefs.current.set(tab.value, el);
+                }}
+                className="flex-none px-4 after:hidden"
+              >
+                {tab.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+
+          {ready && (
+            <span
+              className="absolute bottom-0 h-0.5 bg-primary rounded-full"
+              style={{
+                left: indicatorStyle.left,
+                width: indicatorStyle.width,
+                transition: 'left 250ms ease, width 250ms ease',
+              }}
+            />
+          )}
+        </div>
+
+        <TabsContent value="queue" className="flex-1 overflow-hidden mt-0">
+          <QueueTab
+            queue={queue}
+            onRemove={removeFromQueue}
+            onTogglePlayed={togglePlayed}
+            onPlay={(item) => {
+              loadFile(item.file.path);
+              markPlayed(item.id);
+            }}
+          />
+        </TabsContent>
+
+        <TabsContent value="notes" className="flex-1 overflow-hidden mt-0">
+          <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
+            Coming soon
+          </div>
+        </TabsContent>
+
+        <TabsContent value="themes" className="flex-1 overflow-hidden mt-0">
+          <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
+            Coming soon
+          </div>
+        </TabsContent>
+      </Tabs>
+    </Card>
+  );
+}
+
+function QueueTab({
+  queue,
+  onRemove,
+  onTogglePlayed,
+  onPlay,
+}: {
+  queue: QueueItem[];
+  onRemove: (id: number) => void;
+  onTogglePlayed: (id: number) => void;
+  onPlay: (item: QueueItem) => void;
+}) {
+  if (queue.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
+        Queue is empty
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full overflow-auto">
+      {queue.map((item) => (
+        <ContextMenu key={item.id}>
+          <ContextMenuTrigger>
+            <Button
+              variant="ghost"
+              className={cn(
+                'w-full justify-start text-left p-3 h-auto gap-3',
+                item.played && 'opacity-50'
+              )}
+              onDoubleClick={() => onPlay(item)}
+            >
+              {item.played ? (
+                <CheckCircle2 className="size-4 text-primary shrink-0" />
+              ) : (
+                <Video className="size-4 text-muted-foreground shrink-0" />
+              )}
+              <span className={cn('text-sm truncate', item.played && 'line-through')}>
+                {item.file.name}
+              </span>
+            </Button>
+          </ContextMenuTrigger>
+          <ContextMenuContent side="bottom">
+            <ContextMenuItem onClick={() => onTogglePlayed(item.id)}>
+              <CheckCircle2 className="h-4 w-4" />
+              {item.played ? 'Mark as unplayed' : 'Mark as played'}
+            </ContextMenuItem>
+            <ContextMenuItem onClick={() => onRemove(item.id)} variant="destructive">
+              <ListX className="h-4 w-4" />
+              Remove from queue
+            </ContextMenuItem>
+          </ContextMenuContent>
+        </ContextMenu>
+      ))}
+    </div>
+  );
 }

--- a/src/components/file-list-item.tsx
+++ b/src/components/file-list-item.tsx
@@ -5,6 +5,8 @@ import {
   FolderOpen,
   Headphones,
   Image as ImageIcon,
+  ListPlus,
+  ListVideo,
   Music,
   Trash2,
   Video,
@@ -15,6 +17,7 @@ import {
   ContextMenu,
   ContextMenuContent,
   ContextMenuItem,
+  ContextMenuSeparator,
   ContextMenuTrigger,
 } from '@/components/ui/context-menu';
 import type { FileInfo, MediaType } from '@/services';
@@ -25,6 +28,8 @@ interface FileListItemProps {
   mediaType: MediaType;
   onClick?: (file: FileInfo) => void;
   onDoubleClick?: (file: FileInfo) => void;
+  onPlayNext?: (file: FileInfo) => void;
+  onAddToQueue?: (file: FileInfo) => void;
   isFocused?: boolean;
 }
 
@@ -70,6 +75,8 @@ export function FileListItem({
   mediaType,
   onClick,
   onDoubleClick,
+  onPlayNext,
+  onAddToQueue,
   isFocused,
 }: FileListItemProps) {
   const Icon = getMediaIcon(mediaType);
@@ -110,7 +117,7 @@ export function FileListItem({
       <ContextMenuTrigger>
         <Button
           variant="ghost"
-          className={`w-full justify-start hover:bg-primary/15 text-left p-3 h-auto ${isFocused ? 'ring-2 ring-ring' : ''}`}
+          className={`w-full justify-start text-left p-3 h-auto ${isFocused ? 'ring-2 ring-ring' : ''}`}
           onClick={handleClick}
           onDoubleClick={handleDoubleClick}
           aria-label={fileDescription}
@@ -134,6 +141,23 @@ export function FileListItem({
         </Button>
       </ContextMenuTrigger>
       <ContextMenuContent side="bottom">
+        {(onPlayNext || onAddToQueue) && (
+          <>
+            {onPlayNext && (
+              <ContextMenuItem onClick={() => onPlayNext(file)}>
+                <ListVideo className="h-4 w-4" aria-hidden="true" />
+                Play next
+              </ContextMenuItem>
+            )}
+            {onAddToQueue && (
+              <ContextMenuItem onClick={() => onAddToQueue(file)}>
+                <ListPlus className="h-4 w-4" aria-hidden="true" />
+                Add to queue
+              </ContextMenuItem>
+            )}
+            <ContextMenuSeparator />
+          </>
+        )}
         <ContextMenuItem onClick={handleOpenFolder}>
           <FolderOpen className="h-4 w-4" aria-hidden="true" />
           Open folder

--- a/src/components/media-panel.tsx
+++ b/src/components/media-panel.tsx
@@ -19,9 +19,10 @@ import { FileListItem } from '@/components/file-list-item';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { useAnnounce } from '@/hooks/use-announce';
-import { type FileInfo, fileInitService, fileManagementService, mediaDbService, type MediaType } from '@/services';
-import { usePlayerStore } from '@/stores/player-store';
 import { cn } from '@/lib/utils';
+import { type FileInfo, fileInitService, fileManagementService, type MediaType } from '@/services';
+import { usePlayerStore } from '@/stores/player-store';
+import { useQueueStore } from '@/stores/queue-store';
 import { InputGroup, InputGroupAddon, InputGroupInput } from './ui/input-group';
 
 const mediaItems = [
@@ -36,6 +37,7 @@ const mediaItems = [
 export function MediaPanel() {
   const { t } = useTranslation();
   const player = usePlayerStore();
+  const { addToQueue, playNext } = useQueueStore();
   const [activeMedia, setActiveMedia] = useState<MediaType | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [files, setFiles] = useState<FileInfo[]>([]);
@@ -276,7 +278,10 @@ export function MediaPanel() {
                 aria-label={`Refresh ${currentItem.label.toLowerCase()} folder`}
                 disabled={isLoading}
               >
-                <RefreshCw className={cn('size-4', isLoading && 'animate-spin')} aria-hidden="true" />
+                <RefreshCw
+                  className={cn('size-4', isLoading && 'animate-spin')}
+                  aria-hidden="true"
+                />
               </Button>
             </div>
 
@@ -359,6 +364,8 @@ export function MediaPanel() {
                                 ? (file) => player.loadFile(file.path)
                                 : undefined
                             }
+                            onPlayNext={activeMedia === 'video' ? playNext : undefined}
+                            onAddToQueue={activeMedia === 'video' ? addToQueue : undefined}
                           />
                         </div>
                       </div>
@@ -377,7 +384,7 @@ export function MediaPanel() {
                 <Button
                   key={item.id}
                   onClick={() => setActiveMedia(item.id)}
-                  className="justify-start hover:bg-primary/15"
+                  className="justify-start"
                   type="button"
                   variant="ghost"
                   aria-label={`Open ${item.label} category`}


### PR DESCRIPTION
## Description

Introduces a comprehensive playback queue management system allowing users to queue media files, manage their order, and experience seamless playback transitions.

### What was changed?

- **Queue tab in Aside Panel** — displays queued media, remove items, mark as played/unplayed
- **QueueDbService** — persistent storage for queue items via SQLite
- **Auto-advance** — video player shifts to the next item on media completion
- **Media Panel integration** — context menu options: "Add to Queue" and "Play Next"
- **Application routing** — main view restructured with TanStack Router layout route (`/_layout`); new routes: `/edit`, `/live`, `/presentation`, `/settings`
- **App Header** — functional navigation via TanStack Router `Link`

## Related Issues

- Closes #6