### PR TITLE
feat(modules): build module/extension system foundation

### DIFF
--- a/docs/module-api-reference.md
+++ b/docs/module-api-reference.md
@@ -414,24 +414,71 @@ Exposed on the host but still only wired via bus — read methods return empty/d
 
 ---
 
-## Titlebar menus ⚠️
+## `host.menus` ✅
 
-The titlebar menu system exists and works internally, but the API for modules to register menus is **not yet exposed on `LumenHost`**. It is planned.
-
-When available, the API will look something like:
+Registers menus and menu items in the application titlebar.
 
 ```ts
-// (not yet available on host)
-host.ui.registerMenu({
+// Register a full menu
+host.menus.register({
   id: 'my-module',
   label: 'My Module',
+  priority: 50,          // optional — controls position relative to other menus
   items: [
-    { type: 'action', label: 'Open panel', onClick: () => {} },
+    { type: 'action', id: 'my-module.open', label: 'Open panel', onClick: () => {} },
     { type: 'separator' },
-    { type: 'action', label: 'Settings', onClick: () => {} },
+    { type: 'action', id: 'my-module.settings', label: 'Settings', shortcut: 'Ctrl+,', onClick: () => {} },
   ],
 });
 ```
+
+```ts
+// Add an item to an existing menu (e.g. the built-in Modules menu)
+host.menus.addItem(
+  'modules',
+  { type: 'action', id: 'my-module.reload', label: 'Reload My Module', onClick: () => {} },
+  10,     // optional priority within the menu
+);
+```
+
+Both methods return a `Disposable` — the menu or item is automatically removed on module unload.
+
+### `MenuSpec`
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | `string` | ✓ | Unique menu identifier |
+| `label` | `string` | ✓ | Menu label shown in the titlebar |
+| `items` | `MenuItemDef[]` | | Initial items (can be empty) |
+| `priority` | `number` | | Order relative to other menus (lower = earlier) |
+
+### `MenuItemAction`
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `type` | `'action'` | ✓ | Item type |
+| `id` | `string` | ✓ | Unique item id (needed for `addItem` / unregistration) |
+| `label` | `string` | ✓ | Displayed text |
+| `shortcut` | `string` | | Keyboard shortcut hint shown in the menu |
+| `onClick` | `() => void` | | Click handler |
+
+### `MenuItemSeparator`
+
+```ts
+{ type: 'separator' }
+```
+
+### Built-in menu ids
+
+| `menuId` | Menu |
+|---|---|
+| `'file'` | File |
+| `'edit'` | Edit |
+| `'view'` | View |
+| `'presentation'` | Presentation |
+| `'live'` | Live |
+| `'modules'` | Modules |
+| `'help'` | Help |
 
 ---
 

--- a/docs/module-api-reference.md
+++ b/docs/module-api-reference.md
@@ -181,6 +181,79 @@ host.commands.invoke('my-module.search', { query: 'test' });
 | `onClose` | `() => void` | Closes the palette entirely |
 | `onBack` | `() => void` | Returns to the palette root list |
 
+### Prefix search
+
+Registers a keyword prefix that intercepts typed queries in the palette. When the user types `bible foo`, the query `foo` is routed to your handler instead of running the normal search.
+
+```ts
+host.commands.addPrefix({
+  prefix: 'bible',
+  title: 'Bible',
+  placeholder: 'Type a reference (1Jo 2:1) or phrase...',
+  handle(query) {
+    if (!query) return [];
+
+    // verse reference: "1jo 2:1", "john 3"
+    if (/^\w+\s+\d+(:\d+)?/.test(query)) {
+      return [
+        {
+          id: `verse:${query}`,
+          title: `Go to ${query}`,
+          subtitle: 'Open in Bible viewer',
+          run() { host.bus.emit('bible:navigate', { ref: query }); },
+        },
+      ];
+    }
+
+    // full-text search (async)
+    return searchBibleAsync(query).then((verses) =>
+      verses.map((v) => ({
+        id: `verse:${v.ref}`,
+        title: v.text,
+        subtitle: v.ref,
+        badge: 'VERSE',
+        run() { host.bus.emit('bible:navigate', { ref: v.ref }); },
+      }))
+    );
+  },
+});
+```
+
+While a module prefix is active the filter tabs are hidden and results appear under a single group labeled with the prefix `title`. The input placeholder switches to the value you provide in `placeholder`.
+
+### `PrefixSpec`
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `prefix` | `string` | ✓ | Trigger word, e.g. `'bible'` |
+| `title` | `string` | ✓ | Group heading shown in results |
+| `icon` | `React.ComponentType` | | Optional icon |
+| `placeholder` | `string` | | Input placeholder while prefix is active |
+| `handle` | `(query: string) => PrefixResult[] \| Promise<PrefixResult[]>` | ✓ | Called with the text after the prefix |
+
+### `PrefixResult`
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | `string` | ✓ | Unique within this handler call |
+| `title` | `string` | ✓ | Primary text |
+| `subtitle` | `string` | | Secondary line |
+| `badge` | `string` | | Override the badge label (defaults to prefix `title`) |
+| `run` | `() => void` | | Called on Enter — closes palette |
+| `component` | `React.ComponentType<CommanderAppProps>` | | Opens as an app screen inside the palette |
+
+### Built-in scope prefixes
+
+These are built into the commander — no module registration required. Typing the prefix word followed by a space auto-filters the results to the corresponding scope.
+
+| Prefix | Scope |
+|---|---|
+| `lyric <query>`, `lyrics <query>`, `song <query>` | Lyrics only |
+| `media <query>`, `audio <query>`, `video <query>`, `image <query>` | Media files |
+| `cmd <query>`, `command <query>`, `commands <query>` | Commands & Shortcuts |
+
+Example: `lyric amazing grace` is equivalent to switching to the **Lyrics** tab and typing `amazing grace`.
+
 ---
 
 ## `host.ui` ✅

--- a/docs/module-api-reference.md
+++ b/docs/module-api-reference.md
@@ -462,6 +462,33 @@ Both methods return a `Disposable` — the menu or item is automatically removed
 | `shortcut` | `string` | | Keyboard shortcut hint shown in the menu |
 | `onClick` | `() => void` | | Click handler |
 
+### `MenuItemSubmenu`
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `type` | `'submenu'` | ✓ | Item type |
+| `id` | `string` | | Optional identifier |
+| `label` | `string` | ✓ | Displayed text (becomes the submenu trigger) |
+| `items` | `MenuItemDef[]` | ✓ | Nested items — supports actions, separators, and further submenus |
+
+```ts
+host.menus.register({
+  id: 'my-module',
+  label: 'My Module',
+  items: [
+    { type: 'action', id: 'my-module.open', label: 'Open Panel', onClick: () => {} },
+    {
+      type: 'submenu',
+      label: 'Export',
+      items: [
+        { type: 'action', id: 'my-module.export.csv', label: 'As CSV', onClick: () => {} },
+        { type: 'action', id: 'my-module.export.json', label: 'As JSON', onClick: () => {} },
+      ],
+    },
+  ],
+});
+```
+
 ### `MenuItemSeparator`
 
 ```ts

--- a/docs/module-api-reference.md
+++ b/docs/module-api-reference.md
@@ -1,0 +1,482 @@
+# Module API Reference
+
+Reference for all APIs available to Lumen modules via `host.*`. A module receives the host in `onload` and uses it throughout its lifecycle.
+
+> **Status legend**
+> - ✅ Working — use without caveats
+> - ⚠️ Partial — works with documented limitations
+> - 🚧 Stub — accepts calls but has no real effect yet
+
+---
+
+## Basic module structure
+
+```ts
+import { LumenPlugin } from '@lumen/module-sdk';
+import type { LumenHost } from '@lumen/module-sdk';
+
+export default class MyModule extends LumenPlugin {
+  async onload(host: LumenHost) {
+    // register panels, commands, handlers...
+  }
+
+  async onunload() {
+    // additional cleanup (Disposables are cleaned up automatically)
+  }
+}
+```
+
+### `manifest.json`
+
+```json
+{
+  "id": "my-module",
+  "name": "My Module",
+  "version": "1.0.0",
+  "api": "^1.0.0",
+  "description": "Short description",
+  "author": { "name": "Your Name", "url": "https://example.com" },
+  "entry": "main.js",
+  "icon": "assets/icon.png"
+}
+```
+
+---
+
+## Lifecycle and Disposables
+
+Any resource registered via the host returns a `Disposable`. You can hold on to it to remove the resource manually, or ignore it — the runtime removes everything automatically on unload.
+
+```ts
+async onload(host: LumenHost) {
+  const d = host.commands.add({ id: 'foo', title: 'Foo', run: () => {} });
+
+  // manual removal before unload:
+  d.dispose();
+}
+```
+
+### Crash quota
+
+If a module accumulates **5 or more errors in 10 seconds**, the runtime auto-disables it and shows `faulted` on the Modules settings page. Errors in callbacks registered via the host (`commands.run`, `bus.on`, etc.) are caught and attributed to the module — asynchronous promise rejections are attributed as well.
+
+---
+
+## `host.meta` ✅
+
+```ts
+host.meta.id       // string — manifest id
+host.meta.version  // string — Lumen app version
+```
+
+---
+
+## `host.panels` ⚠️
+
+Adds React components to named slots in the interface. The infrastructure is ready; slots are still being wired into the app layout.
+
+```ts
+host.panels.add({
+  id: 'my-panel',
+  slot: 'sidebar.right.tabs',
+  title: 'My Panel',
+  component: MyComponent,
+  when: () => true,      // optional — visibility condition
+});
+```
+
+### `PanelSpec`
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | `string` | ✓ | Unique panel identifier |
+| `slot` | `SlotName` | ✓ | Where the panel appears |
+| `title` | `string` | | Displayed title |
+| `icon` | `string` | | Icon name or URL |
+| `component` | `React.ComponentType<PanelProps>` | ✓ | Component to render |
+| `when` | `() => boolean` | | Controls dynamic visibility |
+
+### `SlotName`
+
+| Value | Position |
+|---|---|
+| `'sidebar.right.tabs'` | Right sidebar tab |
+| `'toolbar'` | Toolbar |
+| `'statusbar'` | Bottom status bar |
+| `'presenter.content'` | Presenter window |
+| `'dialog'` | Modal over content |
+
+> ⚠️ No `<PanelSlot>` is placed in the app layout yet. Panels register successfully but are not visually rendered until slots are inserted.
+
+---
+
+## `host.commands` ⚠️
+
+Registers commands that appear in the command palette (Ctrl+K).
+
+```ts
+host.commands.add({
+  id: 'my-module.search',
+  title: 'Search file',
+  keybinding: 'Ctrl+Shift+F',
+  run: (args) => {
+    // command logic
+  },
+});
+```
+
+```ts
+// Invoke a command programmatically
+host.commands.invoke('my-module.search', { query: 'test' });
+```
+
+### `CommandSpec`
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | `string` | ✓ | Unique identifier |
+| `title` | `string` | ✓ | Text displayed in palette |
+| `keybinding` | `string` | | Declared keyboard shortcut |
+| `run` | `(args?: unknown) => unknown` | ✓ | Command callback |
+
+> ⚠️ Registration works, but the command palette still shows hardcoded items — module commands are not displayed in the UI yet. `invoke()` works normally.
+
+---
+
+## `host.ui` ✅
+
+```ts
+// Toast notification
+host.ui.notify({ message: 'Saved successfully' });
+host.ui.notify({ title: 'Warning', message: 'Something went wrong', level: 'error' });
+// levels: 'info' | 'warn' | 'error'  (default: 'info')
+
+// Confirmation dialog
+const ok = await host.ui.confirm({
+  title: 'Delete item?',
+  message: 'This action cannot be undone.',
+  danger: true,
+});
+
+// Text prompt
+const name = await host.ui.prompt({
+  title: 'File name',
+  placeholder: 'untitled.txt',
+  initial: '',
+});
+if (name !== null) { /* user confirmed */ }
+
+// Open command palette
+host.ui.openCommandPalette();
+host.ui.openCommandPalette('search');  // with prefilter
+```
+
+---
+
+## `host.bus` ✅
+
+Global bus shared across all modules. Use it for cross-module communication or to react to app events.
+
+```ts
+// Emit
+host.bus.emit('my-module:event', { value: 42 });
+
+// Subscribe
+const sub = host.bus.on<{ value: number }>('my-module:event', (payload) => {
+  console.log(payload.value);
+});
+
+// Unsubscribe before unload:
+sub.dispose();
+```
+
+### Events emitted by the app (listen via `host.bus`)
+
+| Topic | Payload | Description |
+|---|---|---|
+| `'lyrics:advance'` | — | Lyrics slide advanced |
+| `'lyrics:back'` | — | Lyrics slide went back |
+| `'queue:add'` | `QueueItem` | Item added to queue |
+| `'queue:remove'` | `{ id }` | Item removed from queue |
+| `'queue:reorder'` | `{ from, to }` | Queue reordered |
+| `'queue:shuffle'` | — | Queue shuffled |
+| `'queue:markPlayed'` | `{ id }` | Item marked as played |
+| `'player:play'` | `TrackRef?` | Playback started |
+| `'player:pause'` | — | Playback paused |
+| `'player:seek'` | `{ seconds }` | Track seeked |
+| `'player:volume'` | `{ value }` | Volume changed |
+| `'player:next'` | — | Next track |
+| `'player:prev'` | — | Previous track |
+| `'presentation:project'` | `{ viewId, props? }` | Projection started |
+| `'presentation:clear'` | — | Projection cleared |
+| `'themes:apply'` | `{ id }` | Theme changed |
+
+---
+
+## `host.events` ✅
+
+Module-local bus — same API as `bus`, but events are isolated: only the module itself receives them.
+
+```ts
+host.events.emit('state:changed', { active: true });
+host.events.on('state:changed', (payload) => { /* ... */ });
+```
+
+---
+
+## `host.settings` ⚠️
+
+Registers module settings.
+
+```ts
+host.settings.register({
+  key: 'show-badge',
+  label: 'Show badge',
+  description: 'Displays a counter on the sidebar tab',
+  type: 'boolean',
+  default: true,
+});
+
+host.settings.register({
+  key: 'mode',
+  label: 'Operation mode',
+  type: 'select',
+  default: 'compact',
+  options: [
+    { value: 'compact', label: 'Compact' },
+    { value: 'expanded', label: 'Expanded' },
+  ],
+});
+
+const value = host.settings.get<boolean>('show-badge');
+host.settings.set('show-badge', false);
+
+host.settings.onChange<boolean>('show-badge', (newValue) => {
+  // react to change
+});
+```
+
+### `SettingSpec`
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `key` | `string` | ✓ | Unique key within the module |
+| `label` | `string` | ✓ | Display label |
+| `description` | `string` | | Help text |
+| `type` | `'boolean' \| 'string' \| 'number' \| 'select'` | ✓ | Value type |
+| `default` | `T` | ✓ | Default value |
+| `options` | `Array<{ value, label }>` | | Only for `'select'` |
+
+> ⚠️ Settings work in memory but are not shown in any UI and do not persist across reloads. Use `host.data.json` to persist preferences for now.
+
+---
+
+## `host.data` ✅
+
+Persistent storage isolated per module.
+
+### JSON
+
+Ideal for settings and simple state.
+
+```ts
+// Load everything
+const state = await host.data.json.load();
+
+// Save everything at once
+await host.data.json.save({ count: 10, items: [] });
+
+// Read/write individual keys
+const count = await host.data.json.get<number>('count', 0);
+await host.data.json.set('count', count + 1);
+await host.data.json.delete('obsolete-key');
+```
+
+### SQLite
+
+Ideal for larger volumes of structured data.
+
+```ts
+const db = await host.data.sqlite();
+
+// Versioned migrations (always run in onload)
+await db.migrate([
+  {
+    version: 1,
+    up: `CREATE TABLE IF NOT EXISTS items (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL,
+      created_at INTEGER NOT NULL
+    )`,
+  },
+]);
+
+// Write
+await db.exec('INSERT INTO items VALUES (?, ?, ?)', [id, name, Date.now()]);
+
+// Read
+const items = await db.query<{ id: string; name: string }>(
+  'SELECT id, name FROM items ORDER BY created_at DESC'
+);
+```
+
+---
+
+## `host.fs` ✅
+
+File system access within the module's data directory. Paths are always relative to the module root — path traversal attempts (`../`) are blocked by the runtime.
+
+```ts
+// Read
+const bytes = await host.fs.read('cache/thumb.jpg');
+
+// Write
+const encoder = new TextEncoder();
+await host.fs.write('export.csv', encoder.encode('id,name\n1,test'));
+
+// Existence check
+const exists = await host.fs.exists('config.json');
+
+// List directory
+const files = await host.fs.list('cache/');
+
+// Remove
+await host.fs.remove('temp/file.tmp');
+```
+
+---
+
+## `host.net` ✅
+
+Fetch wrapper with error handling. Throws on non-OK responses.
+
+```ts
+// GET — returns parsed JSON
+const data = await host.net.get<{ id: number; title: string }>(
+  'https://api.example.com/items/1'
+);
+
+// POST — body automatically serialized as JSON
+const result = await host.net.post<{ ok: boolean }>(
+  'https://api.example.com/items',
+  { title: 'New item', priority: 1 }
+);
+
+// Extra fetch options (headers, etc.)
+const protected = await host.net.get('https://api.example.com/private', {
+  headers: { Authorization: 'Bearer token' },
+});
+```
+
+---
+
+## `host.log` ✅
+
+Logger prefixed with the module id. Output goes to the console and Tauri logs.
+
+```ts
+host.log.debug('Starting sync...');
+host.log.info('Module loaded', { version: '1.2.0' });
+host.log.warn('Unexpected API response', response);
+host.log.error('Failed to save', error);
+```
+
+---
+
+## `host.i18n` ⚠️
+
+Basic internationalization for module strings.
+
+```ts
+const text = host.i18n.t('greeting', { name: 'Gabriel' });
+// 'Hello, {{name}}' → 'Hello, Gabriel'
+
+const locale = host.i18n.locale();
+// 'en-US'
+```
+
+> ⚠️ Not integrated with the app's i18next instance. Does simple `{{key}}` substitution only — no plurals, namespaces, or automatic translation file loading.
+
+---
+
+## Domain APIs 🚧
+
+Exposed on the host but still only wired via bus — read methods return empty/default data. Use them only to emit events for now; to react to real app state, prefer `host.bus.on(...)`.
+
+| API | Read methods | Write methods |
+|---|---|---|
+| `host.lyrics` | `list()` → `[]`, `get()` → `null`, `currentSlide()` → `null` | `advance()`, `back()` emit on bus |
+| `host.queue` | `items()` → `[]`, `currentIndex()` → `-1` | `add()`, `remove()`, `reorder()`, `shuffle()`, `markPlayed()` emit on bus |
+| `host.library` | `list()` → `[]`, `get()` → `null` | — |
+| `host.player` | `current()` → `null`, `state()` → `'idle'`, `volume()` → `1` | `play()`, `pause()`, `seek()`, `next()`, `prev()` emit on bus |
+| `host.presentation` | `state()` → `'idle'`, `isWindowOpen()` → `false` | `project()`, `clear()` emit on bus |
+| `host.themes` | `current()` → default theme, `list()` → `[default theme]` | `apply()` emits on bus |
+
+---
+
+## Titlebar menus ⚠️
+
+The titlebar menu system exists and works internally, but the API for modules to register menus is **not yet exposed on `LumenHost`**. It is planned.
+
+When available, the API will look something like:
+
+```ts
+// (not yet available on host)
+host.ui.registerMenu({
+  id: 'my-module',
+  label: 'My Module',
+  items: [
+    { type: 'action', label: 'Open panel', onClick: () => {} },
+    { type: 'separator' },
+    { type: 'action', label: 'Settings', onClick: () => {} },
+  ],
+});
+```
+
+---
+
+## Full example
+
+```ts
+import { LumenPlugin } from '@lumen/module-sdk';
+import type { LumenHost } from '@lumen/module-sdk';
+import { MainPanel } from './components/MainPanel';
+
+export default class ExamplePlugin extends LumenPlugin {
+  async onload(host: LumenHost) {
+    // Load persisted state
+    const count = await host.data.json.get<number>('count', 0);
+
+    // Register panel
+    host.panels.add({
+      id: 'example.panel',
+      slot: 'sidebar.right.tabs',
+      title: 'Example',
+      component: MainPanel,
+    });
+
+    // Register command
+    host.commands.add({
+      id: 'example.increment',
+      title: 'Example: Increment counter',
+      run: async () => {
+        const current = await host.data.json.get<number>('count', 0);
+        await host.data.json.set('count', current + 1);
+        host.ui.notify({ message: `Counter: ${current + 1}` });
+        host.bus.emit('example:count', { value: current + 1 });
+      },
+    });
+
+    // React to app events
+    host.bus.on('player:play', (track) => {
+      host.log.info('Playback started', track);
+    });
+
+    host.log.info('Module loaded', { initialCount: count });
+  }
+
+  async onunload() {
+    host.log.info('Module unloaded');
+  }
+}
+```

--- a/docs/module-api-reference.md
+++ b/docs/module-api-reference.md
@@ -110,23 +110,53 @@ host.panels.add({
 
 ---
 
-## `host.commands` ⚠️
+## `host.commands` ✅
 
-Registers commands that appear in the command palette (Ctrl+K).
+Registers entries in the command palette (Ctrl+K / ⌘K). Two types are supported: `'action'` executes a function immediately; `'app'` opens a sub-UI inside the palette itself.
+
+### Action command
 
 ```ts
 host.commands.add({
   id: 'my-module.search',
-  title: 'Search file',
-  keybinding: 'Ctrl+Shift+F',
+  title: 'Search files',
+  subtitle: 'Find files in the library',      // optional — shown below title
+  keybinding: 'Ctrl+Shift+F',                 // optional — displayed as hint
+  keywords: ['find', 'browse'],               // optional — improve search hits
+  type: 'action',                             // default when omitted
   run: (args) => {
-    // command logic
+    // executes when the user selects the command
   },
 });
 ```
 
+### App command
+
+Selecting an app command navigates into a sub-view inside the palette where a React component renders freely.
+
 ```ts
-// Invoke a command programmatically
+import { type CommanderAppProps } from '@lumen/module-sdk';
+
+function SearchApp({ onBack, onClose }: CommanderAppProps) {
+  return (
+    <div className="p-4">
+      {/* full UI here */}
+      <button onClick={onBack}>Back</button>
+    </div>
+  );
+}
+
+host.commands.add({
+  id: 'my-module.browser',
+  title: 'File Browser',
+  subtitle: 'Browse library files',
+  type: 'app',
+  component: SearchApp,
+});
+```
+
+```ts
+// Invoke any command programmatically
 host.commands.invoke('my-module.search', { query: 'test' });
 ```
 
@@ -134,12 +164,22 @@ host.commands.invoke('my-module.search', { query: 'test' });
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `id` | `string` | ✓ | Unique identifier |
+| `id` | `string` | ✓ | Unique identifier (`module-id.name` recommended) |
 | `title` | `string` | ✓ | Text displayed in palette |
-| `keybinding` | `string` | | Declared keyboard shortcut |
-| `run` | `(args?: unknown) => unknown` | ✓ | Command callback |
+| `subtitle` | `string` | | Secondary line below title |
+| `icon` | `React.ComponentType<{ className?: string }>` | | Lucide or custom icon |
+| `keybinding` | `string` | | Keyboard shortcut hint (display only) |
+| `keywords` | `string[]` | | Extra terms that match this command |
+| `type` | `'action' \| 'app'` | | Defaults to `'action'` |
+| `run` | `(args?: unknown) => unknown` | ✓ for `'action'` | Executed on select |
+| `component` | `React.ComponentType<CommanderAppProps>` | ✓ for `'app'` | Sub-UI rendered in palette |
 
-> ⚠️ Registration works, but the command palette still shows hardcoded items — module commands are not displayed in the UI yet. `invoke()` works normally.
+### `CommanderAppProps`
+
+| Prop | Type | Description |
+|---|---|---|
+| `onClose` | `() => void` | Closes the palette entirely |
+| `onBack` | `() => void` | Returns to the palette root list |
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
 			"imports": {
 				"react":             "/__lumen/react.js",
 				"react-dom":         "/__lumen/react-dom.js",
+				"react-dom/client":  "/__lumen/react-dom.js",
 				"@lumen/ui":         "/__lumen/ui.js",
 				"@lumen/module-sdk": "/__lumen/module-sdk.js"
 			}

--- a/index.html
+++ b/index.html
@@ -5,6 +5,16 @@
 		<link rel="icon" type="image/svg+xml" href="/logo.png">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<title>Lumen</title>
+		<script type="importmap">
+		{
+			"imports": {
+				"react":             "/__lumen/react.js",
+				"react-dom":         "/__lumen/react-dom.js",
+				"@lumen/ui":         "/__lumen/ui.js",
+				"@lumen/module-sdk": "/__lumen/module-sdk.js"
+			}
+		}
+		</script>
 	</head>
 
 	<body>

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",
+    "esbuild": "^0.28.0",
     "rocketseat-biomejs-config": "^1.0.1",
     "tw-animate-css": "^1.3.6",
     "typescript": "~5.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,40 +8,10 @@ importers:
 
   .:
     dependencies:
-      '@radix-ui/react-alert-dialog':
-        specifier: ^1.1.15
-        version: 1.1.15(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-checkbox':
-        specifier: ^1.3.3
-        version: 1.3.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-context-menu':
-        specifier: ^2.2.16
-        version: 2.2.16(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-dialog':
-        specifier: ^1.1.15
-        version: 1.1.15(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-dropdown-menu':
-        specifier: ^2.1.16
-        version: 2.1.16(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-hover-card':
-        specifier: ^1.1.15
-        version: 1.1.15(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-label':
-        specifier: ^2.1.7
-        version: 2.1.7(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-menubar':
-        specifier: ^1.1.16
-        version: 1.1.16(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-popover':
-        specifier: ^1.1.15
-        version: 1.1.15(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@base-ui/react':
+        specifier: ^1.2.0
+        version: 1.5.0(@date-fns/tz@1.4.1)(@types/react@19.1.10)(date-fns@4.1.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@radix-ui/react-progress':
-        specifier: ^1.1.7
-        version: 1.1.7(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-select':
-        specifier: ^2.2.6
-        version: 2.2.6(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-separator':
         specifier: ^1.1.7
         version: 1.1.7(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@radix-ui/react-slider':
@@ -50,60 +20,108 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.3
         version: 1.2.3(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-switch':
-        specifier: ^1.2.6
-        version: 1.2.6(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-tabs':
-        specifier: ^1.1.13
-        version: 1.1.13(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-toggle':
-        specifier: ^1.1.10
-        version: 1.1.10(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-toggle-group':
-        specifier: ^1.1.11
-        version: 1.1.11(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-tooltip':
-        specifier: ^1.2.8
-        version: 1.2.8(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@tailwindcss/cli':
         specifier: ^4.0.9
         version: 4.1.11
       '@tailwindcss/vite':
         specifier: ^4.1.11
         version: 4.1.11(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.4))
+      '@tanstack/react-form':
+        specifier: ^1.28.5
+        version: 1.32.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@tanstack/react-router':
         specifier: ^1.131.8
         version: 1.131.8(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@tanstack/react-virtual':
+        specifier: ^3.13.18
+        version: 3.13.25(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@tauri-apps/api':
-        specifier: ^2
-        version: 2.7.0
+        specifier: ^2.11.0
+        version: 2.11.0
       '@tauri-apps/plugin-deep-link':
-        specifier: ~2
-        version: 2.4.1
+        specifier: ~2.4.9
+        version: 2.4.9
       '@tauri-apps/plugin-dialog':
-        specifier: ~2
-        version: 2.3.2
+        specifier: ~2.7.1
+        version: 2.7.1
       '@tauri-apps/plugin-fs':
-        specifier: ~2
-        version: 2.4.5
+        specifier: ~2.5.1
+        version: 2.5.1
       '@tauri-apps/plugin-global-shortcut':
-        specifier: ~2
-        version: 2.3.0
+        specifier: ~2.3.1
+        version: 2.3.1
       '@tauri-apps/plugin-log':
-        specifier: ~2
-        version: 2.6.0
+        specifier: ~2.8.0
+        version: 2.8.0
       '@tauri-apps/plugin-notification':
-        specifier: ~2
-        version: 2.3.0
+        specifier: ~2.3.3
+        version: 2.3.3
       '@tauri-apps/plugin-opener':
-        specifier: ~2
+        specifier: ~2.5.4
+        version: 2.5.4
+      '@tauri-apps/plugin-os':
+        specifier: ~2.3.2
+        version: 2.3.2
+      '@tauri-apps/plugin-shell':
+        specifier: ~2.3.5
+        version: 2.3.5
+      '@tauri-apps/plugin-sql':
+        specifier: ~2.4.0
         version: 2.4.0
+      '@tauri-apps/plugin-store':
+        specifier: ~2.4.3
+        version: 2.4.3
+      '@tauri-apps/plugin-stronghold':
+        specifier: ~2.3.1
+        version: 2.3.1
       '@tauri-apps/plugin-websocket':
-        specifier: ~2.4.0
-        version: 2.4.0
+        specifier: ~2.4.2
+        version: 2.4.2
       '@tauri-apps/plugin-window-state':
-        specifier: ~2.4.0
-        version: 2.4.0
+        specifier: ~2.4.1
+        version: 2.4.1
+      '@tiptap/extension-bubble-menu':
+        specifier: ^3.20.4
+        version: 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)
+      '@tiptap/extension-code-block-lowlight':
+        specifier: ^3.20.4
+        version: 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/extension-code-block@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)(highlight.js@11.11.1)(lowlight@3.3.0)
+      '@tiptap/extension-highlight':
+        specifier: ^3.20.4
+        version: 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))
+      '@tiptap/extension-image':
+        specifier: ^3.20.4
+        version: 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))
+      '@tiptap/extension-link':
+        specifier: ^3.20.4
+        version: 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)
+      '@tiptap/extension-placeholder':
+        specifier: ^3.20.4
+        version: 3.23.6(@tiptap/extensions@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6))
+      '@tiptap/extension-task-item':
+        specifier: ^3.20.4
+        version: 3.23.6(@tiptap/extension-list@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6))
+      '@tiptap/extension-task-list':
+        specifier: ^3.20.4
+        version: 3.23.6(@tiptap/extension-list@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6))
+      '@tiptap/extension-text-align':
+        specifier: ^3.20.4
+        version: 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))
+      '@tiptap/extension-underline':
+        specifier: ^3.20.4
+        version: 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))
+      '@tiptap/markdown':
+        specifier: ^3.20.4
+        version: 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)
+      '@tiptap/pm':
+        specifier: ^3.20.4
+        version: 3.23.6
+      '@tiptap/react':
+        specifier: ^3.20.4
+        version: 3.23.6(@floating-ui/dom@1.7.6)(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@tiptap/starter-kit':
+        specifier: ^3.20.4
+        version: 3.23.6
       '@vitejs/plugin-react-swc':
         specifier: ^4.0.0
         version: 4.0.0(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.4))
@@ -131,6 +149,9 @@ importers:
       polished:
         specifier: ^4.3.1
         version: 4.3.1
+      qrcode:
+        specifier: ^1.5.4
+        version: 1.5.4
       react:
         specifier: ^19.1.0
         version: 19.1.1
@@ -158,9 +179,15 @@ importers:
       tailwindcss:
         specifier: ^4.1.11
         version: 4.1.11
+      usehooks-ts:
+        specifier: ^3.1.1
+        version: 3.1.1(react@19.1.1)
       vaul:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      zustand:
+        specifier: ^5.0.11
+        version: 5.0.13(@types/react@19.1.10)(react@19.1.1)(use-sync-external-store@1.6.0(react@19.1.1))
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.1.4
@@ -169,11 +196,14 @@ importers:
         specifier: ^1.131.7
         version: 1.131.7(@tanstack/react-router@1.131.8(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.4))
       '@tauri-apps/cli':
-        specifier: ^2
-        version: 2.7.1
+        specifier: ^2.11.0
+        version: 2.11.2
       '@types/node':
         specifier: ^24.2.1
         version: 24.2.1
+      '@types/qrcode':
+        specifier: ^1.5.5
+        version: 1.5.6
       '@types/react':
         specifier: ^19.1.8
         version: 19.1.10
@@ -183,6 +213,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.6.0
         version: 4.7.0(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.4))
+      esbuild:
+        specifier: ^0.28.0
+        version: 0.28.0
       rocketseat-biomejs-config:
         specifier: ^1.0.1
         version: 1.0.1
@@ -335,6 +368,10 @@ packages:
     resolution: {integrity: sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.27.2':
     resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
     engines: {node: '>=6.9.0'}
@@ -346,6 +383,33 @@ packages:
   '@babel/types@7.28.2':
     resolution: {integrity: sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==}
     engines: {node: '>=6.9.0'}
+
+  '@base-ui/react@1.5.0':
+    resolution: {integrity: sha512-z1gSAlced1yY+iM+mHDEtIkD8UI3Ebs52MuBPxvV6f5hRutk+xvCH/wuB7hDqDzK9JG5FoMz5nhrqtSs1wjt1A==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@date-fns/tz': ^1.2.0
+      '@types/react': ^17 || ^18 || ^19
+      date-fns: ^4.0.0
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@date-fns/tz':
+        optional: true
+      '@types/react':
+        optional: true
+      date-fns:
+        optional: true
+
+  '@base-ui/utils@0.2.9':
+    resolution: {integrity: sha512-x/PDDCYzoqPpjrdyb3VcyylTI2IjUXEtYDGi5foh7KsnmNJIIaVwA2GLgDH1dps1GgXiJbA60hM+AyuTfQzIvw==}
+    peerDependencies:
+      '@types/react': ^17 || ^18 || ^19
+      react: ^17 || ^18 || ^19
+      react-dom: ^17 || ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@biomejs/biome@1.9.4':
     resolution: {integrity: sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog==}
@@ -386,48 +450,56 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64-musl@2.1.4':
     resolution: {integrity: sha512-nYr7H0CyAJPaLupFE2cH16KZmRC5Z9PEftiA2vWxk+CsFkPZQ6dBRdcC6RuS+zJlPc/JOd8xw3uCCt9Pv41WvQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@1.9.4':
     resolution: {integrity: sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-arm64@2.1.4':
     resolution: {integrity: sha512-juhEkdkKR4nbUi5k/KRp1ocGPNWLgFRD4NrHZSveYrD6i98pyvuzmS9yFYgOZa5JhaVqo0HPnci0+YuzSwT2fw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@1.9.4':
     resolution: {integrity: sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64-musl@2.1.4':
     resolution: {integrity: sha512-lvwvb2SQQHctHUKvBKptR6PLFCM7JfRjpCCrDaTmvB7EeZ5/dQJPhTYBf36BE/B4CRWR2ZiBLRYhK7hhXBCZAg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@1.9.4':
     resolution: {integrity: sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64@2.1.4':
     resolution: {integrity: sha512-Eoy9ycbhpJVYuR+LskV9s3uyaIkp89+qqgqhGQsWnp/I02Uqg2fXFblHJOpGZR8AxdB9ADy87oFVxn9MpFKUrw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@1.9.4':
     resolution: {integrity: sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==}
@@ -462,8 +534,20 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.25.9':
     resolution: {integrity: sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -474,8 +558,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.25.9':
     resolution: {integrity: sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -486,8 +582,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.25.9':
     resolution: {integrity: sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -498,8 +606,20 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.25.9':
     resolution: {integrity: sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -510,8 +630,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.25.9':
     resolution: {integrity: sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -522,8 +654,20 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.25.9':
     resolution: {integrity: sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -534,8 +678,20 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.25.9':
     resolution: {integrity: sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -546,8 +702,20 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.9':
     resolution: {integrity: sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -558,8 +726,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.25.9':
     resolution: {integrity: sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -570,8 +750,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.25.9':
     resolution: {integrity: sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -582,8 +774,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.25.9':
     resolution: {integrity: sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -594,8 +798,20 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.25.9':
     resolution: {integrity: sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -606,8 +822,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.25.9':
     resolution: {integrity: sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -615,17 +843,26 @@ packages:
   '@floating-ui/core@1.7.3':
     resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
 
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
   '@floating-ui/dom@1.7.3':
     resolution: {integrity: sha512-uZA413QEpNuhtb3/iIKoYMSK07keHPYeXF02Zhd6e213j+d1NamLix/mCLxBUDW/Gx52sPH2m+chlUsyaBs/Ag==}
 
-  '@floating-ui/react-dom@2.1.5':
-    resolution: {integrity: sha512-HDO/1/1oH9fjj4eLgegrlH3dklZpHtUYYFiVwMUwfGvk9jWDRWqkklA2/NFScknrcNSspbV868WjXORvreDX+Q==}
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/react-dom@2.1.8':
+    resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
@@ -673,36 +910,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.1':
     resolution: {integrity: sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.1':
     resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.1':
     resolution: {integrity: sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.1':
     resolution: {integrity: sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.1':
     resolution: {integrity: sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.1':
     resolution: {integrity: sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==}
@@ -735,45 +978,6 @@ packages:
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
-  '@radix-ui/react-alert-dialog@1.1.15':
-    resolution: {integrity: sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-arrow@1.1.7':
-    resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-checkbox@1.3.3':
-    resolution: {integrity: sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@radix-ui/react-collection@1.1.7':
     resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
     peerDependencies:
@@ -803,19 +1007,6 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
-        optional: true
-
-  '@radix-ui/react-context-menu@2.2.16':
-    resolution: {integrity: sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-context@1.0.1':
@@ -897,19 +1088,6 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-dropdown-menu@2.1.16':
-    resolution: {integrity: sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@radix-ui/react-focus-guards@1.0.1':
     resolution: {integrity: sha512-Rect2dWbQ8waGzhMavsIbmSVCgYxkXLxxR3ZvCX79JOglzdEy4JXMb98lq4hPxUbLr77nP0UOGf4rcMU+s1pUA==}
     peerDependencies:
@@ -954,19 +1132,6 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-hover-card@1.1.15':
-    resolution: {integrity: sha512-qgTkjNT1CfKMoP0rcasmlH2r1DAiYicWsDsufxl940sT2wHNEWWv6FMWIQXWhVdmC1d/HYfbhQx60KYyAtKxjg==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@radix-ui/react-id@1.0.1':
     resolution: {integrity: sha512-tI7sT/kqYp8p96yGWY1OAnLHrqDgzHefRBKQ2YAkBS5ja7QLcZ9Z/uY7bEjPUatf8RomoXM8/1sMj1IJaE5UzQ==}
     peerDependencies:
@@ -983,71 +1148,6 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
-        optional: true
-
-  '@radix-ui/react-label@2.1.7':
-    resolution: {integrity: sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-menu@2.1.16':
-    resolution: {integrity: sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-menubar@1.1.16':
-    resolution: {integrity: sha512-EB1FktTz5xRRi2Er974AUQZWg2yVBb1yjip38/lgwtCVRd3a+maUoGHN/xs9Yv8SY8QwbSEb+YrxGadVWbEutA==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-popover@1.1.15':
-    resolution: {integrity: sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-popper@1.2.8':
-    resolution: {integrity: sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-portal@1.0.4':
@@ -1141,45 +1241,6 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-roving-focus@1.1.11':
-    resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-select@2.2.6':
-    resolution: {integrity: sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-separator@1.1.7':
-    resolution: {integrity: sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@radix-ui/react-slider@1.3.6':
     resolution: {integrity: sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==}
     peerDependencies:
@@ -1209,71 +1270,6 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
-        optional: true
-
-  '@radix-ui/react-switch@1.2.6':
-    resolution: {integrity: sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-tabs@1.1.13':
-    resolution: {integrity: sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-toggle-group@1.1.11':
-    resolution: {integrity: sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-toggle@1.1.10':
-    resolution: {integrity: sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-tooltip@1.2.8':
-    resolution: {integrity: sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-use-callback-ref@1.0.1':
@@ -1366,15 +1362,6 @@ packages:
       '@types/react':
         optional: true
 
-  '@radix-ui/react-use-rect@1.1.1':
-    resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
   '@radix-ui/react-use-size@1.1.1':
     resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
     peerDependencies:
@@ -1383,22 +1370,6 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
-
-  '@radix-ui/react-visually-hidden@1.2.3':
-    resolution: {integrity: sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/rect@1.1.1':
-    resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
@@ -1440,56 +1411,67 @@ packages:
     resolution: {integrity: sha512-EtP8aquZ0xQg0ETFcxUbU71MZlHaw9MChwrQzatiE8U/bvi5uv/oChExXC4mWhjiqK7azGJBqU0tt5H123SzVA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.46.2':
     resolution: {integrity: sha512-qO7F7U3u1nfxYRPM8HqFtLd+raev2K137dsV08q/LRKRLEc7RsiDWihUnrINdsWQxPR9jqZ8DIIZ1zJJAm5PjQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.46.2':
     resolution: {integrity: sha512-3dRaqLfcOXYsfvw5xMrxAk9Lb1f395gkoBYzSFcc/scgRFptRXL9DOaDpMiehf9CO8ZDRJW2z45b6fpU5nwjng==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.46.2':
     resolution: {integrity: sha512-fhHFTutA7SM+IrR6lIfiHskxmpmPTJUXpWIsBXpeEwNgZzZZSg/q4i6FU4J8qOGyJ0TR+wXBwx/L7Ho9z0+uDg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.46.2':
     resolution: {integrity: sha512-i7wfGFXu8x4+FRqPymzjD+Hyav8l95UIZ773j7J7zRYc3Xsxy2wIn4x+llpunexXe6laaO72iEjeeGyUFmjKeA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.46.2':
     resolution: {integrity: sha512-B/l0dFcHVUnqcGZWKcWBSV2PF01YUt0Rvlurci5P+neqY/yMKchGU8ullZvIv5e8Y1C6wOn+U03mrDylP5q9Yw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.46.2':
     resolution: {integrity: sha512-32k4ENb5ygtkMwPMucAb8MtV8olkPT03oiTxJbgkJa7lJ7dZMr0GCFJlyvy+K8iq7F/iuOr41ZdUHaOiqyR3iQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.46.2':
     resolution: {integrity: sha512-t5B2loThlFEauloaQkZg9gxV05BYeITLvLkWOkRXogP4qHXLkWSbSHKM9S6H1schf/0YGP/qNKtiISlxvfmmZw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.46.2':
     resolution: {integrity: sha512-YKjekwTEKgbB7n17gmODSmJVUIvj8CX7q5442/CK80L8nqOUbMtf8b01QkG3jOqyr1rotrAnW6B/qiHwfcuWQA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.46.2':
     resolution: {integrity: sha512-Jj5a9RUoe5ra+MEyERkDKLwTXVu6s3aACP51nkfnK9wJTraCC8IMe3snOfALkrjTYd2G1ViE1hICj0fZ7ALBPA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.46.2':
     resolution: {integrity: sha512-7kX69DIrBeD7yNp4A5b81izs8BqoZkCIaxQaOpumcJ1S/kmqNFjPhDu1LHeVXv0SexfHQv5cqHsxLOjETuqDuA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.46.2':
     resolution: {integrity: sha512-wiJWMIpeaak/jsbaq2HMh/rzZxHVW1rU6coyeNNpMwk5isiPjSTx0a4YLSlYDwBH/WBvLz+EtsNqQScZTLJy3g==}
@@ -1529,24 +1511,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.13.3':
     resolution: {integrity: sha512-bc+CXYlFc1t8pv9yZJGus372ldzOVscBl7encUBlU1m/Sig0+NDJLz6cXXRcFyl6ABNOApWeR4Yl7iUWx6C8og==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.13.3':
     resolution: {integrity: sha512-dFXoa0TEhohrKcxn/54YKs1iwNeW6tUkHJgXW33H381SvjKFUV53WR231jh1sWVJETjA3vsAwxKwR23s7UCmUA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.13.3':
     resolution: {integrity: sha512-ieyjisLB+ldexiE/yD8uomaZuZIbTc8tjquYln9Quh5ykOBY7LpJJYBWvWtm1g3pHv6AXlBI8Jay7Fffb6aLfA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.13.3':
     resolution: {integrity: sha512-elTQpnaX5vESSbhCEgcwXjpMsnUbqqHfEpB7ewpkAsLzKEXZaK67ihSRYAuAx6ewRQTo7DS5iTT6X5aQD3MzMw==}
@@ -1623,24 +1609,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.11':
     resolution: {integrity: sha512-m/NVRFNGlEHJrNVk3O6I9ggVuNjXHIPoD6bqay/pubtYC9QIdAMpS+cswZQPBLvVvEF6GtSNONbDkZrjWZXYNQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.11':
     resolution: {integrity: sha512-YW6sblI7xukSD2TdbbaeQVDysIm/UPJtObHJHKxDEcW2exAtY47j52f8jZXkqE1krdnkhCMGqP3dbniu1Te2Fg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.11':
     resolution: {integrity: sha512-e3C/RRhGunWYNC3aSF7exsQkdXzQ/M+aYuZHKnw4U7KQwTJotnWsGOIVih0s2qQzmEzOFIJ3+xt7iq67K/p56Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.11':
     resolution: {integrity: sha512-Xo1+/GU0JEN/C/dvcammKHzeM6NqKovG+6921MR6oadee5XPBaKOumrJCXvopJ/Qb5TH7LX/UAywbqrP4lax0g==}
@@ -1675,9 +1665,30 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7
 
+  '@tanstack/devtools-event-client@0.4.3':
+    resolution: {integrity: sha512-OZI6QyULw0FI0wjgmeYzCIfbgPsOEzwJtCpa69XrfLMtNXLGnz3d/dIabk7frg0TmHo+Ah49w5I4KC7Tufwsvw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@tanstack/form-core@1.32.0':
+    resolution: {integrity: sha512-Tn5VRDSjyqjmaet2tJMuEWDRFyrCaon03vxXPlSSaiSs6C/N7lCIwGCXJbZXEUq1kTj8jYN9qyXHbsz4LQHcow==}
+
   '@tanstack/history@1.131.2':
     resolution: {integrity: sha512-cs1WKawpXIe+vSTeiZUuSBy8JFjEuDgdMKZFRLKwQysKo8y2q6Q1HvS74Yw+m5IhOW1nTZooa6rlgdfXcgFAaw==}
     engines: {node: '>=12'}
+
+  '@tanstack/pacer-lite@0.1.1':
+    resolution: {integrity: sha512-y/xtNPNt/YeyoVxE/JCx+T7yjEzpezmbb+toK8DDD1P4m7Kzs5YR956+7OKexG3f8aXgC3rLZl7b1V+yNUSy5w==}
+    engines: {node: '>=18'}
+
+  '@tanstack/react-form@1.32.0':
+    resolution: {integrity: sha512-6WP5SQTA6/H9crCpvpq3ZppYWqtrdE5NjOy6ebABi6uAQPqhfTzrdjS9t40mCZCFtGI5585OhJV6zBP/KN2zcw==}
+    peerDependencies:
+      '@tanstack/react-start': '*'
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@tanstack/react-start':
+        optional: true
 
   '@tanstack/react-router@1.131.8':
     resolution: {integrity: sha512-FbfUB8p42N3PmwGN2NpFx+f59pKmhu1B1QOcmyF3IlbC3y6R0jZofx1FbnmWFLz8cUHVmIP52L0s5DUj3Bj6fQ==}
@@ -1688,6 +1699,18 @@ packages:
 
   '@tanstack/react-store@0.7.3':
     resolution: {integrity: sha512-3Dnqtbw9P2P0gw8uUM8WP2fFfg8XMDSZCTsywRPZe/XqqYW8PGkXKZTvP0AHkE4mpqP9Y43GpOg9vwO44azu6Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/react-store@0.9.3':
+    resolution: {integrity: sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/react-virtual@3.13.25':
+    resolution: {integrity: sha512-bmNoqMu6gcAW9JGrKVB0Q1tN1i5RONZF8r1fW0bbE4Oyf3DwEGnzzQJ2OW+Ozg1P4s8PyugkHg2ULZoFQN+cqw==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -1728,6 +1751,12 @@ packages:
   '@tanstack/store@0.7.2':
     resolution: {integrity: sha512-RP80Z30BYiPX2Pyo0Nyw4s1SJFH2jyM6f9i3HfX4pA+gm5jsnYryscdq2aIQLnL4TaGuQMO+zXmN9nh1Qck+Pg==}
 
+  '@tanstack/store@0.9.3':
+    resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
+
+  '@tanstack/virtual-core@3.15.0':
+    resolution: {integrity: sha512-0AwPGx0I8QxPYjAxShT/+z+ZOe9u8mW5rsXvivCTjRfRmz9a43+3mRyi4wwlyoUqOC56q/jatKa0Bh9M99BEHQ==}
+
   '@tanstack/virtual-file-routes@1.131.2':
     resolution: {integrity: sha512-VEEOxc4mvyu67O+Bl0APtYjwcNRcL9it9B4HKbNgcBTIOEalhk+ufBl4kiqc8WP1sx1+NAaiS+3CcJBhrqaSRg==}
     engines: {node: '>=12'}
@@ -1735,106 +1764,320 @@ packages:
   '@tauri-apps/api@2.10.1':
     resolution: {integrity: sha512-hKL/jWf293UDSUN09rR69hrToyIXBb8CjGaWC7gfinvnQrBVvnLr08FeFi38gxtugAVyVcTa5/FD/Xnkb1siBw==}
 
-  '@tauri-apps/api@2.7.0':
-    resolution: {integrity: sha512-v7fVE8jqBl8xJFOcBafDzXFc8FnicoH3j8o8DNNs0tHuEBmXUDqrCOAzMRX0UkfpwqZLqvrvK0GNQ45DfnoVDg==}
+  '@tauri-apps/api@2.11.0':
+    resolution: {integrity: sha512-7CinYODhky9lmO23xHnUFv0Xt43fbtWMyxZcLcRBlFkcgXKuEirBvHpmtJ89YMhyeGcq20Wuc47Fa4XjyniywA==}
 
-  '@tauri-apps/cli-darwin-arm64@2.7.1':
-    resolution: {integrity: sha512-j2NXQN6+08G03xYiyKDKqbCV2Txt+hUKg0a8hYr92AmoCU8fgCjHyva/p16lGFGUG3P2Yu0xiNe1hXL9ZuRMzA==}
+  '@tauri-apps/cli-darwin-arm64@2.11.2':
+    resolution: {integrity: sha512-+4UZzLt+eOAEQCwgd+TqKgyUJMrvx+BgdXLLaqJYmPqzP+nE6YZr/hY6CWLYGQb8jFn99jEkmC6uA3tNvamA1w==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@tauri-apps/cli-darwin-x64@2.7.1':
-    resolution: {integrity: sha512-CdYAefeM35zKsc91qIyKzbaO7FhzTyWKsE8hj7tEJ1INYpoh1NeNNyL/NSEA3Nebi5ilugioJ5tRK8ZXG8y3gw==}
+  '@tauri-apps/cli-darwin-x64@2.11.2':
+    resolution: {integrity: sha512-VjYYtZUPqDMLutSfJEyxFE3Bz+DPi7c8wC3imckgvciLDZLq4qwKJxBicg0BXGhXjJsl8vKWgWRFNMPELQ+Xyg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@tauri-apps/cli-linux-arm-gnueabihf@2.7.1':
-    resolution: {integrity: sha512-dnvyJrTA1UJxJjQ8q1N/gWomjP8Twij1BUQu2fdcT3OPpqlrbOk5R1yT0oD/721xoKNjroB5BXCsmmlykllxNg==}
+  '@tauri-apps/cli-linux-arm-gnueabihf@2.11.2':
+    resolution: {integrity: sha512-yMemD6f4i95AQriS8EazyOFzbE34yjnP16i3IOzpHGQvBoy2DjypFMFBq0NtPuITURv/cOGguRtHR5d79/9CSA==}
     engines: {node: '>= 10'}
     cpu: [arm]
     os: [linux]
 
-  '@tauri-apps/cli-linux-arm64-gnu@2.7.1':
-    resolution: {integrity: sha512-FtBW6LJPNRTws3qyUc294AqCWU91l/H0SsFKq6q4Q45MSS4x6wxLxou8zB53tLDGEPx3JSoPLcDaSfPlSbyujQ==}
+  '@tauri-apps/cli-linux-arm64-gnu@2.11.2':
+    resolution: {integrity: sha512-cgI91D2wL8GSgoWwZXDqt+DwnuZCP2/bz03QAE4TrhgAKIsrB4hX26W/H1EONPUUNkqrsgeCD0wU6pcNjV/5kw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
-  '@tauri-apps/cli-linux-arm64-musl@2.7.1':
-    resolution: {integrity: sha512-/HXY0t4FHkpFzjeYS5c16mlA6z0kzn5uKLWptTLTdFSnYpr8FCnOP4Sdkvm2TDQPF2ERxXtNCd+WR/jQugbGnA==}
+  '@tauri-apps/cli-linux-arm64-musl@2.11.2':
+    resolution: {integrity: sha512-X1rm0BERqAAggtYTESSgXrS3sz4Sb/OiPiz54UqISlXW+GkR3vNIGnsy/lejNmoXGVqri3Q53BCfQiclOIyRPw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
-  '@tauri-apps/cli-linux-riscv64-gnu@2.7.1':
-    resolution: {integrity: sha512-GeW5lVI2GhhnaYckiDzstG2j2Jwlud5d2XefRGwlOK+C/bVGLT1le8MNPYK8wgRlpeK8fG1WnJJYD6Ke7YQ8bg==}
+  '@tauri-apps/cli-linux-riscv64-gnu@2.11.2':
+    resolution: {integrity: sha512-usbMLJbT3KtkOrBMDVeGYNM35aTHXx38SJSzTMSqqjeUIOQ+iVPjb2yAGNAE+KqmBbAx4FOFIyMeKXx2M/JKGQ==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
-  '@tauri-apps/cli-linux-x64-gnu@2.7.1':
-    resolution: {integrity: sha512-DprxKQkPxIPYwUgg+cscpv2lcIUhn2nxEPlk0UeaiV9vATxCXyytxr1gLcj3xgjGyNPlM0MlJyYaPy1JmRg1cA==}
+  '@tauri-apps/cli-linux-x64-gnu@2.11.2':
+    resolution: {integrity: sha512-Ru4gwJKPG0ctVGchRGpRup4Y4lW2SSfFnrbQcyHhCliKy4g8Qz97TrUgCur4CbWyAgKxvGh3SjrkA0LDYzDGiw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
-  '@tauri-apps/cli-linux-x64-musl@2.7.1':
-    resolution: {integrity: sha512-KLlq3kOK7OUyDR757c0zQjPULpGZpLhNB0lZmZpHXvoOUcqZoCXJHh4dT/mryWZJp5ilrem5l8o9ngrDo0X1AA==}
+  '@tauri-apps/cli-linux-x64-musl@2.11.2':
+    resolution: {integrity: sha512-eUm7T6clN1MMmNSRQ9gaWsQdyehQx2Gmn5hht/QUlqZQI/qcP2OJK5dnaxqwFzCr2HdsEo9ydxaqcS1oJzMvUw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
-  '@tauri-apps/cli-win32-arm64-msvc@2.7.1':
-    resolution: {integrity: sha512-dH7KUjKkSypCeWPiainHyXoES3obS+JIZVoSwSZfKq2gWgs48FY3oT0hQNYrWveE+VR4VoR3b/F3CPGbgFvksA==}
+  '@tauri-apps/cli-win32-arm64-msvc@2.11.2':
+    resolution: {integrity: sha512-HeeZW80jU+gVTOEX4X/hC6NVSAdDVXajwP5fxIZ/3z9WvUC7qrudX2GMTilYq6Dg0e0sk0XgsAJD1hZ5wPBXUA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@tauri-apps/cli-win32-ia32-msvc@2.7.1':
-    resolution: {integrity: sha512-1oeibfyWQPVcijOrTg709qhbXArjX3x1MPjrmA5anlygwrbByxLBcLXvotcOeULFcnH2FYUMMLLant8kgvwE5A==}
+  '@tauri-apps/cli-win32-ia32-msvc@2.11.2':
+    resolution: {integrity: sha512-YhjQNZcXfbkCLyazSv1nPnJ9iRFE1wm6kc51FDbU10/Dk09io+6PAGMLjkxnX2GdM0qMnDmTjstY8mTDVvtKeA==}
     engines: {node: '>= 10'}
     cpu: [ia32]
     os: [win32]
 
-  '@tauri-apps/cli-win32-x64-msvc@2.7.1':
-    resolution: {integrity: sha512-D7Q9kDObutuirCNLxYQ7KAg2Xxg99AjcdYz/KuMw5HvyEPbkC9Q7JL0vOrQOrHEHxIQ2lYzFOZvKKoC2yyqXcg==}
+  '@tauri-apps/cli-win32-x64-msvc@2.11.2':
+    resolution: {integrity: sha512-d2JchlFIpZevZVReyqhQOekJmb1UH3rhZ5VX6sH3ty9ETE0TKQavpihvoScUXfKKpW6HZC0MrFGRU0ZtD+w3gA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
 
-  '@tauri-apps/cli@2.7.1':
-    resolution: {integrity: sha512-RcGWR4jOUEl92w3uvI0h61Llkfj9lwGD1iwvDRD2isMrDhOzjeeeVn9aGzeW1jubQ/kAbMYfydcA4BA0Cy733Q==}
+  '@tauri-apps/cli@2.11.2':
+    resolution: {integrity: sha512-bk3HemqvGRoy+5D/dVMUQHKMYLglD0jVnMm/0iGMH6ufZ+p8r14m6BpIixwij3PBvZdvORUp1YifTD8QxVZ1Nw==}
     engines: {node: '>= 10'}
     hasBin: true
 
-  '@tauri-apps/plugin-deep-link@2.4.1':
-    resolution: {integrity: sha512-I8Bo+spcAKGhIIJ1qN/gapp/Ot3mosQL98znxr975Zn2ODAkUZ++BQ9FnTpR7PDwfIl5ANSGdIW/YU01zVTcJw==}
+  '@tauri-apps/plugin-deep-link@2.4.9':
+    resolution: {integrity: sha512-u0SKOUHnJ1wqeqXsDFq2+kASCBj9xxbG0g9XZWPy9SOmU4wXtp6b/wiYpm6oH6/5fBTQsLqnLhIvqLBRpgHJlA==}
 
-  '@tauri-apps/plugin-dialog@2.3.2':
-    resolution: {integrity: sha512-cNLo9YeQSC0MF4IgXnotHsqEgJk72MBZLXmQPrLA95qTaaWiiaFQ38hIMdZ6YbGUNkr3oni3EhU+AD5jLHcdUA==}
+  '@tauri-apps/plugin-dialog@2.7.1':
+    resolution: {integrity: sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==}
 
-  '@tauri-apps/plugin-fs@2.4.5':
-    resolution: {integrity: sha512-dVxWWGE6VrOxC7/jlhyE+ON/Cc2REJlM35R3PJX3UvFw2XwYhLGQVAIyrehenDdKjotipjYEVc4YjOl3qq90fA==}
+  '@tauri-apps/plugin-fs@2.5.1':
+    resolution: {integrity: sha512-9Lz+Jopp6QyeEWhlpkMx4R/+P9HgR+AVAI4vOZhlT8Xaymtz8iVI/Ov984/XTqgJz/5gz5NretqPB/XEMS3NhQ==}
 
-  '@tauri-apps/plugin-global-shortcut@2.3.0':
-    resolution: {integrity: sha512-WbAz0ElhpP+0kzQZRScdCC7UQ7OPH8PAn//fsBNu7+ywihsnVSVOg1L9YhieAtLNtAlnmFI69Yl5AGaA3ge5IQ==}
+  '@tauri-apps/plugin-global-shortcut@2.3.1':
+    resolution: {integrity: sha512-vr40W2N6G63dmBPaha1TsBQLLURXG538RQbH5vAm0G/ovVZyXJrmZR1HF1W+WneNloQvwn4dm8xzwpEXRW560g==}
 
-  '@tauri-apps/plugin-log@2.6.0':
-    resolution: {integrity: sha512-gVp3l31akA1Jk2bZsTA0hMFD5/gLe49Nw1btu5lViau0QqgC2XyT79LSwvy7a44ewtQbSexchqIg7oTJKMIbXQ==}
+  '@tauri-apps/plugin-log@2.8.0':
+    resolution: {integrity: sha512-a+7rOq3MJwpTOLLKbL8d0qGZ85hgHw5pNOWusA9o3cf7cEgtYHiGY/+O8fj8MvywQIGqFv0da2bYQDlrqLE7rw==}
 
-  '@tauri-apps/plugin-notification@2.3.0':
-    resolution: {integrity: sha512-QDwXo9VzAlH97c0veuf19TZI6cRBPfJDl2O6hNEDvI66j60lOO9z+PL6MJrj8A6Y+t55r7mGhe3rQWLmOre2HA==}
+  '@tauri-apps/plugin-notification@2.3.3':
+    resolution: {integrity: sha512-Zw+ZH18RJb41G4NrfHgIuofJiymusqN+q8fGUIIV7vyCH+5sSn5coqRv/MWB9qETsUs97vmU045q7OyseCV3Qg==}
 
-  '@tauri-apps/plugin-opener@2.4.0':
-    resolution: {integrity: sha512-43VyN8JJtvKWJY72WI/KNZszTpDpzHULFxQs0CJBIYUdCRowQ6Q1feWTDb979N7nldqSuDOaBupZ6wz2nvuWwQ==}
+  '@tauri-apps/plugin-opener@2.5.4':
+    resolution: {integrity: sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ==}
 
-  '@tauri-apps/plugin-websocket@2.4.0':
-    resolution: {integrity: sha512-0TpWqPBb5G3I1qPE/rPnPUmMyAQTWsw2B75Ab6SQ6X4EcypPGyqTyvt3OXymG6PzJeZ+D9wE614Fnf0wXnj1mg==}
+  '@tauri-apps/plugin-os@2.3.2':
+    resolution: {integrity: sha512-n+nXWeuSeF9wcEsSPmRnBEGrRgOy6jjkSU+UVCOV8YUGKb2erhDOxis7IqRXiRVHhY8XMKks00BJ0OAdkpf6+A==}
 
-  '@tauri-apps/plugin-window-state@2.4.0':
-    resolution: {integrity: sha512-hRSzPNi2NG0lPFthfVY0V5C1MyWN/gGaQtQYw7i9zZhLzrhZveHZ2omHG1rIiIsjfTGbO7fhjydSoeTTK9GqLw==}
+  '@tauri-apps/plugin-shell@2.3.5':
+    resolution: {integrity: sha512-jewtULhiQ7lI7+owCKAjc8tYLJr92U16bPOeAa472LHJdgaibLP83NcfAF2e+wkEcA53FxKQAZ7byDzs2eeizg==}
+
+  '@tauri-apps/plugin-sql@2.4.0':
+    resolution: {integrity: sha512-SIICc5JlnK6OrBZzOw7MmhXHPlmASpt5zLWIu10WW4kLr5cDYOXHdV2MoCgYQkgZLQfyBYgF3SQa5XCisUiQkw==}
+
+  '@tauri-apps/plugin-store@2.4.3':
+    resolution: {integrity: sha512-9LWPj9yMphRi9czEtUv87XHbl1b6xgd9EXpPrUnq6nG7+nbtoF84d4Kwz9xhAv/Hf30sr58pq7EOlyI936y8qw==}
+
+  '@tauri-apps/plugin-stronghold@2.3.1':
+    resolution: {integrity: sha512-zFbD1Apk/VFdWaoGaoKcouRrZnzLFiNY9b1KDeBaN47sMaMHRYIa+ZDhvbzMOyH314+OHCQBXfe8I/ph59Lp9g==}
+
+  '@tauri-apps/plugin-websocket@2.4.2':
+    resolution: {integrity: sha512-B1/csKPwJH9kLduNoqWFUdCsTgCvLM84T5ZZYK35jeBc9m2cm2m2G/hbSr28ZpVOZrl0x24fCWFe/9rpp7WETw==}
+
+  '@tauri-apps/plugin-window-state@2.4.1':
+    resolution: {integrity: sha512-OuvdrzyY8Q5Dbzpj+GcrnV1iCeoZbcFdzMjanZMMcAEUNy/6PH5pxZPXpaZLOR7whlzXiuzx0L9EKZbH7zpdRw==}
+
+  '@tiptap/core@3.23.6':
+    resolution: {integrity: sha512-MRB3pHz4Oxqmcawh0cQ5iOGdY5xtNYp/1CoK7hdTLzw5K0C6/gTC2VvanB1R4INaB6EpBkxG/GiWkVirDRnuXw==}
+    peerDependencies:
+      '@tiptap/pm': 3.23.6
+
+  '@tiptap/extension-blockquote@3.23.6':
+    resolution: {integrity: sha512-2RmnqNqTltZ2k1F7IfjoDNs935Uq4rRDR7d98mqkg3OlDktcQIyBpv0t9dTay6H5bkQeZUuS8ogK2S1E8Edjug==}
+    peerDependencies:
+      '@tiptap/core': 3.23.6
+
+  '@tiptap/extension-bold@3.23.6':
+    resolution: {integrity: sha512-1LMhjnytdbbhWHSoOwnLxZAOQZWPkKyXVCNmaIk0Mhi4tLPUXptG4qKS5sVYTCveE5H6IBPFrbgBFi5dMI6krA==}
+    peerDependencies:
+      '@tiptap/core': 3.23.6
+
+  '@tiptap/extension-bubble-menu@3.23.6':
+    resolution: {integrity: sha512-Mwkyp9LkDHFbqmWRIkp63FinRxFu3ajC4qSb9t4mnHsb4kAdbNLLsGtbFg+le0SWk4CxGwAOwM7SzeJ+6UGqCA==}
+    peerDependencies:
+      '@tiptap/core': 3.23.6
+      '@tiptap/pm': 3.23.6
+
+  '@tiptap/extension-bullet-list@3.23.6':
+    resolution: {integrity: sha512-RMRgfXZykr/13X8UBOwvpgysVOo9KchwqMoEbvqQSj4YFfU56iIn59C8sbxiQ1sKfeltUf0wH4fPc0I4iwKqAA==}
+    peerDependencies:
+      '@tiptap/extension-list': 3.23.6
+
+  '@tiptap/extension-code-block-lowlight@3.23.6':
+    resolution: {integrity: sha512-GuB7qDfWKp02FoUFB5SwjkczayE5JMlbgNRHr5H1fMN7j9ofsV4SijvbZpocj5X6kSjNyOnx5nhdOyPwlsvOgw==}
+    peerDependencies:
+      '@tiptap/core': 3.23.6
+      '@tiptap/extension-code-block': 3.23.6
+      '@tiptap/pm': 3.23.6
+      highlight.js: ^11
+      lowlight: ^2 || ^3
+
+  '@tiptap/extension-code-block@3.23.6':
+    resolution: {integrity: sha512-4kccgcn5yHThxrzsIhJny3EwfEZYIk+BjUCL4uIuzOyWvExtGhZ6JMHVCZeMhI8D1/bX1LNkkAKN5DXPzH4lXQ==}
+    peerDependencies:
+      '@tiptap/core': 3.23.6
+      '@tiptap/pm': 3.23.6
+
+  '@tiptap/extension-code@3.23.6':
+    resolution: {integrity: sha512-KG8KXFYyLrtYvT7AZ1WGV61ofx8pDe5g9pH658MERxqQGii+Pyfc6xkz04l7XeBts/7+571UQp/0O7i/z560TA==}
+    peerDependencies:
+      '@tiptap/core': 3.23.6
+
+  '@tiptap/extension-document@3.23.6':
+    resolution: {integrity: sha512-XDAIgG9KcKumFM9KJWUEUhXPbFIhhl47bfy5GknareWTRKke85rcoj/oxKKO9ihLZr8JfpbXjqnS4SCm5yhYPw==}
+    peerDependencies:
+      '@tiptap/core': 3.23.6
+
+  '@tiptap/extension-dropcursor@3.23.6':
+    resolution: {integrity: sha512-+XWEoRKf3lXxi7Le1aOM2xU1XHwxICGpXjT3m4QaYqUgIpsq8gQEuso6kVg8DnTD7biKQs6+oIQ0o2b/gTW9WA==}
+    peerDependencies:
+      '@tiptap/extensions': 3.23.6
+
+  '@tiptap/extension-floating-menu@3.23.6':
+    resolution: {integrity: sha512-2kjuDcEq69lEcECl75xqY5MyzUSh2zcC5aLrpwP1WwhJz5bxsIFHiaps5AP6h9R4A+ZBj5b2haay2Y1wDUU3VA==}
+    peerDependencies:
+      '@floating-ui/dom': ^1.0.0
+      '@tiptap/core': 3.23.6
+      '@tiptap/pm': 3.23.6
+
+  '@tiptap/extension-gapcursor@3.23.6':
+    resolution: {integrity: sha512-wbKmxXsszxWacEkrHucRpSQbiKjz4fmOebD6OVyL9AcrmlbxNk8vcM3iyh/8cVeRy09XY+morM165t/u7/z4IQ==}
+    peerDependencies:
+      '@tiptap/extensions': 3.23.6
+
+  '@tiptap/extension-hard-break@3.23.6':
+    resolution: {integrity: sha512-KeUm+tkUfIVSX9QM9XOIhaay0Fn36sLKUo5NVYjN3uJaxFvaZXZmTlxdO85OTdgF2P5sqh9LomrIgliaFRGk4w==}
+    peerDependencies:
+      '@tiptap/core': 3.23.6
+
+  '@tiptap/extension-heading@3.23.6':
+    resolution: {integrity: sha512-A/0jPhxnUh9THSZymlu0OGPZe1wdFdwHAXnRCmqvYUCwJjrG7LCC/ahzmcj1tcNzI9hgHyuYPSfev8RXYrNu/w==}
+    peerDependencies:
+      '@tiptap/core': 3.23.6
+
+  '@tiptap/extension-highlight@3.23.6':
+    resolution: {integrity: sha512-GWv6R4iZzVrNeB33qtJDBt/BfVjuc5S/sUF/VDFAtK8h86bg4cEm1tGLEsui4T3+vij/t+P+eoGhkzF6NGogdg==}
+    peerDependencies:
+      '@tiptap/core': 3.23.6
+
+  '@tiptap/extension-horizontal-rule@3.23.6':
+    resolution: {integrity: sha512-hEUlz4H+I64r+TH6LCuNCRgO7JTHncXGmx9+WbU69EOfY8O0ZurcgeJc8HeiAKL+r9YuC1e5YHfFxgCaaC0jlg==}
+    peerDependencies:
+      '@tiptap/core': 3.23.6
+      '@tiptap/pm': 3.23.6
+
+  '@tiptap/extension-image@3.23.6':
+    resolution: {integrity: sha512-vvNGxArvD2dW+XvV0KdYovRVUzCy8QVNulc2r5pV7umnG1E6cCmMkiHiif8J2ePJu2KtysAvJQe0iF+UqueGMw==}
+    peerDependencies:
+      '@tiptap/core': 3.23.6
+
+  '@tiptap/extension-italic@3.23.6':
+    resolution: {integrity: sha512-wol5KdwCPAvpiYhH9PLlvO8ZnJHwZtIboVevrfOGgBcKlXRA3dedR4OAMXHnUtkkzu9KtliLg1+TYzEx4JZG9Q==}
+    peerDependencies:
+      '@tiptap/core': 3.23.6
+
+  '@tiptap/extension-link@3.23.6':
+    resolution: {integrity: sha512-KNZz7z7P2/qbQsx5bPAbSPjrKDg1VHsedGlLHJCr8U2VRD5VgmDLkMpkouP1CsDg15qgyUKv/nDib5KgPpLNWA==}
+    peerDependencies:
+      '@tiptap/core': 3.23.6
+      '@tiptap/pm': 3.23.6
+
+  '@tiptap/extension-list-item@3.23.6':
+    resolution: {integrity: sha512-3zzyhdkUWcHVpXuvy6KiIwjh29rbH6gEDEqPQqHLrl1XGnO9pnShC7pSHctlCDjmcx3O4n9cd4QMtVBlUerbiA==}
+    peerDependencies:
+      '@tiptap/extension-list': 3.23.6
+
+  '@tiptap/extension-list-keymap@3.23.6':
+    resolution: {integrity: sha512-x8bPcLViGzg/RAmQM/XtmfqIwQ/Pv9Q8mkd+OgfUiTqjeJqKwVQmiqbLFNa7zw81+H61M+HDU+qGAaQ3vRIMjw==}
+    peerDependencies:
+      '@tiptap/extension-list': 3.23.6
+
+  '@tiptap/extension-list@3.23.6':
+    resolution: {integrity: sha512-z6vj9+Qht2sjdQkyyHcUpsC/yCIZqTrQiyHDhs/HGKrfvoANyAZGpqdNeKf1wSyjIso+27tQuIH5NDfk8ygyNw==}
+    peerDependencies:
+      '@tiptap/core': 3.23.6
+      '@tiptap/pm': 3.23.6
+
+  '@tiptap/extension-ordered-list@3.23.6':
+    resolution: {integrity: sha512-1m/wWB/ZtXcmG2vNdiUkCqsOgqv5vBjCv/mVaHhF9OvV+zQS8YDjoWE7zEuT/GgELdT77Xq8lHrn4nCDudB3/A==}
+    peerDependencies:
+      '@tiptap/extension-list': 3.23.6
+
+  '@tiptap/extension-paragraph@3.23.6':
+    resolution: {integrity: sha512-+7m58LUSncodjrIyXks4RZ3tLNYrvgT77wRR4l3HnM5OABY3GDsDTqi7c1t1yI29NVOSk/DUacqy6UwYAj1DGg==}
+    peerDependencies:
+      '@tiptap/core': 3.23.6
+
+  '@tiptap/extension-placeholder@3.23.6':
+    resolution: {integrity: sha512-8I6b2aevF74aLgymKMxbDxSLxWA2y+2dh0zZDeI8sRZ2m6WHHes+Kyuuwkq1HIPcR+ZLpbec74cmf6lcL/yvqQ==}
+    peerDependencies:
+      '@tiptap/extensions': 3.23.6
+
+  '@tiptap/extension-strike@3.23.6':
+    resolution: {integrity: sha512-oF7FEZ37f15aCe5kPgzGDYf/m+hr7VdQ/Ko/Hds/UM9pX7AG1fdtmRrl6wqkRqDM/incZaC/AQR2/Dpo2VCNGQ==}
+    peerDependencies:
+      '@tiptap/core': 3.23.6
+
+  '@tiptap/extension-task-item@3.23.6':
+    resolution: {integrity: sha512-PIHW+3KZCtEmtC7z34rfkusbC42HYr7uw1h5xNvrazQwJGWhKo1UmI0Yea5vyJNKPrTLPCMEm/mgMrj8nNAZfA==}
+    peerDependencies:
+      '@tiptap/extension-list': 3.23.6
+
+  '@tiptap/extension-task-list@3.23.6':
+    resolution: {integrity: sha512-XNuYbVV7F0TBpxHqqEFvrxwGbmTq01qJrZA6qwbQopOsw5wOsCy4XQsCkeZ8BGkakORCEWGSMjPyVOtIKq2jGA==}
+    peerDependencies:
+      '@tiptap/extension-list': 3.23.6
+
+  '@tiptap/extension-text-align@3.23.6':
+    resolution: {integrity: sha512-pE+gDmvnrSMWHADDnDSzaO7YUi9kOywQkyrqZ9bEPLddZred7ICoJ4NtD2DqLjDSur+HijaJuByResWb78c6FA==}
+    peerDependencies:
+      '@tiptap/core': 3.23.6
+
+  '@tiptap/extension-text@3.23.6':
+    resolution: {integrity: sha512-ipoC2TkIAIOTiF5ByiGgvQB1DqDyfP90wrUB3mohBcgvp7lQnwHszCDGv8dNnmcUek8uXV/uoLu2VXeVQlxjPA==}
+    peerDependencies:
+      '@tiptap/core': 3.23.6
+
+  '@tiptap/extension-underline@3.23.6':
+    resolution: {integrity: sha512-P55wGIZGYTVH92Fq0cgI4/O9AhLCaJC3hhxg15RSERP5/YegM9eJHDK/GQ1EE/DvYA+xpYGOV6agKwAUqfA/Iw==}
+    peerDependencies:
+      '@tiptap/core': 3.23.6
+
+  '@tiptap/extensions@3.23.6':
+    resolution: {integrity: sha512-X09/Db1teB+ifXzDGVVFmOeQRx7wTAayE9/280spxpsHkHZvJ5bHRvWIzUzviMIjbBz+NPDIKYPK7gMfh9iaig==}
+    peerDependencies:
+      '@tiptap/core': 3.23.6
+      '@tiptap/pm': 3.23.6
+
+  '@tiptap/markdown@3.23.6':
+    resolution: {integrity: sha512-11RS+WswVAtAJMn1CaXN1YblMdLn69I6TeFVoHwJXbprV8M45tjyID9uV0WoGYPnpjhfepPhaG7kivgAu5XukQ==}
+    peerDependencies:
+      '@tiptap/core': 3.23.6
+      '@tiptap/pm': 3.23.6
+
+  '@tiptap/pm@3.23.6':
+    resolution: {integrity: sha512-in5CaMaWlJcH2A1q6GJKFtrodE8WLS3M9tIi/f89jPmIVHJShpodC0KZDNyJkrVBQomYk0DEh86Utm6ASXzQww==}
+
+  '@tiptap/react@3.23.6':
+    resolution: {integrity: sha512-Tw9KZkYqFMk3vaJAEQKqEYIO/iq3cSJe7OUEGBul4k4GaMQeLItLf5EYhUd0GIPXci1WVVPNntKJsHfX25M37w==}
+    peerDependencies:
+      '@tiptap/core': 3.23.6
+      '@tiptap/pm': 3.23.6
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tiptap/starter-kit@3.23.6':
+    resolution: {integrity: sha512-gykwtGWrnWCmtql1hid3opac/KV8zQvOAnu3bTqIqcHrn1FusbUwKmNzavSbfGvcktHM3hFjb35W48JyVLyu/A==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -1851,8 +2094,14 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
   '@types/node@24.2.1':
     resolution: {integrity: sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==}
+
+  '@types/qrcode@1.5.6':
+    resolution: {integrity: sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==}
 
   '@types/react-dom@19.1.7':
     resolution: {integrity: sha512-i5ZzwYpqjmrKenzkoLM2Ibzt6mAsM7pxB6BCIouEVVmgiqaMj1TjaK7hnA36hbW5aZv20kx7Lw6hWzPWg0Rurw==}
@@ -1861,6 +2110,12 @@ packages:
 
   '@types/react@19.1.10':
     resolution: {integrity: sha512-EhBeSYX0Y6ye8pNebpKrwFJq7BoQ8J5SO6NlvNwwHjSj6adXJViPQrKlsyPw7hLBLvckEMO1yxeGdR82YBBlDg==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@vitejs/plugin-react-swc@4.0.0':
     resolution: {integrity: sha512-4A1dThI578v07mpG4M+ziNn6lmlMlhtVCheL+2WLvClnLvEULi8rpAZThn2oEKn3GtFXFTOeko6eLRhx2V2kgA==}
@@ -1878,6 +2133,14 @@ packages:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
 
   ansis@4.1.0:
     resolution: {integrity: sha512-BGcItUBWSMRgOCe+SVZJ+S7yTRG0eGt9cXAHev72yuGcY23hnLA7Bky5L/xLyPINoSN95geovfBkqoTlNZYa7w==}
@@ -1911,6 +2174,10 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  camelcase@5.3.1:
+    resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
+    engines: {node: '>=6'}
+
   caniuse-lite@1.0.30001734:
     resolution: {integrity: sha512-uhE1Ye5vgqju6OI71HTQqcBCZrvHugk0MjLak7Q+HfoBgoq5Bi+5YnwjP4fjDgrtYr/l8MVRBvzz9dPD4KyK0A==}
 
@@ -1925,6 +2192,9 @@ packages:
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
+  cliui@6.0.0:
+    resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
+
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
@@ -1934,6 +2204,13 @@ packages:
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -1959,9 +2236,17 @@ packages:
       supports-color:
         optional: true
 
+  decamelize@1.2.0:
+    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
+    engines: {node: '>=0.10.0'}
+
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   detect-libc@1.0.3:
     resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
@@ -1975,12 +2260,21 @@ packages:
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
   diff@8.0.2:
     resolution: {integrity: sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==}
     engines: {node: '>=0.3.1'}
 
+  dijkstrajs@1.0.3:
+    resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
+
   electron-to-chromium@1.5.200:
     resolution: {integrity: sha512-rFCxROw7aOe4uPTfIAx+rXv9cEcGx+buAF4npnhtTqCJk5KDFRnh3+KYj7rdVh6lsFt5/aPs+Irj9rZ33WMA7w==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
   enhanced-resolve@5.18.3:
     resolution: {integrity: sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==}
@@ -1988,6 +2282,11 @@ packages:
 
   esbuild@0.25.9:
     resolution: {integrity: sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1999,6 +2298,10 @@ packages:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
+
+  fast-equals@5.4.0:
+    resolution: {integrity: sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==}
+    engines: {node: '>=6.0.0'}
 
   fdir@6.4.6:
     resolution: {integrity: sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==}
@@ -2012,6 +2315,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  find-up@4.1.0:
+    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
+    engines: {node: '>=8'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2020,6 +2327,10 @@ packages:
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
 
   get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
@@ -2034,6 +2345,10 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  highlight.js@11.11.1:
+    resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
+    engines: {node: '>=12.0.0'}
 
   html-parse-stringify@3.0.1:
     resolution: {integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==}
@@ -2053,6 +2368,10 @@ packages:
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
 
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
@@ -2112,24 +2431,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.1:
     resolution: {integrity: sha512-jmUQVx4331m6LIX+0wUhBbmMX7TCfjF5FoOH6SD1CttzuYlGNVpA7QnrmLxrsub43ClTINfGSYyHe2HWeLl5CQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.1:
     resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.1:
     resolution: {integrity: sha512-rRomAK7eIkL+tHY0YPxbc5Dra2gXlI63HL+v1Pdi1a3sC+tJTcFrHX+E86sulgAXeI7rSzDYhPSeHHjqFhqfeQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.1:
     resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}
@@ -2147,12 +2470,25 @@ packages:
     resolution: {integrity: sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==}
     engines: {node: '>= 12.0.0'}
 
+  linkifyjs@4.3.3:
+    resolution: {integrity: sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==}
+
   load-script@1.0.0:
     resolution: {integrity: sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA==}
+
+  locate-path@5.0.0:
+    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
+    engines: {node: '>=8'}
+
+  lodash.debounce@4.0.8:
+    resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
+
+  lowlight@3.3.0:
+    resolution: {integrity: sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -2164,6 +2500,11 @@ packages:
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
+
+  marked@17.0.6:
+    resolution: {integrity: sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA==}
+    engines: {node: '>= 20'}
+    hasBin: true
 
   memoize-one@5.2.1:
     resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
@@ -2217,6 +2558,25 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  orderedmap@2.1.1:
+    resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
+
+  p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+
+  p-locate@4.1.0:
+    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
+
+  p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -2227,6 +2587,10 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  pngjs@5.0.0:
+    resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
+    engines: {node: '>=10.13.0'}
 
   polished@4.3.1:
     resolution: {integrity: sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==}
@@ -2243,6 +2607,47 @@ packages:
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  prosemirror-changeset@2.4.1:
+    resolution: {integrity: sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==}
+
+  prosemirror-commands@1.7.1:
+    resolution: {integrity: sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==}
+
+  prosemirror-dropcursor@1.8.2:
+    resolution: {integrity: sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==}
+
+  prosemirror-gapcursor@1.4.1:
+    resolution: {integrity: sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==}
+
+  prosemirror-history@1.5.0:
+    resolution: {integrity: sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==}
+
+  prosemirror-keymap@1.2.3:
+    resolution: {integrity: sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==}
+
+  prosemirror-model@1.25.7:
+    resolution: {integrity: sha512-A79aN8QEFUwI6cax8Yq4Rpcx1TJZ3Kagn+ii7qLo4/V8H3mMiHrhFyhTyHHvpSnOgMPpWiDGSwM3etwrxE50ug==}
+
+  prosemirror-schema-list@1.5.1:
+    resolution: {integrity: sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==}
+
+  prosemirror-state@1.4.4:
+    resolution: {integrity: sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==}
+
+  prosemirror-tables@1.8.5:
+    resolution: {integrity: sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==}
+
+  prosemirror-transform@1.12.0:
+    resolution: {integrity: sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==}
+
+  prosemirror-view@1.41.8:
+    resolution: {integrity: sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==}
+
+  qrcode@1.5.4:
+    resolution: {integrity: sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
 
   react-day-picker@9.9.0:
     resolution: {integrity: sha512-NtkJbuX6cl/VaGNb3sVVhmMA6LSMnL5G3xNL+61IyoZj0mUZFWTg4hmj7PHjIQ8MXN9dHWhUHFoJWG6y60DKSg==}
@@ -2344,6 +2749,16 @@ packages:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
     engines: {node: '>= 4'}
 
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  require-main-filename@2.0.0:
+    resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
+
+  reselect@5.2.0:
+    resolution: {integrity: sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==}
+
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
@@ -2354,6 +2769,9 @@ packages:
     resolution: {integrity: sha512-WMmLFI+Boh6xbop+OAGo9cQ3OgX9MIg7xOQjn+pTCwOkk+FNDAeAemXkJ3HzDJrVXleLOFVa1ipuc1AmEx1Dwg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  rope-sequence@1.3.4:
+    resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
 
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
@@ -2371,6 +2789,9 @@ packages:
   seroval@1.3.2:
     resolution: {integrity: sha512-RbcPH1n5cfwKrru7v7+zrZvjLurgHhGyso3HTyGtRivGWgYjbOmGuivCQaORNELjNONoK35nj28EoWul9sb1zQ==}
     engines: {node: '>=10'}
+
+  set-blocking@2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
   sonner@2.0.7:
     resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
@@ -2390,6 +2811,14 @@ packages:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
 
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
   tailwind-merge@3.3.1:
     resolution: {integrity: sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==}
 
@@ -2403,6 +2832,7 @@ packages:
   tar@7.4.3:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
@@ -2472,6 +2902,17 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  usehooks-ts@3.1.1:
+    resolution: {integrity: sha512-I4diPp9Cq6ieSUH2wu+fDAVQO43xwtulo+fKEidHUwZPnYImbtkTjzIJYcDcJqxgmX31GVqNFURodvcgHcW0pA==}
+    engines: {node: '>=16.15.0'}
+    peerDependencies:
+      react: ^16.8.0  || ^17 || ^18 || ^19 || ^19.0.0-rc
+
   vaul@1.1.2:
     resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==}
     peerDependencies:
@@ -2522,8 +2963,21 @@ packages:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
 
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
+
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
+
+  which-module@2.0.1:
+    resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
+
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
+
+  y18n@4.0.3:
+    resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -2532,8 +2986,34 @@ packages:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
 
+  yargs-parser@18.1.3:
+    resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
+    engines: {node: '>=6'}
+
+  yargs@15.4.1:
+    resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
+    engines: {node: '>=8'}
+
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zustand@5.0.13:
+    resolution: {integrity: sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
 snapshots:
 
@@ -2717,6 +3197,8 @@ snapshots:
 
   '@babel/runtime@7.28.2': {}
 
+  '@babel/runtime@7.29.2': {}
+
   '@babel/template@7.27.2':
     dependencies:
       '@babel/code-frame': 7.27.1
@@ -2739,6 +3221,31 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
+
+  '@base-ui/react@1.5.0(@date-fns/tz@1.4.1)(@types/react@19.1.10)(date-fns@4.1.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@base-ui/utils': 0.2.9(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@floating-ui/utils': 0.2.11
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+      use-sync-external-store: 1.6.0(react@19.1.1)
+    optionalDependencies:
+      '@date-fns/tz': 1.4.1
+      '@types/react': 19.1.10
+      date-fns: 4.1.0
+
+  '@base-ui/utils@0.2.9(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@floating-ui/utils': 0.2.11
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+      reselect: 5.2.0
+      use-sync-external-store: 1.6.0(react@19.1.1)
+    optionalDependencies:
+      '@types/react': 19.1.10
 
   '@biomejs/biome@1.9.4':
     optionalDependencies:
@@ -2815,97 +3322,186 @@ snapshots:
   '@esbuild/aix-ppc64@0.25.9':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
   '@esbuild/android-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
     optional: true
 
   '@esbuild/android-arm@0.25.9':
     optional: true
 
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
   '@esbuild/android-x64@0.25.9':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
     optional: true
 
   '@esbuild/darwin-arm64@0.25.9':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
   '@esbuild/darwin-x64@0.25.9':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
     optional: true
 
   '@esbuild/freebsd-arm64@0.25.9':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
   '@esbuild/freebsd-x64@0.25.9':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
     optional: true
 
   '@esbuild/linux-arm64@0.25.9':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
   '@esbuild/linux-arm@0.25.9':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
     optional: true
 
   '@esbuild/linux-ia32@0.25.9':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
   '@esbuild/linux-loong64@0.25.9':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
     optional: true
 
   '@esbuild/linux-mips64el@0.25.9':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
   '@esbuild/linux-ppc64@0.25.9':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
     optional: true
 
   '@esbuild/linux-riscv64@0.25.9':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.9':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
     optional: true
 
   '@esbuild/linux-x64@0.25.9':
     optional: true
 
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/netbsd-x64@0.25.9':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.9':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
     optional: true
 
   '@esbuild/sunos-x64@0.25.9':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
   '@esbuild/win32-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
     optional: true
 
   '@esbuild/win32-ia32@0.25.9':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
   '@esbuild/win32-x64@0.25.9':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
     optional: true
 
   '@floating-ui/core@1.7.3':
     dependencies:
       '@floating-ui/utils': 0.2.10
 
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
   '@floating-ui/dom@1.7.3':
     dependencies:
       '@floating-ui/core': 1.7.3
       '@floating-ui/utils': 0.2.10
 
-  '@floating-ui/react-dom@2.1.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+  '@floating-ui/dom@1.7.6':
     dependencies:
-      '@floating-ui/dom': 1.7.3
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/react-dom@2.1.8(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
 
   '@floating-ui/utils@0.2.10': {}
+
+  '@floating-ui/utils@0.2.11': {}
 
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
@@ -2993,45 +3589,6 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
-  '@radix-ui/react-alert-dialog@1.1.15(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.10)(react@19.1.1)
-      react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
-    optionalDependencies:
-      '@types/react': 19.1.10
-      '@types/react-dom': 19.1.7(@types/react@19.1.10)
-
-  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
-    dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
-    optionalDependencies:
-      '@types/react': 19.1.10
-      '@types/react-dom': 19.1.7(@types/react@19.1.10)
-
-  '@radix-ui/react-checkbox@1.3.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-use-size': 1.1.1(@types/react@19.1.10)(react@19.1.1)
-      react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
-    optionalDependencies:
-      '@types/react': 19.1.10
-      '@types/react-dom': 19.1.7(@types/react@19.1.10)
-
   '@radix-ui/react-collection@1.1.7(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.10)(react@19.1.1)
@@ -3056,20 +3613,6 @@ snapshots:
       react: 19.1.1
     optionalDependencies:
       '@types/react': 19.1.10
-
-  '@radix-ui/react-context-menu@2.2.16(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-context': 1.1.2(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.10)(react@19.1.1)
-      react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
-    optionalDependencies:
-      '@types/react': 19.1.10
-      '@types/react-dom': 19.1.7(@types/react@19.1.10)
 
   '@radix-ui/react-context@1.0.1(@types/react@19.1.10)(react@19.1.1)':
     dependencies:
@@ -3162,21 +3705,6 @@ snapshots:
       '@types/react': 19.1.10
       '@types/react-dom': 19.1.7(@types/react@19.1.10)
 
-  '@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.10)(react@19.1.1)
-      react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
-    optionalDependencies:
-      '@types/react': 19.1.10
-      '@types/react-dom': 19.1.7(@types/react@19.1.10)
-
   '@radix-ui/react-focus-guards@1.0.1(@types/react@19.1.10)(react@19.1.1)':
     dependencies:
       '@babel/runtime': 7.28.2
@@ -3213,23 +3741,6 @@ snapshots:
       '@types/react': 19.1.10
       '@types/react-dom': 19.1.7(@types/react@19.1.10)
 
-  '@radix-ui/react-hover-card@1.1.15(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.10)(react@19.1.1)
-      react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
-    optionalDependencies:
-      '@types/react': 19.1.10
-      '@types/react-dom': 19.1.7(@types/react@19.1.10)
-
   '@radix-ui/react-id@1.0.1(@types/react@19.1.10)(react@19.1.1)':
     dependencies:
       '@babel/runtime': 7.28.2
@@ -3244,100 +3755,6 @@ snapshots:
       react: 19.1.1
     optionalDependencies:
       '@types/react': 19.1.10
-
-  '@radix-ui/react-label@2.1.7(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
-    dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
-    optionalDependencies:
-      '@types/react': 19.1.10
-      '@types/react-dom': 19.1.7(@types/react@19.1.10)
-
-  '@radix-ui/react-menu@2.1.16(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.10)(react@19.1.1)
-      aria-hidden: 1.2.6
-      react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
-      react-remove-scroll: 2.7.1(@types/react@19.1.10)(react@19.1.1)
-    optionalDependencies:
-      '@types/react': 19.1.10
-      '@types/react-dom': 19.1.7(@types/react@19.1.10)
-
-  '@radix-ui/react-menubar@1.1.16(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.10)(react@19.1.1)
-      react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
-    optionalDependencies:
-      '@types/react': 19.1.10
-      '@types/react-dom': 19.1.7(@types/react@19.1.10)
-
-  '@radix-ui/react-popover@1.1.15(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.10)(react@19.1.1)
-      aria-hidden: 1.2.6
-      react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
-      react-remove-scroll: 2.7.1(@types/react@19.1.10)(react@19.1.1)
-    optionalDependencies:
-      '@types/react': 19.1.10
-      '@types/react-dom': 19.1.7(@types/react@19.1.10)
-
-  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
-    dependencies:
-      '@floating-ui/react-dom': 2.1.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-use-size': 1.1.1(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/rect': 1.1.1
-      react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
-    optionalDependencies:
-      '@types/react': 19.1.10
-      '@types/react-dom': 19.1.7(@types/react@19.1.10)
 
   '@radix-ui/react-portal@1.0.4(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
@@ -3409,61 +3826,6 @@ snapshots:
       '@types/react': 19.1.10
       '@types/react-dom': 19.1.7(@types/react@19.1.10)
 
-  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.10)(react@19.1.1)
-      react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
-    optionalDependencies:
-      '@types/react': 19.1.10
-      '@types/react-dom': 19.1.7(@types/react@19.1.10)
-
-  '@radix-ui/react-select@2.2.6(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
-    dependencies:
-      '@radix-ui/number': 1.1.1
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      aria-hidden: 1.2.6
-      react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
-      react-remove-scroll: 2.7.1(@types/react@19.1.10)(react@19.1.1)
-    optionalDependencies:
-      '@types/react': 19.1.10
-      '@types/react-dom': 19.1.7(@types/react@19.1.10)
-
-  '@radix-ui/react-separator@1.1.7(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
-    dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
-    optionalDependencies:
-      '@types/react': 19.1.10
-      '@types/react-dom': 19.1.7(@types/react@19.1.10)
-
   '@radix-ui/react-slider@1.3.6(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
       '@radix-ui/number': 1.1.1
@@ -3497,83 +3859,6 @@ snapshots:
       react: 19.1.1
     optionalDependencies:
       '@types/react': 19.1.10
-
-  '@radix-ui/react-switch@1.2.6(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-use-size': 1.1.1(@types/react@19.1.10)(react@19.1.1)
-      react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
-    optionalDependencies:
-      '@types/react': 19.1.10
-      '@types/react-dom': 19.1.7(@types/react@19.1.10)
-
-  '@radix-ui/react-tabs@1.1.13(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-context': 1.1.2(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.10)(react@19.1.1)
-      react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
-    optionalDependencies:
-      '@types/react': 19.1.10
-      '@types/react-dom': 19.1.7(@types/react@19.1.10)
-
-  '@radix-ui/react-toggle-group@1.1.11(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-context': 1.1.2(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-toggle': 1.1.10(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.10)(react@19.1.1)
-      react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
-    optionalDependencies:
-      '@types/react': 19.1.10
-      '@types/react-dom': 19.1.7(@types/react@19.1.10)
-
-  '@radix-ui/react-toggle@1.1.10(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.10)(react@19.1.1)
-      react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
-    optionalDependencies:
-      '@types/react': 19.1.10
-      '@types/react-dom': 19.1.7(@types/react@19.1.10)
-
-  '@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.10)(react@19.1.1)
-      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
-    optionalDependencies:
-      '@types/react': 19.1.10
-      '@types/react-dom': 19.1.7(@types/react@19.1.10)
 
   '@radix-ui/react-use-callback-ref@1.0.1(@types/react@19.1.10)(react@19.1.1)':
     dependencies:
@@ -3645,30 +3930,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.10
 
-  '@radix-ui/react-use-rect@1.1.1(@types/react@19.1.10)(react@19.1.1)':
-    dependencies:
-      '@radix-ui/rect': 1.1.1
-      react: 19.1.1
-    optionalDependencies:
-      '@types/react': 19.1.10
-
   '@radix-ui/react-use-size@1.1.1(@types/react@19.1.10)(react@19.1.1)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.10)(react@19.1.1)
       react: 19.1.1
     optionalDependencies:
       '@types/react': 19.1.10
-
-  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
-    dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      react: 19.1.1
-      react-dom: 19.1.1(react@19.1.1)
-    optionalDependencies:
-      '@types/react': 19.1.10
-      '@types/react-dom': 19.1.7(@types/react@19.1.10)
-
-  '@radix-ui/rect@1.1.1': {}
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
@@ -3867,7 +4134,25 @@ snapshots:
       tailwindcss: 4.1.11
       vite: 7.1.2(@types/node@24.2.1)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.4)
 
+  '@tanstack/devtools-event-client@0.4.3': {}
+
+  '@tanstack/form-core@1.32.0':
+    dependencies:
+      '@tanstack/devtools-event-client': 0.4.3
+      '@tanstack/pacer-lite': 0.1.1
+      '@tanstack/store': 0.9.3
+
   '@tanstack/history@1.131.2': {}
+
+  '@tanstack/pacer-lite@0.1.1': {}
+
+  '@tanstack/react-form@1.32.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@tanstack/form-core': 1.32.0
+      '@tanstack/react-store': 0.9.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      react: 19.1.1
+    transitivePeerDependencies:
+      - react-dom
 
   '@tanstack/react-router@1.131.8(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
@@ -3886,6 +4171,19 @@ snapshots:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
       use-sync-external-store: 1.5.0(react@19.1.1)
+
+  '@tanstack/react-store@0.9.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@tanstack/store': 0.9.3
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+      use-sync-external-store: 1.6.0(react@19.1.1)
+
+  '@tanstack/react-virtual@3.13.25(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@tanstack/virtual-core': 3.15.0
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
 
   '@tanstack/router-core@1.131.7':
     dependencies:
@@ -3945,94 +4243,326 @@ snapshots:
 
   '@tanstack/store@0.7.2': {}
 
+  '@tanstack/store@0.9.3': {}
+
+  '@tanstack/virtual-core@3.15.0': {}
+
   '@tanstack/virtual-file-routes@1.131.2': {}
 
   '@tauri-apps/api@2.10.1': {}
 
-  '@tauri-apps/api@2.7.0': {}
+  '@tauri-apps/api@2.11.0': {}
 
-  '@tauri-apps/cli-darwin-arm64@2.7.1':
+  '@tauri-apps/cli-darwin-arm64@2.11.2':
     optional: true
 
-  '@tauri-apps/cli-darwin-x64@2.7.1':
+  '@tauri-apps/cli-darwin-x64@2.11.2':
     optional: true
 
-  '@tauri-apps/cli-linux-arm-gnueabihf@2.7.1':
+  '@tauri-apps/cli-linux-arm-gnueabihf@2.11.2':
     optional: true
 
-  '@tauri-apps/cli-linux-arm64-gnu@2.7.1':
+  '@tauri-apps/cli-linux-arm64-gnu@2.11.2':
     optional: true
 
-  '@tauri-apps/cli-linux-arm64-musl@2.7.1':
+  '@tauri-apps/cli-linux-arm64-musl@2.11.2':
     optional: true
 
-  '@tauri-apps/cli-linux-riscv64-gnu@2.7.1':
+  '@tauri-apps/cli-linux-riscv64-gnu@2.11.2':
     optional: true
 
-  '@tauri-apps/cli-linux-x64-gnu@2.7.1':
+  '@tauri-apps/cli-linux-x64-gnu@2.11.2':
     optional: true
 
-  '@tauri-apps/cli-linux-x64-musl@2.7.1':
+  '@tauri-apps/cli-linux-x64-musl@2.11.2':
     optional: true
 
-  '@tauri-apps/cli-win32-arm64-msvc@2.7.1':
+  '@tauri-apps/cli-win32-arm64-msvc@2.11.2':
     optional: true
 
-  '@tauri-apps/cli-win32-ia32-msvc@2.7.1':
+  '@tauri-apps/cli-win32-ia32-msvc@2.11.2':
     optional: true
 
-  '@tauri-apps/cli-win32-x64-msvc@2.7.1':
+  '@tauri-apps/cli-win32-x64-msvc@2.11.2':
     optional: true
 
-  '@tauri-apps/cli@2.7.1':
+  '@tauri-apps/cli@2.11.2':
     optionalDependencies:
-      '@tauri-apps/cli-darwin-arm64': 2.7.1
-      '@tauri-apps/cli-darwin-x64': 2.7.1
-      '@tauri-apps/cli-linux-arm-gnueabihf': 2.7.1
-      '@tauri-apps/cli-linux-arm64-gnu': 2.7.1
-      '@tauri-apps/cli-linux-arm64-musl': 2.7.1
-      '@tauri-apps/cli-linux-riscv64-gnu': 2.7.1
-      '@tauri-apps/cli-linux-x64-gnu': 2.7.1
-      '@tauri-apps/cli-linux-x64-musl': 2.7.1
-      '@tauri-apps/cli-win32-arm64-msvc': 2.7.1
-      '@tauri-apps/cli-win32-ia32-msvc': 2.7.1
-      '@tauri-apps/cli-win32-x64-msvc': 2.7.1
+      '@tauri-apps/cli-darwin-arm64': 2.11.2
+      '@tauri-apps/cli-darwin-x64': 2.11.2
+      '@tauri-apps/cli-linux-arm-gnueabihf': 2.11.2
+      '@tauri-apps/cli-linux-arm64-gnu': 2.11.2
+      '@tauri-apps/cli-linux-arm64-musl': 2.11.2
+      '@tauri-apps/cli-linux-riscv64-gnu': 2.11.2
+      '@tauri-apps/cli-linux-x64-gnu': 2.11.2
+      '@tauri-apps/cli-linux-x64-musl': 2.11.2
+      '@tauri-apps/cli-win32-arm64-msvc': 2.11.2
+      '@tauri-apps/cli-win32-ia32-msvc': 2.11.2
+      '@tauri-apps/cli-win32-x64-msvc': 2.11.2
 
-  '@tauri-apps/plugin-deep-link@2.4.1':
+  '@tauri-apps/plugin-deep-link@2.4.9':
     dependencies:
-      '@tauri-apps/api': 2.7.0
+      '@tauri-apps/api': 2.11.0
 
-  '@tauri-apps/plugin-dialog@2.3.2':
+  '@tauri-apps/plugin-dialog@2.7.1':
     dependencies:
-      '@tauri-apps/api': 2.7.0
+      '@tauri-apps/api': 2.11.0
 
-  '@tauri-apps/plugin-fs@2.4.5':
+  '@tauri-apps/plugin-fs@2.5.1':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
+
+  '@tauri-apps/plugin-global-shortcut@2.3.1':
     dependencies:
       '@tauri-apps/api': 2.10.1
 
-  '@tauri-apps/plugin-global-shortcut@2.3.0':
+  '@tauri-apps/plugin-log@2.8.0':
     dependencies:
-      '@tauri-apps/api': 2.7.0
+      '@tauri-apps/api': 2.10.1
 
-  '@tauri-apps/plugin-log@2.6.0':
+  '@tauri-apps/plugin-notification@2.3.3':
     dependencies:
-      '@tauri-apps/api': 2.7.0
+      '@tauri-apps/api': 2.10.1
 
-  '@tauri-apps/plugin-notification@2.3.0':
+  '@tauri-apps/plugin-opener@2.5.4':
     dependencies:
-      '@tauri-apps/api': 2.7.0
+      '@tauri-apps/api': 2.11.0
 
-  '@tauri-apps/plugin-opener@2.4.0':
+  '@tauri-apps/plugin-os@2.3.2':
     dependencies:
-      '@tauri-apps/api': 2.7.0
+      '@tauri-apps/api': 2.10.1
 
-  '@tauri-apps/plugin-websocket@2.4.0':
+  '@tauri-apps/plugin-shell@2.3.5':
     dependencies:
-      '@tauri-apps/api': 2.7.0
+      '@tauri-apps/api': 2.10.1
 
-  '@tauri-apps/plugin-window-state@2.4.0':
+  '@tauri-apps/plugin-sql@2.4.0':
     dependencies:
-      '@tauri-apps/api': 2.7.0
+      '@tauri-apps/api': 2.10.1
+
+  '@tauri-apps/plugin-store@2.4.3':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
+
+  '@tauri-apps/plugin-stronghold@2.3.1':
+    dependencies:
+      '@tauri-apps/api': 2.10.1
+
+  '@tauri-apps/plugin-websocket@2.4.2':
+    dependencies:
+      '@tauri-apps/api': 2.10.1
+
+  '@tauri-apps/plugin-window-state@2.4.1':
+    dependencies:
+      '@tauri-apps/api': 2.10.1
+
+  '@tiptap/core@3.23.6(@tiptap/pm@3.23.6)':
+    dependencies:
+      '@tiptap/pm': 3.23.6
+
+  '@tiptap/extension-blockquote@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))':
+    dependencies:
+      '@tiptap/core': 3.23.6(@tiptap/pm@3.23.6)
+
+  '@tiptap/extension-bold@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))':
+    dependencies:
+      '@tiptap/core': 3.23.6(@tiptap/pm@3.23.6)
+
+  '@tiptap/extension-bubble-menu@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)':
+    dependencies:
+      '@floating-ui/dom': 1.7.3
+      '@tiptap/core': 3.23.6(@tiptap/pm@3.23.6)
+      '@tiptap/pm': 3.23.6
+
+  '@tiptap/extension-bullet-list@3.23.6(@tiptap/extension-list@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6))':
+    dependencies:
+      '@tiptap/extension-list': 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)
+
+  '@tiptap/extension-code-block-lowlight@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/extension-code-block@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)(highlight.js@11.11.1)(lowlight@3.3.0)':
+    dependencies:
+      '@tiptap/core': 3.23.6(@tiptap/pm@3.23.6)
+      '@tiptap/extension-code-block': 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)
+      '@tiptap/pm': 3.23.6
+      highlight.js: 11.11.1
+      lowlight: 3.3.0
+
+  '@tiptap/extension-code-block@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)':
+    dependencies:
+      '@tiptap/core': 3.23.6(@tiptap/pm@3.23.6)
+      '@tiptap/pm': 3.23.6
+
+  '@tiptap/extension-code@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))':
+    dependencies:
+      '@tiptap/core': 3.23.6(@tiptap/pm@3.23.6)
+
+  '@tiptap/extension-document@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))':
+    dependencies:
+      '@tiptap/core': 3.23.6(@tiptap/pm@3.23.6)
+
+  '@tiptap/extension-dropcursor@3.23.6(@tiptap/extensions@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6))':
+    dependencies:
+      '@tiptap/extensions': 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)
+
+  '@tiptap/extension-floating-menu@3.23.6(@floating-ui/dom@1.7.6)(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      '@tiptap/core': 3.23.6(@tiptap/pm@3.23.6)
+      '@tiptap/pm': 3.23.6
+    optional: true
+
+  '@tiptap/extension-gapcursor@3.23.6(@tiptap/extensions@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6))':
+    dependencies:
+      '@tiptap/extensions': 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)
+
+  '@tiptap/extension-hard-break@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))':
+    dependencies:
+      '@tiptap/core': 3.23.6(@tiptap/pm@3.23.6)
+
+  '@tiptap/extension-heading@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))':
+    dependencies:
+      '@tiptap/core': 3.23.6(@tiptap/pm@3.23.6)
+
+  '@tiptap/extension-highlight@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))':
+    dependencies:
+      '@tiptap/core': 3.23.6(@tiptap/pm@3.23.6)
+
+  '@tiptap/extension-horizontal-rule@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)':
+    dependencies:
+      '@tiptap/core': 3.23.6(@tiptap/pm@3.23.6)
+      '@tiptap/pm': 3.23.6
+
+  '@tiptap/extension-image@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))':
+    dependencies:
+      '@tiptap/core': 3.23.6(@tiptap/pm@3.23.6)
+
+  '@tiptap/extension-italic@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))':
+    dependencies:
+      '@tiptap/core': 3.23.6(@tiptap/pm@3.23.6)
+
+  '@tiptap/extension-link@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)':
+    dependencies:
+      '@tiptap/core': 3.23.6(@tiptap/pm@3.23.6)
+      '@tiptap/pm': 3.23.6
+      linkifyjs: 4.3.3
+
+  '@tiptap/extension-list-item@3.23.6(@tiptap/extension-list@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6))':
+    dependencies:
+      '@tiptap/extension-list': 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)
+
+  '@tiptap/extension-list-keymap@3.23.6(@tiptap/extension-list@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6))':
+    dependencies:
+      '@tiptap/extension-list': 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)
+
+  '@tiptap/extension-list@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)':
+    dependencies:
+      '@tiptap/core': 3.23.6(@tiptap/pm@3.23.6)
+      '@tiptap/pm': 3.23.6
+
+  '@tiptap/extension-ordered-list@3.23.6(@tiptap/extension-list@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6))':
+    dependencies:
+      '@tiptap/extension-list': 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)
+
+  '@tiptap/extension-paragraph@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))':
+    dependencies:
+      '@tiptap/core': 3.23.6(@tiptap/pm@3.23.6)
+
+  '@tiptap/extension-placeholder@3.23.6(@tiptap/extensions@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6))':
+    dependencies:
+      '@tiptap/extensions': 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)
+
+  '@tiptap/extension-strike@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))':
+    dependencies:
+      '@tiptap/core': 3.23.6(@tiptap/pm@3.23.6)
+
+  '@tiptap/extension-task-item@3.23.6(@tiptap/extension-list@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6))':
+    dependencies:
+      '@tiptap/extension-list': 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)
+
+  '@tiptap/extension-task-list@3.23.6(@tiptap/extension-list@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6))':
+    dependencies:
+      '@tiptap/extension-list': 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)
+
+  '@tiptap/extension-text-align@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))':
+    dependencies:
+      '@tiptap/core': 3.23.6(@tiptap/pm@3.23.6)
+
+  '@tiptap/extension-text@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))':
+    dependencies:
+      '@tiptap/core': 3.23.6(@tiptap/pm@3.23.6)
+
+  '@tiptap/extension-underline@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))':
+    dependencies:
+      '@tiptap/core': 3.23.6(@tiptap/pm@3.23.6)
+
+  '@tiptap/extensions@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)':
+    dependencies:
+      '@tiptap/core': 3.23.6(@tiptap/pm@3.23.6)
+      '@tiptap/pm': 3.23.6
+
+  '@tiptap/markdown@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)':
+    dependencies:
+      '@tiptap/core': 3.23.6(@tiptap/pm@3.23.6)
+      '@tiptap/pm': 3.23.6
+      marked: 17.0.6
+
+  '@tiptap/pm@3.23.6':
+    dependencies:
+      prosemirror-changeset: 2.4.1
+      prosemirror-commands: 1.7.1
+      prosemirror-dropcursor: 1.8.2
+      prosemirror-gapcursor: 1.4.1
+      prosemirror-history: 1.5.0
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.7
+      prosemirror-schema-list: 1.5.1
+      prosemirror-state: 1.4.4
+      prosemirror-tables: 1.8.5
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.41.8
+
+  '@tiptap/react@3.23.6(@floating-ui/dom@1.7.6)(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@tiptap/core': 3.23.6(@tiptap/pm@3.23.6)
+      '@tiptap/pm': 3.23.6
+      '@types/react': 19.1.10
+      '@types/react-dom': 19.1.7(@types/react@19.1.10)
+      '@types/use-sync-external-store': 0.0.6
+      fast-equals: 5.4.0
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+      use-sync-external-store: 1.5.0(react@19.1.1)
+    optionalDependencies:
+      '@tiptap/extension-bubble-menu': 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)
+      '@tiptap/extension-floating-menu': 3.23.6(@floating-ui/dom@1.7.6)(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)
+    transitivePeerDependencies:
+      - '@floating-ui/dom'
+
+  '@tiptap/starter-kit@3.23.6':
+    dependencies:
+      '@tiptap/core': 3.23.6(@tiptap/pm@3.23.6)
+      '@tiptap/extension-blockquote': 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))
+      '@tiptap/extension-bold': 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))
+      '@tiptap/extension-bullet-list': 3.23.6(@tiptap/extension-list@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6))
+      '@tiptap/extension-code': 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))
+      '@tiptap/extension-code-block': 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)
+      '@tiptap/extension-document': 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))
+      '@tiptap/extension-dropcursor': 3.23.6(@tiptap/extensions@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6))
+      '@tiptap/extension-gapcursor': 3.23.6(@tiptap/extensions@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6))
+      '@tiptap/extension-hard-break': 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))
+      '@tiptap/extension-heading': 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))
+      '@tiptap/extension-horizontal-rule': 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)
+      '@tiptap/extension-italic': 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))
+      '@tiptap/extension-link': 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)
+      '@tiptap/extension-list': 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)
+      '@tiptap/extension-list-item': 3.23.6(@tiptap/extension-list@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6))
+      '@tiptap/extension-list-keymap': 3.23.6(@tiptap/extension-list@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6))
+      '@tiptap/extension-ordered-list': 3.23.6(@tiptap/extension-list@3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6))
+      '@tiptap/extension-paragraph': 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))
+      '@tiptap/extension-strike': 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))
+      '@tiptap/extension-text': 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))
+      '@tiptap/extension-underline': 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))
+      '@tiptap/extensions': 3.23.6(@tiptap/core@3.23.6(@tiptap/pm@3.23.6))(@tiptap/pm@3.23.6)
+      '@tiptap/pm': 3.23.6
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -4057,9 +4587,17 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/node@24.2.1':
     dependencies:
       undici-types: 7.10.0
+
+  '@types/qrcode@1.5.6':
+    dependencies:
+      '@types/node': 24.2.1
 
   '@types/react-dom@19.1.7(@types/react@19.1.10)':
     dependencies:
@@ -4068,6 +4606,10 @@ snapshots:
   '@types/react@19.1.10':
     dependencies:
       csstype: 3.1.3
+
+  '@types/unist@3.0.3': {}
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@vitejs/plugin-react-swc@4.0.0(vite@7.1.2(@types/node@24.2.1)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.4))':
     dependencies:
@@ -4090,6 +4632,12 @@ snapshots:
       - supports-color
 
   acorn@8.15.0: {}
+
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
 
   ansis@4.1.0: {}
 
@@ -4128,6 +4676,8 @@ snapshots:
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.2)
 
+  camelcase@5.3.1: {}
+
   caniuse-lite@1.0.30001734: {}
 
   chokidar@3.6.0:
@@ -4148,6 +4698,12 @@ snapshots:
     dependencies:
       clsx: 2.1.1
 
+  cliui@6.0.0:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
+
   clsx@2.1.1: {}
 
   cmdk@1.0.0(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
@@ -4159,6 +4715,12 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
 
   convert-source-map@2.0.0: {}
 
@@ -4174,7 +4736,11 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decamelize@1.2.0: {}
+
   deepmerge@4.3.1: {}
+
+  dequal@2.0.3: {}
 
   detect-libc@1.0.3: {}
 
@@ -4182,9 +4748,17 @@ snapshots:
 
   detect-node-es@1.1.0: {}
 
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
+
   diff@8.0.2: {}
 
+  dijkstrajs@1.0.3: {}
+
   electron-to-chromium@1.5.200: {}
+
+  emoji-regex@8.0.0: {}
 
   enhanced-resolve@5.18.3:
     dependencies:
@@ -4220,9 +4794,40 @@ snapshots:
       '@esbuild/win32-ia32': 0.25.9
       '@esbuild/win32-x64': 0.25.9
 
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
+
   escalade@3.2.0: {}
 
   esprima@4.0.1: {}
+
+  fast-equals@5.4.0: {}
 
   fdir@6.4.6(picomatch@4.0.3):
     optionalDependencies:
@@ -4232,10 +4837,17 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  find-up@4.1.0:
+    dependencies:
+      locate-path: 5.0.0
+      path-exists: 4.0.0
+
   fsevents@2.3.3:
     optional: true
 
   gensync@1.0.0-beta.2: {}
+
+  get-caller-file@2.0.5: {}
 
   get-nonce@1.0.1: {}
 
@@ -4248,6 +4860,8 @@ snapshots:
       is-glob: 4.0.3
 
   graceful-fs@4.2.11: {}
+
+  highlight.js@11.11.1: {}
 
   html-parse-stringify@3.0.1:
     dependencies:
@@ -4264,6 +4878,8 @@ snapshots:
       binary-extensions: 2.3.0
 
   is-extglob@2.1.1: {}
+
+  is-fullwidth-code-point@3.0.0: {}
 
   is-glob@4.0.3:
     dependencies:
@@ -4326,11 +4942,25 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.30.1
       lightningcss-win32-x64-msvc: 1.30.1
 
+  linkifyjs@4.3.3: {}
+
   load-script@1.0.0: {}
+
+  locate-path@5.0.0:
+    dependencies:
+      p-locate: 4.1.0
+
+  lodash.debounce@4.0.8: {}
 
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
+
+  lowlight@3.3.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      devlop: 1.1.0
+      highlight.js: 11.11.1
 
   lru-cache@5.1.1:
     dependencies:
@@ -4343,6 +4973,8 @@ snapshots:
   magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  marked@17.0.6: {}
 
   memoize-one@5.2.1: {}
 
@@ -4378,11 +5010,27 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  orderedmap@2.1.1: {}
+
+  p-limit@2.3.0:
+    dependencies:
+      p-try: 2.2.0
+
+  p-locate@4.1.0:
+    dependencies:
+      p-limit: 2.3.0
+
+  p-try@2.2.0: {}
+
+  path-exists@4.0.0: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
 
   picomatch@4.0.3: {}
+
+  pngjs@5.0.0: {}
 
   polished@4.3.1:
     dependencies:
@@ -4401,6 +5049,81 @@ snapshots:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  prosemirror-changeset@2.4.1:
+    dependencies:
+      prosemirror-transform: 1.12.0
+
+  prosemirror-commands@1.7.1:
+    dependencies:
+      prosemirror-model: 1.25.7
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+
+  prosemirror-dropcursor@1.8.2:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.41.8
+
+  prosemirror-gapcursor@1.4.1:
+    dependencies:
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.7
+      prosemirror-state: 1.4.4
+      prosemirror-view: 1.41.8
+
+  prosemirror-history@1.5.0:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.41.8
+      rope-sequence: 1.3.4
+
+  prosemirror-keymap@1.2.3:
+    dependencies:
+      prosemirror-state: 1.4.4
+      w3c-keyname: 2.2.8
+
+  prosemirror-model@1.25.7:
+    dependencies:
+      orderedmap: 2.1.1
+
+  prosemirror-schema-list@1.5.1:
+    dependencies:
+      prosemirror-model: 1.25.7
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+
+  prosemirror-state@1.4.4:
+    dependencies:
+      prosemirror-model: 1.25.7
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.41.8
+
+  prosemirror-tables@1.8.5:
+    dependencies:
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.7
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.41.8
+
+  prosemirror-transform@1.12.0:
+    dependencies:
+      prosemirror-model: 1.25.7
+
+  prosemirror-view@1.41.8:
+    dependencies:
+      prosemirror-model: 1.25.7
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.12.0
+
+  qrcode@1.5.4:
+    dependencies:
+      dijkstrajs: 1.0.3
+      pngjs: 5.0.0
+      yargs: 15.4.1
 
   react-day-picker@9.9.0(react@19.1.1):
     dependencies:
@@ -4496,6 +5219,12 @@ snapshots:
       tiny-invariant: 1.3.3
       tslib: 2.8.1
 
+  require-directory@2.1.1: {}
+
+  require-main-filename@2.0.0: {}
+
+  reselect@5.2.0: {}
+
   resolve-pkg-maps@1.0.0: {}
 
   rocketseat-biomejs-config@1.0.1:
@@ -4528,6 +5257,8 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.46.2
       fsevents: 2.3.3
 
+  rope-sequence@1.3.4: {}
+
   scheduler@0.26.0: {}
 
   semver@6.3.1: {}
@@ -4537,6 +5268,8 @@ snapshots:
       seroval: 1.3.2
 
   seroval@1.3.2: {}
+
+  set-blocking@2.0.0: {}
 
   sonner@2.0.7(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
     dependencies:
@@ -4548,6 +5281,16 @@ snapshots:
   source-map@0.6.1: {}
 
   source-map@0.7.6: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
 
   tailwind-merge@3.3.1: {}
 
@@ -4623,6 +5366,15 @@ snapshots:
     dependencies:
       react: 19.1.1
 
+  use-sync-external-store@1.6.0(react@19.1.1):
+    dependencies:
+      react: 19.1.1
+
+  usehooks-ts@3.1.1(react@19.1.1):
+    dependencies:
+      lodash.debounce: 4.0.8
+      react: 19.1.1
+
   vaul@1.1.2(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1):
     dependencies:
       '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -4649,10 +5401,47 @@ snapshots:
 
   void-elements@3.1.0: {}
 
+  w3c-keyname@2.2.8: {}
+
   webpack-virtual-modules@0.6.2: {}
+
+  which-module@2.0.1: {}
+
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  y18n@4.0.3: {}
 
   yallist@3.1.1: {}
 
   yallist@5.0.0: {}
 
+  yargs-parser@18.1.3:
+    dependencies:
+      camelcase: 5.3.1
+      decamelize: 1.2.0
+
+  yargs@15.4.1:
+    dependencies:
+      cliui: 6.0.0
+      decamelize: 1.2.0
+      find-up: 4.1.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      require-main-filename: 2.0.0
+      set-blocking: 2.0.0
+      string-width: 4.2.3
+      which-module: 2.0.1
+      y18n: 4.0.3
+      yargs-parser: 18.1.3
+
   zod@3.25.76: {}
+
+  zustand@5.0.13(@types/react@19.1.10)(react@19.1.1)(use-sync-external-store@1.6.0(react@19.1.1)):
+    optionalDependencies:
+      '@types/react': 19.1.10
+      react: 19.1.1
+      use-sync-external-store: 1.6.0(react@19.1.1)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/scripts/vite-plugin-lumen-host-modules.ts
+++ b/scripts/vite-plugin-lumen-host-modules.ts
@@ -1,0 +1,89 @@
+import { build } from 'esbuild';
+import type { Plugin } from 'vite';
+
+const HOST_DEPS: Record<string, string> = {
+  'react.js': 'react',
+  'react-dom.js': 'react-dom/client',
+};
+
+const MODULE_SDK_STUB = `
+export class LumenPlugin {
+  constructor() {}
+  async onload(_host) {}
+  async onunload() {}
+}
+`.trimStart();
+
+const cache = new Map<string, string>();
+
+async function bundleDep(entrypoint: string): Promise<string> {
+  if (cache.has(entrypoint)) return cache.get(entrypoint)!;
+
+  const result = await build({
+    entryPoints: [entrypoint],
+    bundle: true,
+    format: 'esm',
+    write: false,
+    minify: true,
+    platform: 'browser',
+  });
+
+  const code = result.outputFiles[0].text;
+  cache.set(entrypoint, code);
+  return code;
+}
+
+export function lumenHostModules(): Plugin {
+  return {
+    name: 'lumen-host-modules',
+
+    configureServer(server) {
+      server.middlewares.use(async (req, res, next) => {
+        if (!req.url?.startsWith('/__lumen/')) return next();
+
+        const file = req.url.slice('/__lumen/'.length);
+
+        res.setHeader('Content-Type', 'application/javascript');
+
+        if (file === 'module-sdk.js') {
+          res.end(MODULE_SDK_STUB);
+          return;
+        }
+
+        if (file === 'ui.js') {
+          res.end('// @lumen/ui not yet packaged — use host components via React props');
+          return;
+        }
+
+        const dep = HOST_DEPS[file];
+        if (!dep) {
+          res.statusCode = 404;
+          res.end(`Not found: /__lumen/${file}`);
+          return;
+        }
+
+        try {
+          const code = await bundleDep(dep);
+          res.end(code);
+        } catch (err) {
+          res.statusCode = 500;
+          res.end(String(err));
+        }
+      });
+    },
+
+    async generateBundle() {
+      for (const [file, dep] of Object.entries(HOST_DEPS)) {
+        const code = await bundleDep(dep);
+        this.emitFile({ type: 'asset', fileName: `__lumen/${file}`, source: code });
+      }
+
+      this.emitFile({ type: 'asset', fileName: '__lumen/module-sdk.js', source: MODULE_SDK_STUB });
+      this.emitFile({
+        type: 'asset',
+        fileName: '__lumen/ui.js',
+        source: '// @lumen/ui not yet packaged — use host components via React props',
+      });
+    },
+  };
+}

--- a/scripts/vite-plugin-lumen-host-modules.ts
+++ b/scripts/vite-plugin-lumen-host-modules.ts
@@ -1,5 +1,6 @@
+import path from 'node:path';
 import { build } from 'esbuild';
-import type { Plugin } from 'vite';
+import type { Plugin, ViteDevServer } from 'vite';
 
 const HOST_DEPS: Record<string, string> = {
   'react.js': 'react',
@@ -33,6 +34,12 @@ async function bundleDep(entrypoint: string): Promise<string> {
   return code;
 }
 
+function viteDepUrl(server: ViteDevServer, specifier: string): string {
+  const relCacheDir = path.relative(server.config.root, server.config.cacheDir).replace(/\\/g, '/');
+  const flatId = specifier.replace(/\//g, '_');
+  return `/${relCacheDir}/deps/${flatId}.js`;
+}
+
 export function lumenHostModules(): Plugin {
   return {
     name: 'lumen-host-modules',
@@ -62,13 +69,8 @@ export function lumenHostModules(): Plugin {
           return;
         }
 
-        try {
-          const code = await bundleDep(dep);
-          res.end(code);
-        } catch (err) {
-          res.statusCode = 500;
-          res.end(String(err));
-        }
+        const url = viteDepUrl(server, dep);
+        res.end(`export*from'${url}';export{default}from'${url}';`);
       });
     },
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -151,6 +151,9 @@ name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "arc-swap"
@@ -1464,6 +1467,17 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3511,6 +3525,7 @@ dependencies = [
  "uuid",
  "webrtc",
  "windows 0.58.0",
+ "zip",
 ]
 
 [[package]]
@@ -9543,10 +9558,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "crossbeam-utils",
+ "displaydoc",
+ "flate2",
+ "indexmap 2.14.0",
+ "memchr",
+ "thiserror 2.0.18",
+ "zopfli",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zune-core"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -49,6 +49,7 @@ image = { version = "0.25", default-features = false, features = ["jpeg", "png",
 symphonia = { version = "0.5", default-features = false, features = ["mp3", "aac", "isomp4", "opt-simd"] }
 blake3 = "1"
 rayon = "1"
+zip = { version = "2", default-features = false, features = ["deflate"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.58", features = [

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,15 @@
+mod module_runtime;
+
+use tauri::Manager;
+use module_runtime::{
+    ModuleRuntime,
+    dev_server::start_dev_server,
+    module_data_json_delete, module_data_json_load, module_data_json_save,
+    module_data_json_set, module_disable, module_enable, module_fs_exists, module_fs_list,
+    module_fs_read, module_fs_remove, module_fs_write, module_get, module_install,
+    module_list_installed, module_uninstall,
+};
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -7,7 +19,24 @@ pub fn run() {
         .plugin(tauri_plugin_global_shortcut::Builder::new().build())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_deep_link::init())
-        .invoke_handler(tauri::generate_handler![open_folder])
+        .invoke_handler(tauri::generate_handler![
+            open_folder,
+            module_list_installed,
+            module_install,
+            module_get,
+            module_enable,
+            module_disable,
+            module_uninstall,
+            module_data_json_load,
+            module_data_json_save,
+            module_data_json_set,
+            module_data_json_delete,
+            module_fs_read,
+            module_fs_write,
+            module_fs_exists,
+            module_fs_list,
+            module_fs_remove,
+        ])
         .setup(|app| {
             if cfg!(debug_assertions) {
                 app.handle().plugin(
@@ -16,6 +45,18 @@ pub fn run() {
                         .build(),
                 )?;
             }
+
+            let runtime = ModuleRuntime::init(app.handle())
+                .expect("failed to initialize module runtime");
+            app.manage(runtime);
+
+            if cfg!(debug_assertions) {
+                let app_handle = app.handle().clone();
+                tokio::spawn(async move {
+                    start_dev_server(app_handle).await;
+                });
+            }
+
             Ok(())
         })
         .run(tauri::generate_context!())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 mod module_runtime;
 
 use tauri::Manager;
+use module_runtime::protocol::handle_module_request;
 use module_runtime::{
     ModuleRuntime,
     dev_server::start_dev_server,
@@ -13,6 +14,7 @@ use module_runtime::{
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
+        .register_uri_scheme_protocol("lumen-module", handle_module_request)
         .plugin(tauri_plugin_window_state::Builder::new().build())
         .plugin(tauri_plugin_websocket::init())
         .plugin(tauri_plugin_notification::init())

--- a/src-tauri/src/module_runtime/dev_server.rs
+++ b/src-tauri/src/module_runtime/dev_server.rs
@@ -1,0 +1,138 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::routing::{delete, get, post};
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter};
+use tokio::net::TcpListener;
+
+use crate::module_runtime::ModuleRuntime;
+
+pub const DEV_SERVER_PORT: u16 = 5179;
+
+#[derive(Clone)]
+struct AppState {
+    app: AppHandle,
+}
+
+#[derive(Deserialize)]
+struct InstallBody {
+    path: String,
+    #[serde(default)]
+    dev_mode: bool,
+}
+
+#[derive(Serialize)]
+struct ModuleListItem {
+    id: String,
+    version: String,
+    source: String,
+    enabled: bool,
+}
+
+pub async fn start_dev_server(app: AppHandle) {
+    let state = AppState { app: app.clone() };
+
+    let router = Router::new()
+        .route("/modules", get(list_modules))
+        .route("/modules", post(install_module))
+        .route("/modules/{id}/reload", post(reload_module))
+        .route("/modules/{id}/disable", post(disable_module))
+        .route("/modules/{id}", delete(uninstall_module))
+        .with_state(Arc::new(state));
+
+    let addr = SocketAddr::from(([127, 0, 0, 1], DEV_SERVER_PORT));
+    match TcpListener::bind(addr).await {
+        Ok(listener) => {
+            log::info!("[dev-server] listening on http://{addr}");
+            if let Err(e) = axum::serve(listener, router).await {
+                log::error!("[dev-server] server error: {e}");
+            }
+        }
+        Err(e) => {
+            log::error!("[dev-server] failed to bind {addr}: {e}");
+        }
+    }
+}
+
+async fn list_modules(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    use tauri::Manager;
+    let runtime = state.app.state::<ModuleRuntime>();
+    let reg = match runtime.registry.lock() {
+        Ok(r) => r,
+        Err(_) => return (StatusCode::INTERNAL_SERVER_ERROR, Json(Vec::<ModuleListItem>::new())),
+    };
+    let entries = reg.list_all().unwrap_or_default();
+    let items: Vec<ModuleListItem> = entries
+        .into_iter()
+        .map(|e| ModuleListItem {
+            id: e.id,
+            version: e.version,
+            source: e.source,
+            enabled: e.enabled,
+        })
+        .collect();
+    (StatusCode::OK, Json(items))
+}
+
+async fn install_module(
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<InstallBody>,
+) -> impl IntoResponse {
+    match super::module_install(state.app.clone(), body.path, body.dev_mode) {
+        Ok(m) => (
+            StatusCode::OK,
+            Json(serde_json::json!({ "id": m.manifest.id, "status": "installed" })),
+        ),
+        Err(e) => (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": e })),
+        ),
+    }
+}
+
+async fn reload_module(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    state
+        .app
+        .emit("module:reload", &id)
+        .map(|_| (StatusCode::OK, Json(serde_json::json!({ "status": "reload-requested" }))))
+        .unwrap_or_else(|e: tauri::Error| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": e.to_string() })),
+            )
+        })
+}
+
+async fn disable_module(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    match super::module_disable(state.app.clone(), id) {
+        Ok(_) => (StatusCode::OK, Json(serde_json::json!({ "status": "disabled" }))),
+        Err(e) => (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": e })),
+        ),
+    }
+}
+
+async fn uninstall_module(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> impl IntoResponse {
+    match super::module_uninstall(state.app.clone(), id) {
+        Ok(_) => (StatusCode::OK, Json(serde_json::json!({ "status": "uninstalled" }))),
+        Err(e) => (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": e })),
+        ),
+    }
+}

--- a/src-tauri/src/module_runtime/install.rs
+++ b/src-tauri/src/module_runtime/install.rs
@@ -1,0 +1,137 @@
+use std::fs;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use zip::ZipArchive;
+
+use crate::module_runtime::manifest::{load_manifest, ModuleManifest};
+use crate::module_runtime::registry::{ModuleEntry, Registry};
+
+pub struct Installer<'a> {
+    modules_dir: &'a Path,
+    registry: &'a Registry,
+}
+
+impl<'a> Installer<'a> {
+    pub fn new(modules_dir: &'a Path, registry: &'a Registry) -> Self {
+        Self { modules_dir, registry }
+    }
+
+    pub fn install_from_path(
+        &self,
+        source_path: &Path,
+        dev_mode: bool,
+    ) -> Result<ModuleManifest, String> {
+        let ext = source_path
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("");
+
+        if ext == "lumenpack" {
+            self.install_from_pack(source_path)
+        } else if source_path.is_dir() {
+            self.install_from_dir(source_path, dev_mode)
+        } else {
+            Err(format!(
+                "unsupported source: {}. Expected a .lumenpack file or a directory.",
+                source_path.display()
+            ))
+        }
+    }
+
+    fn install_from_pack(&self, pack_path: &Path) -> Result<ModuleManifest, String> {
+        let file = fs::File::open(pack_path)
+            .map_err(|e| format!("cannot open pack: {e}"))?;
+        let mut archive =
+            ZipArchive::new(file).map_err(|e| format!("invalid zip archive: {e}"))?;
+
+        let manifest = extract_manifest_from_archive(&mut archive)?;
+        manifest.validate()?;
+
+        let dest = self.modules_dir.join(&manifest.id);
+        if dest.exists() {
+            fs::remove_dir_all(&dest).map_err(|e| format!("cannot remove existing dir: {e}"))?;
+        }
+        fs::create_dir_all(&dest).map_err(|e| format!("cannot create module dir: {e}"))?;
+
+        for i in 0..archive.len() {
+            let mut file = archive.by_index(i).map_err(|e| e.to_string())?;
+            let out_path = dest.join(file.name());
+
+            if file.name().ends_with('/') {
+                fs::create_dir_all(&out_path).map_err(|e| e.to_string())?;
+            } else {
+                if let Some(parent) = out_path.parent() {
+                    fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+                }
+                let mut out =
+                    fs::File::create(&out_path).map_err(|e| e.to_string())?;
+                std::io::copy(&mut file, &mut out).map_err(|e| e.to_string())?;
+            }
+        }
+
+        self.registry
+            .insert(&ModuleEntry {
+                id: manifest.id.clone(),
+                version: manifest.version.clone(),
+                source: "sideload".into(),
+                enabled: true,
+                path: dest,
+            })
+            .map_err(|e| e.to_string())?;
+
+        Ok(manifest)
+    }
+
+    fn install_from_dir(&self, dir: &Path, dev_mode: bool) -> Result<ModuleManifest, String> {
+        let manifest = load_manifest(dir)?;
+
+        let dest: PathBuf = if dev_mode {
+            dir.to_path_buf()
+        } else {
+            let d = self.modules_dir.join(&manifest.id);
+            if d.exists() {
+                fs::remove_dir_all(&d).map_err(|e| format!("cannot remove existing dir: {e}"))?;
+            }
+            copy_dir_all(dir, &d)?;
+            d
+        };
+
+        self.registry
+            .insert(&ModuleEntry {
+                id: manifest.id.clone(),
+                version: manifest.version.clone(),
+                source: if dev_mode { "dev" } else { "sideload" }.into(),
+                enabled: true,
+                path: dest,
+            })
+            .map_err(|e| e.to_string())?;
+
+        Ok(manifest)
+    }
+}
+
+fn extract_manifest_from_archive(
+    archive: &mut ZipArchive<fs::File>,
+) -> Result<ModuleManifest, String> {
+    let mut file = archive
+        .by_name("manifest.json")
+        .map_err(|_| "manifest.json not found in archive")?;
+    let mut content = String::new();
+    file.read_to_string(&mut content)
+        .map_err(|e| format!("cannot read manifest.json: {e}"))?;
+    serde_json::from_str(&content).map_err(|e| format!("invalid manifest.json: {e}"))
+}
+
+fn copy_dir_all(src: &Path, dst: &Path) -> Result<(), String> {
+    fs::create_dir_all(dst).map_err(|e| e.to_string())?;
+    for entry in fs::read_dir(src).map_err(|e| e.to_string())? {
+        let entry = entry.map_err(|e| e.to_string())?;
+        let dst_path = dst.join(entry.file_name());
+        if entry.file_type().map_err(|e| e.to_string())?.is_dir() {
+            copy_dir_all(&entry.path(), &dst_path)?;
+        } else {
+            fs::copy(entry.path(), &dst_path).map_err(|e| e.to_string())?;
+        }
+    }
+    Ok(())
+}

--- a/src-tauri/src/module_runtime/manifest.rs
+++ b/src-tauri/src/module_runtime/manifest.rs
@@ -1,0 +1,59 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModuleManifest {
+    pub id: String,
+    pub name: String,
+    pub version: String,
+    pub api: String,
+    #[serde(rename = "minLumenVersion")]
+    pub min_lumen_version: Option<String>,
+    pub description: Option<String>,
+    pub author: Option<ModuleAuthor>,
+    pub entry: Option<String>,
+    pub icon: Option<String>,
+    pub homepage: Option<String>,
+    pub repository: Option<String>,
+    pub license: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModuleAuthor {
+    pub name: String,
+    pub url: Option<String>,
+}
+
+impl ModuleManifest {
+    pub fn entry_file(&self) -> &str {
+        self.entry.as_deref().unwrap_or("main.js")
+    }
+
+    pub fn validate(&self) -> Result<(), String> {
+        if self.id.is_empty() {
+            return Err("manifest.id is required".into());
+        }
+        if !self.id.contains('.') {
+            return Err("manifest.id must be reverse-DNS (e.g. com.example.my-module)".into());
+        }
+        if self.name.is_empty() {
+            return Err("manifest.name is required".into());
+        }
+        if self.version.is_empty() {
+            return Err("manifest.version is required".into());
+        }
+        if self.api.is_empty() {
+            return Err("manifest.api is required".into());
+        }
+        Ok(())
+    }
+}
+
+pub fn load_manifest(dir: &std::path::Path) -> Result<ModuleManifest, String> {
+    let path = dir.join("manifest.json");
+    let content = std::fs::read_to_string(&path)
+        .map_err(|e| format!("failed to read manifest at {}: {e}", path.display()))?;
+    let manifest: ModuleManifest = serde_json::from_str(&content)
+        .map_err(|e| format!("failed to parse manifest at {}: {e}", path.display()))?;
+    manifest.validate()?;
+    Ok(manifest)
+}

--- a/src-tauri/src/module_runtime/mod.rs
+++ b/src-tauri/src/module_runtime/mod.rs
@@ -1,0 +1,313 @@
+pub mod dev_server;
+pub mod install;
+pub mod manifest;
+pub mod protocol;
+pub mod registry;
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Manager};
+
+use manifest::ModuleManifest;
+use registry::Registry;
+
+use self::install::Installer;
+
+pub struct ModuleRuntime {
+    pub modules_dir: PathBuf,
+    pub registry: Arc<Mutex<Registry>>,
+}
+
+impl ModuleRuntime {
+    pub fn init(app: &AppHandle) -> Result<Self, String> {
+        let data_dir = app
+            .path()
+            .app_data_dir()
+            .map_err(|e| e.to_string())?
+            .join("modules");
+
+        std::fs::create_dir_all(&data_dir).map_err(|e| e.to_string())?;
+
+        let db_path = app
+            .path()
+            .app_data_dir()
+            .map_err(|e| e.to_string())?
+            .join("lumen.sqlite");
+
+        let registry =
+            Registry::open(&db_path).map_err(|e| format!("registry open failed: {e}"))?;
+
+        Ok(Self {
+            modules_dir: data_dir,
+            registry: Arc::new(Mutex::new(registry)),
+        })
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct InstalledModule {
+    pub manifest: ModuleManifest,
+    pub source: String,
+    pub enabled: bool,
+}
+
+#[tauri::command]
+pub fn module_list_installed(
+    app: AppHandle,
+) -> Result<Vec<InstalledModule>, String> {
+    let runtime = app.state::<ModuleRuntime>();
+    let reg = runtime.registry.lock().map_err(|e| e.to_string())?;
+    let entries = reg.list_enabled().map_err(|e| e.to_string())?;
+
+    let mut result = Vec::new();
+    for entry in entries {
+        match manifest::load_manifest(&entry.path) {
+            Ok(manifest) => {
+                result.push(InstalledModule {
+                    manifest,
+                    source: entry.source,
+                    enabled: entry.enabled,
+                });
+            }
+            Err(e) => {
+                log::warn!("skipping module {}: {e}", entry.id);
+            }
+        }
+    }
+    Ok(result)
+}
+
+#[derive(Debug, Deserialize)]
+pub struct InstallModuleArgs {
+    pub path: String,
+    #[serde(default)]
+    pub dev_mode: bool,
+}
+
+#[tauri::command]
+pub fn module_install(
+    app: AppHandle,
+    path: String,
+    dev_mode: bool,
+) -> Result<InstalledModule, String> {
+    let runtime = app.state::<ModuleRuntime>();
+    let reg = runtime.registry.lock().map_err(|e| e.to_string())?;
+    let installer = Installer::new(&runtime.modules_dir, &reg);
+
+    let source_path = std::path::Path::new(&path);
+    let manifest = installer.install_from_path(source_path, dev_mode)?;
+
+    let source = if dev_mode {
+        "dev"
+    } else if source_path.extension().and_then(|e| e.to_str()) == Some("lumenpack") {
+        "sideload"
+    } else {
+        "sideload"
+    };
+
+    Ok(InstalledModule {
+        manifest,
+        source: source.into(),
+        enabled: true,
+    })
+}
+
+#[tauri::command]
+pub fn module_get(app: AppHandle, id: String) -> Result<Option<InstalledModule>, String> {
+    let runtime = app.state::<ModuleRuntime>();
+    let reg = runtime.registry.lock().map_err(|e| e.to_string())?;
+    let entry = reg.get(&id).map_err(|e| e.to_string())?;
+
+    let Some(entry) = entry else {
+        return Ok(None);
+    };
+
+    let manifest = manifest::load_manifest(&entry.path)?;
+    Ok(Some(InstalledModule {
+        manifest,
+        source: entry.source,
+        enabled: entry.enabled,
+    }))
+}
+
+#[tauri::command]
+pub fn module_enable(app: AppHandle, id: String) -> Result<(), String> {
+    let runtime = app.state::<ModuleRuntime>();
+    let reg = runtime.registry.lock().map_err(|e| e.to_string())?;
+    reg.set_enabled(&id, true).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn module_disable(app: AppHandle, id: String) -> Result<(), String> {
+    let runtime = app.state::<ModuleRuntime>();
+    let reg = runtime.registry.lock().map_err(|e| e.to_string())?;
+    reg.set_enabled(&id, false).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn module_uninstall(app: AppHandle, id: String) -> Result<(), String> {
+    let runtime = app.state::<ModuleRuntime>();
+    let reg = runtime.registry.lock().map_err(|e| e.to_string())?;
+
+    let entry = reg.get(&id).map_err(|e| e.to_string())?;
+    if let Some(entry) = entry {
+        if entry.source != "dev" && entry.path.exists() {
+            std::fs::remove_dir_all(&entry.path)
+                .map_err(|e| format!("failed to remove module dir: {e}"))?;
+        }
+    }
+
+    reg.remove(&id).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn module_data_json_load(
+    app: AppHandle,
+    module_id: String,
+) -> Result<serde_json::Value, String> {
+    let data_path = module_data_json_path(&app, &module_id)?;
+    if !data_path.exists() {
+        return Ok(serde_json::Value::Object(Default::default()));
+    }
+    let content = std::fs::read_to_string(&data_path).map_err(|e| e.to_string())?;
+    serde_json::from_str(&content).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn module_data_json_save(
+    app: AppHandle,
+    module_id: String,
+    value: serde_json::Value,
+) -> Result<(), String> {
+    let data_path = module_data_json_path(&app, &module_id)?;
+    let content = serde_json::to_string_pretty(&value).map_err(|e| e.to_string())?;
+    std::fs::write(&data_path, content).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn module_data_json_set(
+    app: AppHandle,
+    module_id: String,
+    key: String,
+    value: serde_json::Value,
+) -> Result<(), String> {
+    let data_path = module_data_json_path(&app, &module_id)?;
+    let mut data: serde_json::Map<String, serde_json::Value> = if data_path.exists() {
+        let content = std::fs::read_to_string(&data_path).map_err(|e| e.to_string())?;
+        serde_json::from_str(&content).map_err(|e| e.to_string())?
+    } else {
+        Default::default()
+    };
+    data.insert(key, value);
+    let content =
+        serde_json::to_string_pretty(&serde_json::Value::Object(data)).map_err(|e| e.to_string())?;
+    std::fs::write(&data_path, content).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn module_data_json_delete(
+    app: AppHandle,
+    module_id: String,
+    key: String,
+) -> Result<(), String> {
+    let data_path = module_data_json_path(&app, &module_id)?;
+    if !data_path.exists() {
+        return Ok(());
+    }
+    let content = std::fs::read_to_string(&data_path).map_err(|e| e.to_string())?;
+    let mut data: serde_json::Map<String, serde_json::Value> =
+        serde_json::from_str(&content).map_err(|e| e.to_string())?;
+    data.remove(&key);
+    let content =
+        serde_json::to_string_pretty(&serde_json::Value::Object(data)).map_err(|e| e.to_string())?;
+    std::fs::write(&data_path, content).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn module_fs_read(app: AppHandle, module_id: String, path: String) -> Result<Vec<u8>, String> {
+    let full = scoped_module_path(&app, &module_id, &path)?;
+    std::fs::read(&full).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn module_fs_write(
+    app: AppHandle,
+    module_id: String,
+    path: String,
+    data: Vec<u8>,
+) -> Result<(), String> {
+    let full = scoped_module_path(&app, &module_id, &path)?;
+    if let Some(parent) = full.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    std::fs::write(&full, data).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn module_fs_exists(app: AppHandle, module_id: String, path: String) -> Result<bool, String> {
+    let full = scoped_module_path(&app, &module_id, &path)?;
+    Ok(full.exists())
+}
+
+#[tauri::command]
+pub fn module_fs_list(
+    app: AppHandle,
+    module_id: String,
+    path: String,
+) -> Result<Vec<String>, String> {
+    let full = scoped_module_path(&app, &module_id, &path)?;
+    let entries = std::fs::read_dir(&full).map_err(|e| e.to_string())?;
+    let names: Vec<String> = entries
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .collect();
+    Ok(names)
+}
+
+#[tauri::command]
+pub fn module_fs_remove(
+    app: AppHandle,
+    module_id: String,
+    path: String,
+) -> Result<(), String> {
+    let full = scoped_module_path(&app, &module_id, &path)?;
+    if full.is_dir() {
+        std::fs::remove_dir_all(&full).map_err(|e| e.to_string())
+    } else {
+        std::fs::remove_file(&full).map_err(|e| e.to_string())
+    }
+}
+
+fn module_data_json_path(app: &AppHandle, module_id: &str) -> Result<PathBuf, String> {
+    let dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| e.to_string())?
+        .join("modules")
+        .join(module_id);
+    std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+    Ok(dir.join("data.json"))
+}
+
+fn scoped_module_path(
+    app: &AppHandle,
+    module_id: &str,
+    relative: &str,
+) -> Result<PathBuf, String> {
+    let base = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| e.to_string())?
+        .join("modules")
+        .join(module_id);
+
+    let full = base.join(relative);
+
+    if !full.starts_with(&base) {
+        return Err("path traversal attempt blocked".into());
+    }
+
+    Ok(full)
+}

--- a/src-tauri/src/module_runtime/protocol.rs
+++ b/src-tauri/src/module_runtime/protocol.rs
@@ -1,0 +1,101 @@
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use tauri::{AppHandle, UriSchemeContext, UriSchemeResponder};
+
+use crate::module_runtime::registry::Registry;
+
+pub fn register_lumen_module_protocol(
+    app: &AppHandle,
+    modules_dir: PathBuf,
+    registry: Arc<Mutex<Registry>>,
+) {
+    let _ = (app, modules_dir, registry);
+}
+
+pub fn handle_module_request(
+    _ctx: UriSchemeContext<tauri::Wry>,
+    request: tauri::http::Request<Vec<u8>>,
+    responder: UriSchemeResponder,
+    modules_dir: PathBuf,
+    registry: Arc<Mutex<Registry>>,
+) {
+    let uri = request.uri().to_string();
+
+    let path_part = uri
+        .strip_prefix("lumen-module://")
+        .unwrap_or("")
+        .trim_start_matches('/');
+
+    let parts: Vec<&str> = path_part.splitn(2, '/').collect();
+    if parts.len() < 2 {
+        responder.respond(
+            tauri::http::Response::builder()
+                .status(400)
+                .body(b"Bad Request: expected lumen-module://{id}/{file}".to_vec())
+                .unwrap(),
+        );
+        return;
+    }
+
+    let module_id = parts[0];
+    let file_path = parts[1];
+
+    let enabled = registry
+        .lock()
+        .ok()
+        .and_then(|reg| reg.get(module_id).ok().flatten())
+        .map(|e| e.enabled)
+        .unwrap_or(false);
+
+    if !enabled {
+        responder.respond(
+            tauri::http::Response::builder()
+                .status(403)
+                .body(b"Forbidden: module is not enabled".to_vec())
+                .unwrap(),
+        );
+        return;
+    }
+
+    let full_path = modules_dir.join(module_id).join(file_path);
+
+    match std::fs::read(&full_path) {
+        Ok(bytes) => {
+            let content_type = mime_for_ext(
+                full_path
+                    .extension()
+                    .and_then(|e| e.to_str())
+                    .unwrap_or(""),
+            );
+            responder.respond(
+                tauri::http::Response::builder()
+                    .status(200)
+                    .header("Content-Type", content_type)
+                    .header("Access-Control-Allow-Origin", "*")
+                    .body(bytes)
+                    .unwrap(),
+            );
+        }
+        Err(e) => {
+            responder.respond(
+                tauri::http::Response::builder()
+                    .status(404)
+                    .body(format!("Not Found: {e}").into_bytes())
+                    .unwrap(),
+            );
+        }
+    }
+}
+
+fn mime_for_ext(ext: &str) -> &'static str {
+    match ext {
+        "js" | "mjs" => "application/javascript",
+        "css" => "text/css",
+        "json" => "application/json",
+        "svg" => "image/svg+xml",
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "woff2" => "font/woff2",
+        _ => "application/octet-stream",
+    }
+}

--- a/src-tauri/src/module_runtime/protocol.rs
+++ b/src-tauri/src/module_runtime/protocol.rs
@@ -1,24 +1,15 @@
-use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
-use tauri::{AppHandle, UriSchemeContext, UriSchemeResponder};
+use tauri::{Manager, UriSchemeContext};
 
-use crate::module_runtime::registry::Registry;
-
-pub fn register_lumen_module_protocol(
-    app: &AppHandle,
-    modules_dir: PathBuf,
-    registry: Arc<Mutex<Registry>>,
-) {
-    let _ = (app, modules_dir, registry);
-}
+use crate::module_runtime::ModuleRuntime;
 
 pub fn handle_module_request(
-    _ctx: UriSchemeContext<tauri::Wry>,
+    ctx: UriSchemeContext<'_, tauri::Wry>,
     request: tauri::http::Request<Vec<u8>>,
-    responder: UriSchemeResponder,
-    modules_dir: PathBuf,
-    registry: Arc<Mutex<Registry>>,
-) {
+) -> tauri::http::Response<Vec<u8>> {
+    let runtime = ctx.app_handle().state::<ModuleRuntime>();
+    let modules_dir = runtime.modules_dir.clone();
+    let registry = runtime.registry.clone();
+
     let uri = request.uri().to_string();
 
     let path_part = uri
@@ -28,13 +19,10 @@ pub fn handle_module_request(
 
     let parts: Vec<&str> = path_part.splitn(2, '/').collect();
     if parts.len() < 2 {
-        responder.respond(
-            tauri::http::Response::builder()
-                .status(400)
-                .body(b"Bad Request: expected lumen-module://{id}/{file}".to_vec())
-                .unwrap(),
-        );
-        return;
+        return tauri::http::Response::builder()
+            .status(400)
+            .body(b"Bad Request: expected lumen-module://{id}/{file}".to_vec())
+            .unwrap();
     }
 
     let module_id = parts[0];
@@ -48,13 +36,10 @@ pub fn handle_module_request(
         .unwrap_or(false);
 
     if !enabled {
-        responder.respond(
-            tauri::http::Response::builder()
-                .status(403)
-                .body(b"Forbidden: module is not enabled".to_vec())
-                .unwrap(),
-        );
-        return;
+        return tauri::http::Response::builder()
+            .status(403)
+            .body(b"Forbidden: module is not enabled".to_vec())
+            .unwrap();
     }
 
     let full_path = modules_dir.join(module_id).join(file_path);
@@ -67,23 +52,17 @@ pub fn handle_module_request(
                     .and_then(|e| e.to_str())
                     .unwrap_or(""),
             );
-            responder.respond(
-                tauri::http::Response::builder()
-                    .status(200)
-                    .header("Content-Type", content_type)
-                    .header("Access-Control-Allow-Origin", "*")
-                    .body(bytes)
-                    .unwrap(),
-            );
+            tauri::http::Response::builder()
+                .status(200)
+                .header("Content-Type", content_type)
+                .header("Access-Control-Allow-Origin", "*")
+                .body(bytes)
+                .unwrap()
         }
-        Err(e) => {
-            responder.respond(
-                tauri::http::Response::builder()
-                    .status(404)
-                    .body(format!("Not Found: {e}").into_bytes())
-                    .unwrap(),
-            );
-        }
+        Err(e) => tauri::http::Response::builder()
+            .status(404)
+            .body(format!("Not Found: {e}").into_bytes())
+            .unwrap(),
     }
 }
 

--- a/src-tauri/src/module_runtime/registry.rs
+++ b/src-tauri/src/module_runtime/registry.rs
@@ -1,0 +1,108 @@
+use rusqlite::{Connection, Result, params};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModuleEntry {
+    pub id: String,
+    pub version: String,
+    pub source: String,
+    pub enabled: bool,
+    pub path: PathBuf,
+}
+
+pub struct Registry {
+    conn: Connection,
+}
+
+impl Registry {
+    pub fn open(db_path: &std::path::Path) -> Result<Self> {
+        let conn = Connection::open(db_path)?;
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS modules (
+                id      TEXT PRIMARY KEY,
+                version TEXT NOT NULL,
+                source  TEXT NOT NULL DEFAULT 'sideload',
+                enabled INTEGER NOT NULL DEFAULT 1,
+                path    TEXT NOT NULL
+            );",
+        )?;
+        Ok(Self { conn })
+    }
+
+    pub fn list_enabled(&self) -> Result<Vec<ModuleEntry>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, version, source, enabled, path FROM modules WHERE enabled = 1",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok(ModuleEntry {
+                id: row.get(0)?,
+                version: row.get(1)?,
+                source: row.get(2)?,
+                enabled: row.get::<_, i64>(3)? != 0,
+                path: PathBuf::from(row.get::<_, String>(4)?),
+            })
+        })?;
+        rows.collect()
+    }
+
+    pub fn list_all(&self) -> Result<Vec<ModuleEntry>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, version, source, enabled, path FROM modules",
+        )?;
+        let rows = stmt.query_map([], |row| {
+            Ok(ModuleEntry {
+                id: row.get(0)?,
+                version: row.get(1)?,
+                source: row.get(2)?,
+                enabled: row.get::<_, i64>(3)? != 0,
+                path: PathBuf::from(row.get::<_, String>(4)?),
+            })
+        })?;
+        rows.collect()
+    }
+
+    pub fn get(&self, id: &str) -> Result<Option<ModuleEntry>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT id, version, source, enabled, path FROM modules WHERE id = ?1",
+        )?;
+        let mut rows = stmt.query_map(params![id], |row| {
+            Ok(ModuleEntry {
+                id: row.get(0)?,
+                version: row.get(1)?,
+                source: row.get(2)?,
+                enabled: row.get::<_, i64>(3)? != 0,
+                path: PathBuf::from(row.get::<_, String>(4)?),
+            })
+        })?;
+        Ok(rows.next().transpose()?)
+    }
+
+    pub fn insert(&self, entry: &ModuleEntry) -> Result<()> {
+        self.conn.execute(
+            "INSERT OR REPLACE INTO modules (id, version, source, enabled, path)
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                entry.id,
+                entry.version,
+                entry.source,
+                entry.enabled as i64,
+                entry.path.to_string_lossy(),
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn set_enabled(&self, id: &str, enabled: bool) -> Result<()> {
+        self.conn.execute(
+            "UPDATE modules SET enabled = ?1 WHERE id = ?2",
+            params![enabled as i64, id],
+        )?;
+        Ok(())
+    }
+
+    pub fn remove(&self, id: &str) -> Result<()> {
+        self.conn.execute("DELETE FROM modules WHERE id = ?1", params![id])?;
+        Ok(())
+    }
+}

--- a/src/app/__root.tsx
+++ b/src/app/__root.tsx
@@ -4,6 +4,7 @@ import { GlobalAlert } from '@/components/global-alert';
 import { LyricModal } from '@/components/lyric-modal';
 import { QuickShortcutsModal } from '@/components/quick-shortcuts-modal';
 import { Toaster } from '@/components/ui/sonner';
+import { useModules } from '@/hooks/use-modules';
 import { useProfiles } from '@/hooks/use-profiles';
 import { useSingleInstance } from '@/hooks/use-single-instance';
 import { useTheme } from '@/hooks/use-theme';
@@ -16,6 +17,7 @@ function RootComponent() {
   useSingleInstance();
   useTheme();
   useProfiles();
+  useModules();
 
   return (
     <React.Fragment>

--- a/src/app/media-window.tsx
+++ b/src/app/media-window.tsx
@@ -121,6 +121,7 @@ function MediaWindowComponent() {
   const [isFullscreen, setIsFullscreen] = useState(true);
   const [mode, setMode] = useState<'video' | 'lyric'>('video');
   const [lyricPath, setLyricPath] = useState('');
+  const [imagePath, setImagePath] = useState<string | null>(null);
   const [streamOverlayActive, setStreamOverlayActive] = useState(false);
 
   const saveCurrentPosition = useCallback(async () => {
@@ -238,11 +239,17 @@ function MediaWindowComponent() {
     const unlistenLyric = listen<{ url: string }>('load-lyric', (event) => {
       setMode('lyric');
       setLyricPath(event.payload.url);
+      setImagePath(null);
     });
 
     const unlistenLoadUrl = listen('load-url', () => {
       setMode('video');
       invoke('push_stream_blank').catch(() => {});
+    });
+
+    const unlistenLoadImage = listen<{ url: string }>('load-image', (event) => {
+      setImagePath(event.payload.url);
+      setMode('video');
     });
 
     const unlistenStreamOverlay = listen<{ active: boolean }>('stream-overlay-toggle', (event) => {
@@ -252,6 +259,7 @@ function MediaWindowComponent() {
     return () => {
       unlistenLyric.then((f) => f());
       unlistenLoadUrl.then((f) => f());
+      unlistenLoadImage.then((f) => f());
       unlistenStreamOverlay.then((f) => f());
     };
   }, []);
@@ -266,6 +274,20 @@ function MediaWindowComponent() {
   return (
     <div className="relative h-dvh w-dvw bg-black">
       <Videoplayer className="h-full w-full" url="" autoplay muted={false} interactive={false} />
+      {imagePath && mode !== 'lyric' && (
+        <button
+          type="button"
+          aria-label="Close image"
+          className="absolute inset-0 z-10 flex items-center justify-center bg-black cursor-pointer"
+          onClick={() => setImagePath(null)}
+        >
+          <img
+            src={`asset://localhost/${imagePath.replace(/\\/g, '/')}`}
+            alt=""
+            className="max-h-full max-w-full object-contain"
+          />
+        </button>
+      )}
       {mode === 'lyric' && lyricPath && (
         <div className="absolute inset-0 z-10">
           <LyricPresentation filePath={lyricPath} />

--- a/src/components/miniplayer.tsx
+++ b/src/components/miniplayer.tsx
@@ -11,11 +11,13 @@ import {
   LucideVolumeX,
 } from 'lucide-react';
 import { useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card';
 import { Slider } from '@/components/ui/slider';
 import { cn } from '@/lib/utils';
+import { mediaDbService } from '@/services/media-db-service';
 import { usePlayerStore } from '@/stores/player-store';
-import { Button } from './ui/button';
-import { HoverCard, HoverCardContent, HoverCardTrigger } from './ui/hover-card';
+import { useQueueStore } from '@/stores/queue-store';
 
 interface MiniPlayerProps {
   className?: string;
@@ -33,6 +35,7 @@ function formatTime(seconds: number): string {
 
 export function MiniPlayer({ className }: MiniPlayerProps) {
   const player = usePlayerStore();
+  const queue = useQueueStore();
 
   useEffect(() => {
     const cleanupWs = player.initWs();
@@ -43,6 +46,36 @@ export function MiniPlayer({ className }: MiniPlayerProps) {
       cleanupListeners();
     };
   }, [player.initWs, player.initListeners, player.restoreLastMedia]);
+
+  useEffect(() => {
+    const handler = async (e: Event) => {
+      const { source, path, action } = (e as CustomEvent<{ source: string; path: string; action: 'play' | 'queue' }>).detail;
+
+      if (action === 'play') {
+        if (source === 'lyric') { await player.presentLyric(path); return; }
+        if (source === 'image') { await player.presentImage(path); return; }
+        await player.loadFile(path);
+        return;
+      }
+
+      if (action === 'queue') {
+        const hit = await mediaDbService.getByPath(path);
+        if (!hit) return;
+        await queue.addToQueue({
+          name: hit.name,
+          path: hit.path,
+          size: 0,
+          modifiedAt: new Date(hit.modified_at),
+          extension: hit.path.split('.').pop() ?? '',
+          duration: hit.duration ?? undefined,
+          artist: hit.artist ?? undefined,
+        });
+      }
+    };
+
+    window.addEventListener('lumen:commander-open', handler);
+    return () => window.removeEventListener('lumen:commander-open', handler);
+  }, [player, queue]);
 
   const iconBtn =
     'p-2 rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted transition-colors';

--- a/src/components/quick-shortcuts-modal.tsx
+++ b/src/components/quick-shortcuts-modal.tsx
@@ -49,28 +49,28 @@ const SOURCE_THEME: Record<SearchSource, SourceTheme> = {
   },
   audio: {
     icon: Music,
-    iconBox: 'bg-purple-500/10 text-purple-300 border-purple-500/25',
-    badge: 'bg-purple-500/15 text-purple-300 border-purple-500/30',
+    iconBox: 'bg-primary/10 text-primary border-primary/25',
+    badge: 'bg-primary/15 text-primary border-primary/30',
   },
   video: {
     icon: Video,
-    iconBox: 'bg-purple-500/10 text-purple-300 border-purple-500/25',
-    badge: 'bg-purple-500/15 text-purple-300 border-purple-500/30',
+    iconBox: 'bg-primary/10 text-primary border-primary/25',
+    badge: 'bg-primary/15 text-primary border-primary/30',
   },
   image: {
     icon: ImageIcon,
-    iconBox: 'bg-purple-500/10 text-purple-300 border-purple-500/25',
-    badge: 'bg-purple-500/15 text-purple-300 border-purple-500/30',
+    iconBox: 'bg-primary/10 text-primary border-primary/25',
+    badge: 'bg-primary/15 text-primary border-primary/30',
   },
   command: {
     icon: Terminal,
-    iconBox: 'bg-primary/10 text-primary border-primary/25',
-    badge: 'bg-primary/15 text-primary border-primary/30',
+    iconBox: 'bg-purple-500/10 text-purple-300 border-purple-500/25',
+    badge: 'bg-purple-500/15 text-purple-300 border-purple-500/30',
   },
   app: {
     icon: Sparkles,
-    iconBox: 'bg-primary/10 text-primary border-primary/25',
-    badge: 'bg-primary/15 text-primary border-primary/30',
+    iconBox: 'bg-purple-500/10 text-purple-300 border-purple-500/25',
+    badge: 'bg-purple-500/15 text-purple-300 border-purple-500/30',
   },
 };
 
@@ -172,7 +172,7 @@ function ResultRow({
   result: SearchResult;
   tokens: string[];
   selected: boolean;
-  onSelect: (r: SearchResult) => void;
+  onSelect: (r: SearchResult, queued: boolean) => void;
 }) {
   const { t } = useTranslation();
   const theme = SOURCE_THEME[result.source];
@@ -183,7 +183,7 @@ function ResultRow({
       type="button"
       role="option"
       aria-selected={selected}
-      onClick={() => onSelect(result)}
+      onClick={(e) => onSelect(result, e.shiftKey)}
       className={cn(
         'group/row flex w-full items-center gap-3 rounded-lg border px-2.5 py-2.5 text-left transition-colors',
         selected
@@ -389,8 +389,14 @@ function CommanderFooter({
         </span>
         <span className="flex items-center gap-1.5">
           <Kbd>↵</Kbd>
-          {showBack ? t('Select') : t('Open')}
+          {showBack ? t('Select') : t('Play')}
         </span>
+        {!showBack && (
+          <span className="flex items-center gap-1.5">
+            <Kbd>⇧↵</Kbd>
+            {t('Queue')}
+          </span>
+        )}
         {!showBack && (
           <span className="flex items-center gap-1.5">
             <Kbd>Tab</Kbd>
@@ -482,7 +488,7 @@ function RootView() {
     overscan: 8,
   });
 
-  function handleSelect(r: SearchResult) {
+  function handleSelect(r: SearchResult, queued = false) {
     if (r.source === 'app' && r.commandSpec?.component) {
       pushApp({
         commandId: r.commandSpec.id,
@@ -499,7 +505,7 @@ function RootView() {
     if (r.path) {
       window.dispatchEvent(
         new CustomEvent('lumen:commander-open', {
-          detail: { source: r.source, id: r.id, path: r.path },
+          detail: { source: r.source, id: r.id, path: r.path, action: queued ? 'queue' : 'play' },
         })
       );
       close();
@@ -532,7 +538,7 @@ function RootView() {
     if (event.key === 'Enter') {
       event.preventDefault();
       const row = flatRows[itemIndices[selectedIdx] ?? -1];
-      if (row?.kind === 'item') handleSelect(row.result);
+      if (row?.kind === 'item') handleSelect(row.result, event.shiftKey);
     }
   }
 
@@ -594,7 +600,7 @@ function RootView() {
                       result={row.result}
                       tokens={tokens}
                       selected={itemIndices[selectedIdx] === vItem.index}
-                      onSelect={handleSelect}
+                      onSelect={(r, queued) => handleSelect(r, queued)}
                     />
                   )}
                 </div>

--- a/src/components/quick-shortcuts-modal.tsx
+++ b/src/components/quick-shortcuts-modal.tsx
@@ -278,6 +278,7 @@ function PaletteHeader({
   inputValue,
   setInputValue,
   inputId,
+  placeholder,
 }: {
   app?: ActiveApp;
   fullContent: boolean;
@@ -285,6 +286,7 @@ function PaletteHeader({
   inputValue: string;
   setInputValue: (v: string) => void;
   inputId: string;
+  placeholder?: string;
 }) {
   const { t } = useTranslation();
   const { popApp } = useCommandStore();
@@ -317,7 +319,7 @@ function PaletteHeader({
           id={inputId}
           value={inputValue}
           onChange={(e) => setInputValue(e.target.value)}
-          placeholder={app ? app.title : t('Type a command or search...')}
+          placeholder={app ? app.title : (placeholder ?? t('Type a command or search...'))}
           className="h-full w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
         />
       </label>
@@ -357,11 +359,12 @@ function CommanderFooter({
   const { t } = useTranslation();
   const hasQuery = !!query?.trim();
 
-  const hint = (kbd: React.ReactNode, tooltip: string) => (
+  const hint = (kbd: React.ReactNode, label: string, tooltip: string) => (
     <Tooltip>
       <TooltipTrigger>
-        <span className="flex cursor-default items-center gap-0.5">
+        <span className="flex cursor-default items-center gap-1">
           <Kbd className="flex items-center gap-0.5">{kbd}</Kbd>
+          <span>{label}</span>
         </span>
       </TooltipTrigger>
       <TooltipContent side="top">{tooltip}</TooltipContent>
@@ -395,20 +398,22 @@ function CommanderFooter({
       </div>
       <TooltipProvider delay={400}>
         <div className="flex items-center gap-2.5">
-          {hint(<ArrowUpDown />, t('Arrow Up/Down'))}
-          {hint(<CornerDownLeft />, showBack ? t('Enter') : t('Enter'))}
+          {hint(<ArrowUpDown />, t('Navigate'), t('Arrow Up / Down'))}
+          {hint(<CornerDownLeft />, showBack ? t('Select') : t('Play'), t('Enter'))}
           {!showBack &&
             hint(
               <>
                 <ArrowBigUp />
                 <CornerDownLeft />
               </>,
+              t('Queue'),
               t('Shift + Enter')
             )}
-          {!showBack && hint(<span className="text-[10px]">Tab</span>, t('Tab'))}
+          {!showBack && hint(<span className="text-[10px]">Tab</span>, t('Filter'), t('Tab'))}
           {hint(
             showBack ? <ArrowLeft /> : <span className="text-[10px]">Esc</span>,
-            showBack ? t('Back') : t('Esc')
+            showBack ? t('Back') : t('Close'),
+            showBack ? t('←') : t('Esc')
           )}
         </div>
       </TooltipProvider>
@@ -418,9 +423,32 @@ function CommanderFooter({
 
 type VirtualRow = { kind: 'heading'; label: string } | { kind: 'item'; result: SearchResult };
 
+const BUILTIN_SCOPE_PREFIXES: Record<string, SearchScope> = {
+  lyric: 'lyrics',
+  lyrics: 'lyrics',
+  song: 'lyrics',
+  media: 'media',
+  audio: 'media',
+  video: 'media',
+  image: 'media',
+  cmd: 'commands',
+  command: 'commands',
+  commands: 'commands',
+};
+
+function parseBuiltinPrefix(query: string): { scope: SearchScope; rest: string } | null {
+  const lower = query.toLowerCase();
+  for (const [alias, targetScope] of Object.entries(BUILTIN_SCOPE_PREFIXES)) {
+    if (lower.startsWith(`${alias} `)) {
+      return { scope: targetScope, rest: query.slice(alias.length + 1) };
+    }
+  }
+  return null;
+}
+
 function RootView() {
   const { t } = useTranslation();
-  const { commands, prefilter, close, pushApp } = useCommandStore();
+  const { commands, prefixes, prefilter, close, pushApp } = useCommandStore();
   const [query, setQuery] = useState(prefilter);
   const [scope, setScope] = useState<SearchScope>('all');
   const [fullContent, setFullContent] = useState(false);
@@ -436,36 +464,47 @@ function RootView() {
   const runIdRef = useRef(0);
 
   const [debouncedQuery] = useDebounceValue(query, 120);
+
+  const builtinPrefix = useMemo(() => parseBuiltinPrefix(debouncedQuery), [debouncedQuery]);
+  const effectiveScope = builtinPrefix?.scope ?? scope;
+  const effectiveQuery = builtinPrefix?.rest ?? debouncedQuery;
+
   const tokens = useMemo(
     () =>
-      debouncedQuery.trim() ? normalize(debouncedQuery.trim()).split(/\s+/).filter(Boolean) : [],
-    [debouncedQuery]
+      effectiveQuery.trim() ? normalize(effectiveQuery.trim()).split(/\s+/).filter(Boolean) : [],
+    [effectiveQuery]
   );
 
   useEffect(() => {
     const runId = ++runIdRef.current;
     setSelectedIdx(0);
     runSearch({
-      query: debouncedQuery,
-      scope,
+      query: effectiveQuery,
+      scope: effectiveScope,
       fullContent,
       commands,
-      limitPerGroup: debouncedQuery.trim() ? 500 : 10,
+      prefixes,
+      limitPerGroup: effectiveQuery.trim() ? 500 : 10,
     }).then((res) => {
       if (runIdRef.current === runId) setResults(res);
     });
-  }, [debouncedQuery, scope, fullContent, commands]);
+  }, [effectiveQuery, effectiveScope, fullContent, commands, prefixes]);
 
   const groups = useMemo(() => {
+    if (results.activePrefix) {
+      return results.commands.length
+        ? [{ key: 'commands' as SearchScope, heading: results.activePrefix.title, results: results.commands }]
+        : [];
+    }
     const g: Array<{ key: SearchScope; heading: string; results: SearchResult[] }> = [];
-    if ((scope === 'all' || scope === 'lyrics') && results.lyrics.length)
+    if ((effectiveScope === 'all' || effectiveScope === 'lyrics') && results.lyrics.length)
       g.push({ key: 'lyrics', heading: t('Lyrics / Songs'), results: results.lyrics });
-    if ((scope === 'all' || scope === 'commands') && results.commands.length)
+    if ((effectiveScope === 'all' || effectiveScope === 'commands') && results.commands.length)
       g.push({ key: 'commands', heading: t('Commands & Shortcuts'), results: results.commands });
-    if ((scope === 'all' || scope === 'media') && results.media.length)
+    if ((effectiveScope === 'all' || effectiveScope === 'media') && results.media.length)
       g.push({ key: 'media', heading: t('Media Assets'), results: results.media });
     return g;
-  }, [results, scope, t]);
+  }, [results, effectiveScope, t]);
 
   const flatRows = useMemo<VirtualRow[]>(() => {
     const rows: VirtualRow[] = [];
@@ -559,9 +598,12 @@ function RootView() {
         inputValue={query}
         setInputValue={setQuery}
         inputId={inputId}
+        placeholder={results.activePrefix?.placeholder}
       />
 
-      <FilterTabs scope={scope} setScope={setScope} results={results} />
+      {!results.activePrefix && (
+        <FilterTabs scope={effectiveScope} setScope={setScope} results={results} />
+      )}
 
       <ScrollArea
         ref={scrollRef}

--- a/src/components/quick-shortcuts-modal.tsx
+++ b/src/components/quick-shortcuts-modal.tsx
@@ -4,6 +4,7 @@ import {
   ArrowLeft,
   ArrowUpDown,
   CornerDownLeft,
+  Headphones,
   Image as ImageIcon,
   LayoutGrid,
   Music,
@@ -54,7 +55,7 @@ const SOURCE_THEME: Record<SearchSource, SourceTheme> = {
     badge: 'bg-sky-500/15 text-sky-300 border-sky-500/30',
   },
   audio: {
-    icon: Music,
+    icon: Headphones,
     iconBox: 'bg-primary/10 text-primary border-primary/25',
     badge: 'bg-primary/15 text-primary border-primary/30',
   },
@@ -493,7 +494,13 @@ function RootView() {
   const groups = useMemo(() => {
     if (results.activePrefix) {
       return results.commands.length
-        ? [{ key: 'commands' as SearchScope, heading: results.activePrefix.title, results: results.commands }]
+        ? [
+            {
+              key: 'commands' as SearchScope,
+              heading: results.activePrefix.title,
+              results: results.commands,
+            },
+          ]
         : [];
     }
     const g: Array<{ key: SearchScope; heading: string; results: SearchResult[] }> = [];

--- a/src/components/quick-shortcuts-modal.tsx
+++ b/src/components/quick-shortcuts-modal.tsx
@@ -35,6 +35,7 @@ import {
   type SearchSource,
 } from '@/services/search-service';
 import { type ActiveApp, useCommandStore } from '@/stores/command-store';
+import { Button } from './ui/button';
 import { Dialog, DialogContent } from './ui/dialog';
 import { Kbd } from './ui/kbd';
 import { ScrollArea } from './ui/scroll-area';
@@ -322,8 +323,9 @@ function PaletteHeader({
       </label>
 
       {!app && (
-        <button
+        <Button
           type="button"
+          variant="ghost"
           onClick={() => setFullContent(!fullContent)}
           className={cn(
             'flex h-10 shrink-0 items-center gap-1.5 rounded-lg border px-3 text-xs font-medium transition-colors',
@@ -335,7 +337,7 @@ function PaletteHeader({
         >
           <Search className="size-3.5" />
           <span>{t('Global Search')}</span>
-        </button>
+        </Button>
       )}
     </div>
   );

--- a/src/components/quick-shortcuts-modal.tsx
+++ b/src/components/quick-shortcuts-modal.tsx
@@ -1,51 +1,178 @@
-import { useEffect } from "react";
-import { useCommandStore } from "@/stores/command-store";
+import { ArrowLeft, ChevronRight, Terminal } from 'lucide-react';
+import { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { CommandSpec } from '@/modules/types';
+import { type ActiveApp, useCommandStore } from '@/stores/command-store';
 import {
-	Command,
-	CommandEmpty,
-	CommandGroup,
-	CommandInput,
-	CommandItem,
-	CommandList,
-} from "./ui/command";
-import { Dialog, DialogContent } from "./ui/dialog";
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+  CommandShortcut,
+} from './ui/command';
+import { Dialog, DialogContent } from './ui/dialog';
+import { Kbd } from './ui/kbd';
+
+function CommandIcon({ spec }: { spec: CommandSpec }) {
+  if (spec.icon) {
+    const Icon = spec.icon;
+    return <Icon className="size-4 shrink-0 text-muted-foreground" />;
+  }
+  return <Terminal className="size-4 shrink-0 text-muted-foreground" />;
+}
+
+function RootView() {
+  const { t } = useTranslation();
+  const { commands, prefilter, close, pushApp } = useCommandStore();
+
+  const actions = commands.filter((c) => c.type !== 'app');
+  const apps = commands.filter((c) => c.type === 'app');
+
+  function handleSelect(spec: CommandSpec) {
+    if (spec.type === 'app' && spec.component) {
+      pushApp({ commandId: spec.id, title: spec.title, component: spec.component } satisfies ActiveApp);
+    } else {
+      spec.run?.();
+      close();
+    }
+  }
+
+  return (
+    <Command className="rounded-none">
+      <CommandInput placeholder={t('Type a command or search...')} defaultValue={prefilter} autoFocus />
+      <CommandList className="max-h-[320px]">
+        <CommandEmpty>{t('No results found.')}</CommandEmpty>
+
+        {actions.length > 0 && (
+          <CommandGroup heading={t('Commands')}>
+            {actions.map((spec) => (
+              <CommandItem
+                key={spec.id}
+                value={`${spec.title} ${spec.keywords?.join(' ') ?? ''}`}
+                onSelect={() => handleSelect(spec)}
+                className="gap-3 py-2"
+              >
+                <CommandIcon spec={spec} />
+                <div className="flex min-w-0 flex-col">
+                  <span className="truncate text-sm">{spec.title}</span>
+                  {spec.subtitle && (
+                    <span className="truncate text-xs text-muted-foreground">{spec.subtitle}</span>
+                  )}
+                </div>
+                {spec.keybinding && <CommandShortcut>{spec.keybinding}</CommandShortcut>}
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
+
+        {actions.length > 0 && apps.length > 0 && <CommandSeparator />}
+
+        {apps.length > 0 && (
+          <CommandGroup heading={t('Apps')}>
+            {apps.map((spec) => (
+              <CommandItem
+                key={spec.id}
+                value={`${spec.title} ${spec.keywords?.join(' ') ?? ''}`}
+                onSelect={() => handleSelect(spec)}
+                className="gap-3 py-2"
+              >
+                <CommandIcon spec={spec} />
+                <div className="flex min-w-0 flex-1 flex-col">
+                  <span className="truncate text-sm">{spec.title}</span>
+                  {spec.subtitle && (
+                    <span className="truncate text-xs text-muted-foreground">{spec.subtitle}</span>
+                  )}
+                </div>
+                <ChevronRight className="size-3.5 shrink-0 text-muted-foreground" />
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
+      </CommandList>
+
+      <Footer />
+    </Command>
+  );
+}
+
+function AppView({ app }: { app: ActiveApp }) {
+  const { close, popApp } = useCommandStore();
+  const AppComponent = app.component;
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex h-10 shrink-0 items-center gap-2 border-b px-3">
+        <button
+          type="button"
+          onClick={popApp}
+          className="flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <ArrowLeft className="size-3.5" />
+          <span>{app.title}</span>
+        </button>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-auto">
+        <AppComponent onClose={close} onBack={popApp} />
+      </div>
+
+      <Footer showBack />
+    </div>
+  );
+}
+
+function Footer({ showBack }: { showBack?: boolean }) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex shrink-0 items-center justify-between border-t bg-muted/30 px-3 py-1.5 text-xs text-muted-foreground">
+      <div className="flex items-center gap-3">
+        <span className="flex items-center gap-1">
+          <Kbd className="h-auto text-[10px]">↑↓</Kbd>
+          {t('Navigate')}
+        </span>
+        <span className="flex items-center gap-1">
+          <Kbd className="h-auto text-[10px]">↵</Kbd>
+          {t('Select')}
+        </span>
+        {showBack && (
+          <span className="flex items-center gap-1">
+            <Kbd className="h-auto text-[10px]">Esc</Kbd>
+            {t('Back')}
+          </span>
+        )}
+      </div>
+      <span className="flex items-center gap-1">
+        <Kbd className="h-auto text-[10px]">Esc</Kbd>
+        {showBack ? t('Close') : t('Close')}
+      </span>
+    </div>
+  );
+}
 
 export function QuickShortcutsModal() {
-	const { isOpen, toggle, close } = useCommandStore();
+  const { isOpen, toggle, close, activeApp } = useCommandStore();
 
-	useEffect(() => {
-		const handleKeyDown = (event: KeyboardEvent) => {
-			if (event.ctrlKey && event.key === "k") {
-				event.preventDefault();
-				toggle();
-			}
-		};
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if ((event.ctrlKey || event.metaKey) && event.key === 'k') {
+        event.preventDefault();
+        toggle();
+      }
+    };
 
-		document.addEventListener("keydown", handleKeyDown);
-		return () => document.removeEventListener("keydown", handleKeyDown);
-	}, [toggle]);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [toggle]);
 
-	return (
-		<Dialog open={isOpen} onOpenChange={(open) => !open && close()}>
-			<DialogContent className="p-0 overflow-hidden">
-				<Command>
-					<CommandInput placeholder="Type a command or search..." />
-					<CommandList>
-						<CommandEmpty>No results found.</CommandEmpty>
-						<CommandGroup heading="Suggestions">
-							<CommandItem>
-								<span>Search for files</span>
-							</CommandItem>
-							<CommandItem>
-								<span>Create new task</span>
-							</CommandItem>
-							<CommandItem>
-								<span>Go to settings</span>
-							</CommandItem>
-						</CommandGroup>
-					</CommandList>
-				</Command>
-			</DialogContent>
-		</Dialog>
-	);
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && close()}>
+      <DialogContent className="overflow-hidden p-0 sm:max-w-[560px]">
+        {activeApp ? <AppView app={activeApp} /> : <RootView />}
+      </DialogContent>
+    </Dialog>
+  );
 }

--- a/src/components/quick-shortcuts-modal.tsx
+++ b/src/components/quick-shortcuts-modal.tsx
@@ -1,154 +1,634 @@
-import { ArrowLeft, ChevronRight, Terminal } from 'lucide-react';
-import { useEffect } from 'react';
-import { useTranslation } from 'react-i18next';
-import type { CommandSpec } from '@/modules/types';
-import { type ActiveApp, useCommandStore } from '@/stores/command-store';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-  CommandSeparator,
-  CommandShortcut,
-} from './ui/command';
+  ArrowLeft,
+  Image as ImageIcon,
+  LayoutGrid,
+  Music,
+  Search,
+  ShieldQuestion,
+  Sparkles,
+  Terminal,
+  Video,
+} from 'lucide-react';
+import {
+  type ComponentType,
+  Fragment,
+  type KeyboardEvent,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { useTranslation } from 'react-i18next';
+import { cn } from '@/lib/utils';
+import {
+  normalize,
+  search as runSearch,
+  type SearchResult,
+  type SearchResults,
+  type SearchScope,
+  type SearchSource,
+} from '@/services/search-service';
+import { type ActiveApp, useCommandStore } from '@/stores/command-store';
 import { Dialog, DialogContent } from './ui/dialog';
 import { Kbd } from './ui/kbd';
+import { ScrollArea } from './ui/scroll-area';
 
-function CommandIcon({ spec }: { spec: CommandSpec }) {
-  if (spec.icon) {
-    const Icon = spec.icon;
-    return <Icon className="size-4 shrink-0 text-muted-foreground" />;
-  }
-  return <Terminal className="size-4 shrink-0 text-muted-foreground" />;
+interface SourceTheme {
+  icon: ComponentType<{ className?: string }>;
+  iconBox: string;
+  badge: string;
 }
+
+const SOURCE_THEME: Record<SearchSource, SourceTheme> = {
+  lyric: {
+    icon: Music,
+    iconBox: 'bg-sky-500/10 text-sky-300 border-sky-500/25',
+    badge: 'bg-sky-500/15 text-sky-300 border-sky-500/30',
+  },
+  audio: {
+    icon: Music,
+    iconBox: 'bg-purple-500/10 text-purple-300 border-purple-500/25',
+    badge: 'bg-purple-500/15 text-purple-300 border-purple-500/30',
+  },
+  video: {
+    icon: Video,
+    iconBox: 'bg-purple-500/10 text-purple-300 border-purple-500/25',
+    badge: 'bg-purple-500/15 text-purple-300 border-purple-500/30',
+  },
+  image: {
+    icon: ImageIcon,
+    iconBox: 'bg-purple-500/10 text-purple-300 border-purple-500/25',
+    badge: 'bg-purple-500/15 text-purple-300 border-purple-500/30',
+  },
+  command: {
+    icon: Terminal,
+    iconBox: 'bg-primary/10 text-primary border-primary/25',
+    badge: 'bg-primary/15 text-primary border-primary/30',
+  },
+  app: {
+    icon: Sparkles,
+    iconBox: 'bg-primary/10 text-primary border-primary/25',
+    badge: 'bg-primary/15 text-primary border-primary/30',
+  },
+};
+
+const SCOPES: SearchScope[] = ['all', 'lyrics', 'media', 'commands'];
+
+const SCOPE_ICON: Record<SearchScope, ComponentType<{ className?: string }>> = {
+  all: LayoutGrid,
+  lyrics: Music,
+  media: Video,
+  commands: Terminal,
+};
+
+function scopeLabel(scope: SearchScope, t: (k: string) => string): string {
+  switch (scope) {
+    case 'all':
+      return t('All');
+    case 'lyrics':
+      return t('Lyrics');
+    case 'media':
+      return t('Media');
+    case 'commands':
+      return t('Commands');
+  }
+}
+
+function countForScope(scope: SearchScope, results: SearchResults): number {
+  switch (scope) {
+    case 'all':
+      return results.total;
+    case 'lyrics':
+      return results.lyrics.length;
+    case 'media':
+      return results.media.length;
+    case 'commands':
+      return results.commands.length;
+  }
+}
+
+function Highlight({ text, tokens }: { text: string; tokens: string[] }) {
+  if (tokens.length === 0 || !text) return <>{text}</>;
+  const lower = normalize(text);
+  const matches: Array<[number, number]> = [];
+
+  for (const token of tokens) {
+    if (!token) continue;
+    let idx = 0;
+    while (idx < lower.length) {
+      const found = lower.indexOf(token, idx);
+      if (found === -1) break;
+      matches.push([found, found + token.length]);
+      idx = found + token.length;
+    }
+  }
+
+  if (matches.length === 0) return <>{text}</>;
+
+  matches.sort((a, b) => a[0] - b[0]);
+  const merged: Array<[number, number]> = [];
+  for (const [s, e] of matches) {
+    const last = merged[merged.length - 1];
+    if (last && s <= last[1]) {
+      last[1] = Math.max(last[1], e);
+    } else {
+      merged.push([s, e]);
+    }
+  }
+
+  const out: React.ReactNode[] = [];
+  let cursor = 0;
+  for (const [s, e] of merged) {
+    if (cursor < s) out.push(<Fragment key={`p-${cursor}`}>{text.slice(cursor, s)}</Fragment>);
+    out.push(
+      <span key={`m-${s}`} className="text-primary font-semibold">
+        {text.slice(s, e)}
+      </span>
+    );
+    cursor = e;
+  }
+  if (cursor < text.length)
+    out.push(<Fragment key={`p-${cursor}-end`}>{text.slice(cursor)}</Fragment>);
+  return <>{out}</>;
+}
+
+function useDebounced<T>(value: T, delay = 120): T {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const id = window.setTimeout(() => setDebounced(value), delay);
+    return () => window.clearTimeout(id);
+  }, [value, delay]);
+  return debounced;
+}
+
+function ResultRow({
+  result,
+  tokens,
+  selected,
+  onSelect,
+}: {
+  result: SearchResult;
+  tokens: string[];
+  selected: boolean;
+  onSelect: (r: SearchResult) => void;
+}) {
+  const { t } = useTranslation();
+  const theme = SOURCE_THEME[result.source];
+  const Icon = theme.icon;
+
+  return (
+    <button
+      type="button"
+      role="option"
+      aria-selected={selected}
+      onClick={() => onSelect(result)}
+      className={cn(
+        'group/row flex w-full items-center gap-3 rounded-lg border px-2.5 py-2.5 text-left transition-colors',
+        selected
+          ? 'border-primary/40 bg-primary/5'
+          : 'border-transparent hover:border-primary/20 hover:bg-primary/5'
+      )}
+    >
+      <div
+        className={cn(
+          'flex size-10 shrink-0 items-center justify-center rounded-md border',
+          theme.iconBox
+        )}
+      >
+        <Icon className="size-4" />
+      </div>
+
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="truncate text-sm font-medium text-foreground">
+            <Highlight text={result.title} tokens={tokens} />
+          </span>
+          <span
+            className={cn(
+              'shrink-0 rounded-sm border px-1.5 py-px text-[10px] font-semibold tracking-wider uppercase',
+              theme.badge
+            )}
+          >
+            {result.badge}
+          </span>
+        </div>
+        {result.subtitle && (
+          <span className="truncate text-xs text-muted-foreground">
+            <Highlight text={result.subtitle} tokens={tokens} />
+          </span>
+        )}
+      </div>
+
+      <Kbd className={cn('ml-2 shrink-0 opacity-60', selected && 'opacity-100')}>
+        {result.shortcut ?? t('Enter')}
+      </Kbd>
+    </button>
+  );
+}
+
+function FilterTabs({
+  scope,
+  setScope,
+  results,
+}: {
+  scope: SearchScope;
+  setScope: (s: SearchScope) => void;
+  results: SearchResults;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <div
+      data-no-window-drag="true"
+      className="flex shrink-0 items-center gap-1 border-b border-border/40 px-3 pb-2"
+    >
+      {SCOPES.map((s) => {
+        const Icon = SCOPE_ICON[s];
+        const active = s === scope;
+        const count = countForScope(s, results);
+        return (
+          <button
+            key={s}
+            type="button"
+            onClick={() => setScope(s)}
+            className={cn(
+              'flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs transition-colors',
+              active
+                ? 'border-primary/50 bg-primary/10 text-primary'
+                : 'border-transparent text-muted-foreground hover:bg-muted/40 hover:text-foreground'
+            )}
+          >
+            <Icon className="size-3.5" />
+            <span>{scopeLabel(s, t)}</span>
+            <span
+              className={cn('text-[11px]', active ? 'text-primary/70' : 'text-muted-foreground/70')}
+            >
+              ({count})
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function PaletteHeader({
+  app,
+  fullContent,
+  setFullContent,
+  inputValue,
+  setInputValue,
+  inputId,
+}: {
+  app?: ActiveApp;
+  fullContent: boolean;
+  setFullContent: (v: boolean) => void;
+  inputValue: string;
+  setInputValue: (v: string) => void;
+  inputId: string;
+}) {
+  const { t } = useTranslation();
+  const { popApp } = useCommandStore();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  return (
+    <div className="flex shrink-0 items-center gap-2 p-3">
+      {app && (
+        <button
+          type="button"
+          onClick={popApp}
+          aria-label={t('Back')}
+          className="flex size-10 shrink-0 items-center justify-center rounded-lg border border-border/60 bg-muted/30 text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
+        >
+          <ArrowLeft className="size-4" />
+        </button>
+      )}
+
+      <label
+        htmlFor={inputId}
+        className="flex h-10 flex-1 items-center gap-2 rounded-lg border border-border/60 bg-muted/30 px-3 focus-within:border-primary/40"
+      >
+        <Search className="size-4 shrink-0 text-muted-foreground" />
+        <input
+          ref={inputRef}
+          id={inputId}
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          placeholder={app ? app.title : t('Type a command or search...')}
+          className="h-full w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+        />
+      </label>
+
+      {!app && (
+        <button
+          type="button"
+          onClick={() => setFullContent(!fullContent)}
+          className={cn(
+            'flex h-10 shrink-0 items-center gap-1.5 rounded-lg border px-3 text-xs font-medium transition-colors',
+            fullContent
+              ? 'border-primary/50 bg-primary/10 text-primary'
+              : 'border-border/60 bg-muted/30 text-muted-foreground hover:text-foreground'
+          )}
+          title={fullContent ? t('Searching titles + content') : t('Searching titles only')}
+        >
+          <Search className="size-3.5" />
+          <span>{t('Global Search')}</span>
+        </button>
+      )}
+    </div>
+  );
+}
+
+function CommanderFooter({
+  results,
+  query,
+  fullContent,
+  showBack,
+}: {
+  results?: SearchResults;
+  query?: string;
+  fullContent?: boolean;
+  showBack?: boolean;
+}) {
+  const { t } = useTranslation();
+  const hasQuery = !!query?.trim();
+
+  return (
+    <div className="flex shrink-0 items-center justify-between border-t border-border/40 bg-muted/20 px-3 py-2 text-[10px] font-medium tracking-wider text-muted-foreground/80 uppercase">
+      <div className="flex items-center gap-2">
+        {results && !showBack && (
+          <>
+            <span
+              className={cn(
+                'inline-block size-1.5 rounded-full',
+                fullContent
+                  ? 'bg-primary shadow-[0_0_8px_var(--color-primary)]'
+                  : 'bg-muted-foreground/40'
+              )}
+            />
+            <span>{fullContent ? t('Global Search') : t('Title Search')}</span>
+            <span className="text-muted-foreground/40">•</span>
+            <span className="normal-case tracking-normal">
+              {hasQuery
+                ? t('{{count}} results matching query', { count: results.total })
+                : t('{{count}} items', { count: results.total })}
+            </span>
+          </>
+        )}
+      </div>
+      <div className="flex items-center gap-3">
+        <span className="flex items-center gap-1.5">
+          <Kbd>↑↓</Kbd>
+          {t('Navigate')}
+        </span>
+        <span className="flex items-center gap-1.5">
+          <Kbd>↵</Kbd>
+          {showBack ? t('Select') : t('Open')}
+        </span>
+        {!showBack && (
+          <span className="flex items-center gap-1.5">
+            <Kbd>Tab</Kbd>
+            {t('Filter')}
+          </span>
+        )}
+        <span className="flex items-center gap-1.5">
+          <Kbd>Esc</Kbd>
+          {showBack ? t('Back') : t('Close')}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+type VirtualRow = { kind: 'heading'; label: string } | { kind: 'item'; result: SearchResult };
 
 function RootView() {
   const { t } = useTranslation();
   const { commands, prefilter, close, pushApp } = useCommandStore();
+  const [query, setQuery] = useState(prefilter);
+  const [scope, setScope] = useState<SearchScope>('all');
+  const [fullContent, setFullContent] = useState(false);
+  const [results, setResults] = useState<SearchResults>({
+    lyrics: [],
+    media: [],
+    commands: [],
+    total: 0,
+  });
+  const [selectedIdx, setSelectedIdx] = useState(0);
+  const inputId = useId();
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const runIdRef = useRef(0);
 
-  const actions = commands.filter((c) => c.type !== 'app');
-  const apps = commands.filter((c) => c.type === 'app');
+  const debouncedQuery = useDebounced(query, 120);
+  const tokens = useMemo(
+    () =>
+      debouncedQuery.trim() ? normalize(debouncedQuery.trim()).split(/\s+/).filter(Boolean) : [],
+    [debouncedQuery]
+  );
 
-  function handleSelect(spec: CommandSpec) {
-    if (spec.type === 'app' && spec.component) {
-      pushApp({ commandId: spec.id, title: spec.title, component: spec.component } satisfies ActiveApp);
-    } else {
-      spec.run?.();
+  useEffect(() => {
+    const runId = ++runIdRef.current;
+    setSelectedIdx(0);
+    runSearch({
+      query: debouncedQuery,
+      scope,
+      fullContent,
+      commands,
+      limitPerGroup: debouncedQuery.trim() ? 500 : 10,
+    }).then((res) => {
+      if (runIdRef.current === runId) setResults(res);
+    });
+  }, [debouncedQuery, scope, fullContent, commands]);
+
+  const groups = useMemo(() => {
+    const g: Array<{ key: SearchScope; heading: string; results: SearchResult[] }> = [];
+    if ((scope === 'all' || scope === 'lyrics') && results.lyrics.length)
+      g.push({ key: 'lyrics', heading: t('Lyrics / Songs'), results: results.lyrics });
+    if ((scope === 'all' || scope === 'commands') && results.commands.length)
+      g.push({ key: 'commands', heading: t('Commands & Shortcuts'), results: results.commands });
+    if ((scope === 'all' || scope === 'media') && results.media.length)
+      g.push({ key: 'media', heading: t('Media Assets'), results: results.media });
+    return g;
+  }, [results, scope, t]);
+
+  const flatRows = useMemo<VirtualRow[]>(() => {
+    const rows: VirtualRow[] = [];
+    for (const g of groups) {
+      rows.push({ kind: 'heading', label: g.heading });
+      for (const r of g.results) rows.push({ kind: 'item', result: r });
+    }
+    return rows;
+  }, [groups]);
+
+  const itemIndices = useMemo(
+    () =>
+      flatRows.reduce<number[]>((acc, row, i) => {
+        if (row.kind === 'item') acc.push(i);
+        return acc;
+      }, []),
+    [flatRows]
+  );
+
+  const virtualizer = useVirtualizer({
+    count: flatRows.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: (i) => (flatRows[i]?.kind === 'heading' ? 36 : 60),
+    overscan: 8,
+  });
+
+  function handleSelect(r: SearchResult) {
+    if (r.source === 'app' && r.commandSpec?.component) {
+      pushApp({
+        commandId: r.commandSpec.id,
+        title: r.commandSpec.title,
+        component: r.commandSpec.component,
+      } satisfies ActiveApp);
+      return;
+    }
+    if (r.source === 'command' && r.commandSpec?.run) {
+      r.commandSpec.run();
+      close();
+      return;
+    }
+    if (r.path) {
+      window.dispatchEvent(
+        new CustomEvent('lumen:commander-open', {
+          detail: { source: r.source, id: r.id, path: r.path },
+        })
+      );
       close();
     }
   }
 
+  function handleKeyDown(event: KeyboardEvent<HTMLDivElement>) {
+    if (event.key === 'Tab') {
+      event.preventDefault();
+      const idx = SCOPES.indexOf(scope);
+      setScope(SCOPES[(idx + (event.shiftKey ? -1 + SCOPES.length : 1)) % SCOPES.length]);
+      return;
+    }
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      const next = Math.min(selectedIdx + 1, itemIndices.length - 1);
+      setSelectedIdx(next);
+      if (itemIndices[next] !== undefined)
+        virtualizer.scrollToIndex(itemIndices[next], { align: 'auto' });
+      return;
+    }
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      const prev = Math.max(selectedIdx - 1, 0);
+      setSelectedIdx(prev);
+      if (itemIndices[prev] !== undefined)
+        virtualizer.scrollToIndex(itemIndices[prev], { align: 'auto' });
+      return;
+    }
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      const row = flatRows[itemIndices[selectedIdx] ?? -1];
+      if (row?.kind === 'item') handleSelect(row.result);
+    }
+  }
+
   return (
-    <Command className="rounded-none">
-      <CommandInput placeholder={t('Type a command or search...')} defaultValue={prefilter} autoFocus />
-      <CommandList className="max-h-[320px]">
-        <CommandEmpty>{t('No results found.')}</CommandEmpty>
+    <div
+      role="listbox"
+      tabIndex={-1}
+      onKeyDown={handleKeyDown}
+      className="flex flex-col rounded-none bg-transparent outline-none"
+    >
+      <PaletteHeader
+        fullContent={fullContent}
+        setFullContent={setFullContent}
+        inputValue={query}
+        setInputValue={setQuery}
+        inputId={inputId}
+      />
 
-        {actions.length > 0 && (
-          <CommandGroup heading={t('Commands')}>
-            {actions.map((spec) => (
-              <CommandItem
-                key={spec.id}
-                value={`${spec.title} ${spec.keywords?.join(' ') ?? ''}`}
-                onSelect={() => handleSelect(spec)}
-                className="gap-3 py-2"
-              >
-                <CommandIcon spec={spec} />
-                <div className="flex min-w-0 flex-col">
-                  <span className="truncate text-sm">{spec.title}</span>
-                  {spec.subtitle && (
-                    <span className="truncate text-xs text-muted-foreground">{spec.subtitle}</span>
+      <FilterTabs scope={scope} setScope={setScope} results={results} />
+
+      <ScrollArea
+        ref={scrollRef}
+        className="max-h-[420px]"
+        viewportClassName="!h-auto max-h-[420px] px-2 pb-2 focus-visible:ring-0 focus-visible:outline-none"
+      >
+        {flatRows.length === 0 ? (
+          <div className="py-10 text-center text-sm text-muted-foreground">
+            <div className="flex flex-col items-center gap-2">
+              <ShieldQuestion className="size-6 text-muted-foreground/60" />
+              <span>{t('No results found.')}</span>
+            </div>
+          </div>
+        ) : (
+          <div style={{ height: virtualizer.getTotalSize(), position: 'relative' }}>
+            {virtualizer.getVirtualItems().map((vItem) => {
+              const row = flatRows[vItem.index];
+              if (!row) return null;
+              return (
+                <div
+                  key={vItem.key}
+                  data-index={vItem.index}
+                  ref={virtualizer.measureElement}
+                  className={row.kind === 'item' ? 'pb-1' : undefined}
+                  style={{
+                    position: 'absolute',
+                    top: 0,
+                    left: 0,
+                    width: '100%',
+                    transform: `translateY(${vItem.start}px)`,
+                  }}
+                >
+                  {row.kind === 'heading' && (
+                    <div className="px-2 pb-1 pt-3 text-[10px] font-semibold tracking-wider text-muted-foreground/70 uppercase">
+                      {row.label}
+                    </div>
+                  )}
+                  {row.kind === 'item' && (
+                    <ResultRow
+                      result={row.result}
+                      tokens={tokens}
+                      selected={itemIndices[selectedIdx] === vItem.index}
+                      onSelect={handleSelect}
+                    />
                   )}
                 </div>
-                {spec.keybinding && <CommandShortcut>{spec.keybinding}</CommandShortcut>}
-              </CommandItem>
-            ))}
-          </CommandGroup>
+              );
+            })}
+          </div>
         )}
+      </ScrollArea>
 
-        {actions.length > 0 && apps.length > 0 && <CommandSeparator />}
-
-        {apps.length > 0 && (
-          <CommandGroup heading={t('Apps')}>
-            {apps.map((spec) => (
-              <CommandItem
-                key={spec.id}
-                value={`${spec.title} ${spec.keywords?.join(' ') ?? ''}`}
-                onSelect={() => handleSelect(spec)}
-                className="gap-3 py-2"
-              >
-                <CommandIcon spec={spec} />
-                <div className="flex min-w-0 flex-1 flex-col">
-                  <span className="truncate text-sm">{spec.title}</span>
-                  {spec.subtitle && (
-                    <span className="truncate text-xs text-muted-foreground">{spec.subtitle}</span>
-                  )}
-                </div>
-                <ChevronRight className="size-3.5 shrink-0 text-muted-foreground" />
-              </CommandItem>
-            ))}
-          </CommandGroup>
-        )}
-      </CommandList>
-
-      <Footer />
-    </Command>
+      <CommanderFooter results={results} query={debouncedQuery} fullContent={fullContent} />
+    </div>
   );
 }
 
 function AppView({ app }: { app: ActiveApp }) {
   const { close, popApp } = useCommandStore();
   const AppComponent = app.component;
+  const inputId = useId();
+  const [value, setValue] = useState('');
 
   return (
-    <div className="flex h-full flex-col">
-      <div className="flex h-10 shrink-0 items-center gap-2 border-b px-3">
-        <button
-          type="button"
-          onClick={popApp}
-          className="flex items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
-        >
-          <ArrowLeft className="size-3.5" />
-          <span>{app.title}</span>
-        </button>
-      </div>
-
-      <div className="min-h-0 flex-1 overflow-auto">
+    <div className="flex flex-col rounded-none bg-transparent">
+      <PaletteHeader
+        app={app}
+        fullContent={false}
+        setFullContent={() => {}}
+        inputValue={value}
+        setInputValue={setValue}
+        inputId={inputId}
+      />
+      <div className="min-h-[320px] flex-1 overflow-auto px-3 pb-3">
         <AppComponent onClose={close} onBack={popApp} />
       </div>
-
-      <Footer showBack />
-    </div>
-  );
-}
-
-function Footer({ showBack }: { showBack?: boolean }) {
-  const { t } = useTranslation();
-
-  return (
-    <div className="flex shrink-0 items-center justify-between border-t bg-muted/30 px-3 py-1.5 text-xs text-muted-foreground">
-      <div className="flex items-center gap-3">
-        <span className="flex items-center gap-1">
-          <Kbd className="h-auto text-[10px]">↑↓</Kbd>
-          {t('Navigate')}
-        </span>
-        <span className="flex items-center gap-1">
-          <Kbd className="h-auto text-[10px]">↵</Kbd>
-          {t('Select')}
-        </span>
-        {showBack && (
-          <span className="flex items-center gap-1">
-            <Kbd className="h-auto text-[10px]">Esc</Kbd>
-            {t('Back')}
-          </span>
-        )}
-      </div>
-      <span className="flex items-center gap-1">
-        <Kbd className="h-auto text-[10px]">Esc</Kbd>
-        {showBack ? t('Close') : t('Close')}
-      </span>
+      <CommanderFooter showBack />
     </div>
   );
 }
@@ -157,8 +637,8 @@ export function QuickShortcutsModal() {
   const { isOpen, toggle, close, activeApp } = useCommandStore();
 
   useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if ((event.ctrlKey || event.metaKey) && event.key === 'k') {
+    const handleKeyDown = (event: globalThis.KeyboardEvent) => {
+      if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'k') {
         event.preventDefault();
         toggle();
       }
@@ -170,7 +650,7 @@ export function QuickShortcutsModal() {
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && close()}>
-      <DialogContent className="overflow-hidden p-0 sm:max-w-[560px]">
+      <DialogContent showCloseButton={false} className="overflow-hidden p-0 sm:max-w-[760px]">
         {activeApp ? <AppView app={activeApp} /> : <RootView />}
       </DialogContent>
     </Dialog>

--- a/src/components/quick-shortcuts-modal.tsx
+++ b/src/components/quick-shortcuts-modal.tsx
@@ -21,6 +21,7 @@ import {
   useState,
 } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useDebounceValue, useEventListener } from 'usehooks-ts';
 import { cn } from '@/lib/utils';
 import {
   normalize,
@@ -152,15 +153,6 @@ function Highlight({ text, tokens }: { text: string; tokens: string[] }) {
   if (cursor < text.length)
     out.push(<Fragment key={`p-${cursor}-end`}>{text.slice(cursor)}</Fragment>);
   return <>{out}</>;
-}
-
-function useDebounced<T>(value: T, delay = 120): T {
-  const [debounced, setDebounced] = useState(value);
-  useEffect(() => {
-    const id = window.setTimeout(() => setDebounced(value), delay);
-    return () => window.clearTimeout(id);
-  }, [value, delay]);
-  return debounced;
 }
 
 function ResultRow({
@@ -431,7 +423,7 @@ function RootView() {
   const scrollRef = useRef<HTMLDivElement>(null);
   const runIdRef = useRef(0);
 
-  const debouncedQuery = useDebounced(query, 120);
+  const [debouncedQuery] = useDebounceValue(query, 120);
   const tokens = useMemo(
     () =>
       debouncedQuery.trim() ? normalize(debouncedQuery.trim()).split(/\s+/).filter(Boolean) : [],
@@ -642,17 +634,12 @@ function AppView({ app }: { app: ActiveApp }) {
 export function QuickShortcutsModal() {
   const { isOpen, toggle, close, activeApp } = useCommandStore();
 
-  useEffect(() => {
-    const handleKeyDown = (event: globalThis.KeyboardEvent) => {
-      if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'k') {
-        event.preventDefault();
-        toggle();
-      }
-    };
-
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [toggle]);
+  useEventListener('keydown', (event) => {
+    if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'k') {
+      event.preventDefault();
+      toggle();
+    }
+  });
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && close()}>

--- a/src/components/quick-shortcuts-modal.tsx
+++ b/src/components/quick-shortcuts-modal.tsx
@@ -1,6 +1,9 @@
 import { useVirtualizer } from '@tanstack/react-virtual';
 import {
+  ArrowBigUp,
   ArrowLeft,
+  ArrowUpDown,
+  CornerDownLeft,
   Image as ImageIcon,
   LayoutGrid,
   Music,
@@ -35,6 +38,7 @@ import { type ActiveApp, useCommandStore } from '@/stores/command-store';
 import { Dialog, DialogContent } from './ui/dialog';
 import { Kbd } from './ui/kbd';
 import { ScrollArea } from './ui/scroll-area';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './ui/tooltip';
 
 interface SourceTheme {
   icon: ComponentType<{ className?: string }>;
@@ -351,55 +355,61 @@ function CommanderFooter({
   const { t } = useTranslation();
   const hasQuery = !!query?.trim();
 
+  const hint = (kbd: React.ReactNode, tooltip: string) => (
+    <Tooltip>
+      <TooltipTrigger>
+        <span className="flex cursor-default items-center gap-0.5">
+          <Kbd className="flex items-center gap-0.5">{kbd}</Kbd>
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top">{tooltip}</TooltipContent>
+    </Tooltip>
+  );
+
   return (
-    <div className="flex shrink-0 items-center justify-between border-t border-border/40 bg-muted/20 px-3 py-2 text-[10px] font-medium tracking-wider text-muted-foreground/80 uppercase">
+    <div className="flex shrink-0 items-center justify-between border-t border-border/40 px-3 py-1.5 text-[10px] text-muted-foreground/60">
       <div className="flex items-center gap-2">
         {results && !showBack && (
           <>
             <span
               className={cn(
-                'inline-block size-1.5 rounded-full',
+                'inline-block size-1.5 shrink-0 rounded-full',
                 fullContent
-                  ? 'bg-primary shadow-[0_0_8px_var(--color-primary)]'
-                  : 'bg-muted-foreground/40'
+                  ? 'bg-primary shadow-[0_0_6px_var(--color-primary)]'
+                  : 'bg-muted-foreground/30'
               )}
             />
-            <span>{fullContent ? t('Global Search') : t('Title Search')}</span>
-            <span className="text-muted-foreground/40">•</span>
-            <span className="normal-case tracking-normal">
+            <span className="font-medium">
+              {fullContent ? t('Global Search') : t('Title Search')}
+            </span>
+            <span className="text-muted-foreground/30">·</span>
+            <span>
               {hasQuery
-                ? t('{{count}} results matching query', { count: results.total })
+                ? t('{{count}} results', { count: results.total })
                 : t('{{count}} items', { count: results.total })}
             </span>
           </>
         )}
       </div>
-      <div className="flex items-center gap-3">
-        <span className="flex items-center gap-1.5">
-          <Kbd>↑↓</Kbd>
-          {t('Navigate')}
-        </span>
-        <span className="flex items-center gap-1.5">
-          <Kbd>↵</Kbd>
-          {showBack ? t('Select') : t('Play')}
-        </span>
-        {!showBack && (
-          <span className="flex items-center gap-1.5">
-            <Kbd>⇧↵</Kbd>
-            {t('Queue')}
-          </span>
-        )}
-        {!showBack && (
-          <span className="flex items-center gap-1.5">
-            <Kbd>Tab</Kbd>
-            {t('Filter')}
-          </span>
-        )}
-        <span className="flex items-center gap-1.5">
-          <Kbd>Esc</Kbd>
-          {showBack ? t('Back') : t('Close')}
-        </span>
-      </div>
+      <TooltipProvider delay={400}>
+        <div className="flex items-center gap-2.5">
+          {hint(<ArrowUpDown />, t('Arrow Up/Down'))}
+          {hint(<CornerDownLeft />, showBack ? t('Enter') : t('Enter'))}
+          {!showBack &&
+            hint(
+              <>
+                <ArrowBigUp />
+                <CornerDownLeft />
+              </>,
+              t('Shift + Enter')
+            )}
+          {!showBack && hint(<span className="text-[10px]">Tab</span>, t('Tab'))}
+          {hint(
+            showBack ? <ArrowLeft /> : <span className="text-[10px]">Esc</span>,
+            showBack ? t('Back') : t('Esc')
+          )}
+        </div>
+      </TooltipProvider>
     </div>
   );
 }

--- a/src/components/settings-dialog.tsx
+++ b/src/components/settings-dialog.tsx
@@ -5,6 +5,7 @@ import {
   ChevronDown,
   Info,
   Monitor,
+  Package,
   Palette,
   RotateCcw,
   Settings,
@@ -23,6 +24,7 @@ import { AboutSection } from './settings/about-section';
 import { AdvancedSection } from './settings/advanced-section';
 import { DevicePermissionsSection } from './settings/device-permissions-section';
 import { GeneralAccessSection } from './settings/general-access-section';
+import { ModulesSection } from './settings/modules-section';
 import { ThemeSection } from './settings/theme-section';
 import { Button } from './ui/button';
 import { Card, CardContent, CardHeader } from './ui/card';
@@ -40,6 +42,11 @@ const SECTION_TITLES: Record<SettingsSection, { label: string; title: string; de
     title: 'About',
     description:
       'Review app version details, system information, and quick access to release notes and legal resources.',
+  },
+  modules: {
+    label: 'Application settings',
+    title: 'Modules',
+    description: 'Manage installed modules. Enable, disable, reload or uninstall.',
   },
 };
 
@@ -169,6 +176,18 @@ export const SettingsDialog = () => {
 
             <Button
               variant="ghost"
+              onClick={() => handleNavClick('modules')}
+              className={cn(
+                'w-full justify-start gap-2.5',
+                activeSection === 'modules' && 'bg-primary/10 text-primary font-medium'
+              )}
+            >
+              <Package className="size-4" />
+              {t('Modules')}
+            </Button>
+
+            <Button
+              variant="ghost"
               onClick={() => handleNavClick('about')}
               className={cn(
                 'w-full justify-start gap-2.5',
@@ -234,6 +253,7 @@ export const SettingsDialog = () => {
                 {activeSection === 'remote_general' && <GeneralAccessSection />}
                 {activeSection === 'remote_permissions' && <DevicePermissionsSection />}
                 {activeSection === 'advanced' && <AdvancedSection />}
+                {activeSection === 'modules' && <ModulesSection />}
                 {activeSection === 'about' && <AboutSection />}
               </div>
             </ScrollArea>

--- a/src/components/settings/modules-section.tsx
+++ b/src/components/settings/modules-section.tsx
@@ -1,0 +1,123 @@
+import { AlertTriangle, CheckCircle, Package, RefreshCw, Trash2, XCircle } from 'lucide-react';
+import { disableModule, reloadModule, uninstallModule } from '@/modules/injector';
+import { useModuleStore } from '@/modules/store';
+import type { ModuleRecord, ModuleStatus } from '@/modules/types';
+import { Badge } from '../ui/badge';
+import { Button } from '../ui/button';
+import { Separator } from '../ui/separator';
+
+function StatusBadge({ status }: { status: ModuleStatus }) {
+  if (status === 'active') {
+    return (
+      <Badge variant="outline" className="gap-1 text-emerald-400 border-emerald-400/30">
+        <CheckCircle className="size-3" /> Active
+      </Badge>
+    );
+  }
+  if (status === 'faulted') {
+    return (
+      <Badge variant="outline" className="gap-1 text-destructive border-destructive/30">
+        <AlertTriangle className="size-3" /> Faulted
+      </Badge>
+    );
+  }
+  if (status === 'loading') {
+    return (
+      <Badge variant="outline" className="gap-1 text-muted-foreground">
+        <RefreshCw className="size-3 animate-spin" /> Loading
+      </Badge>
+    );
+  }
+  return (
+    <Badge variant="outline" className="gap-1 text-muted-foreground">
+      <XCircle className="size-3" /> Disabled
+    </Badge>
+  );
+}
+
+function ModuleRow({ record }: { record: ModuleRecord }) {
+  const { manifest, status, error, source } = record;
+
+  return (
+    <div className="flex flex-col gap-1.5 py-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="font-medium text-sm">{manifest.name}</span>
+            <span className="text-xs text-muted-foreground">v{manifest.version}</span>
+            <StatusBadge status={status} />
+            {source === 'dev' && (
+              <Badge variant="secondary" className="text-xs">dev</Badge>
+            )}
+          </div>
+          <p className="text-xs text-muted-foreground mt-0.5 truncate">{manifest.id}</p>
+          {manifest.description && (
+            <p className="text-xs text-muted-foreground mt-1">{manifest.description}</p>
+          )}
+          {status === 'faulted' && error && (
+            <p className="text-xs text-destructive mt-1 font-mono">{error}</p>
+          )}
+        </div>
+
+        <div className="flex items-center gap-1 shrink-0">
+          {(status === 'faulted' || status === 'disabled') && (
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              title="Reload"
+              onClick={() => reloadModule(manifest.id)}
+            >
+              <RefreshCw className="size-3.5" />
+            </Button>
+          )}
+          {status === 'active' && (
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              title="Disable"
+              onClick={() => disableModule(manifest.id)}
+            >
+              <XCircle className="size-3.5" />
+            </Button>
+          )}
+          {source !== 'bundled' && (
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              title="Uninstall"
+              className="text-destructive hover:text-destructive"
+              onClick={() => uninstallModule(manifest.id)}
+            >
+              <Trash2 className="size-3.5" />
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ModulesSection() {
+  const modules = useModuleStore((s) => s.modules);
+  const list = Array.from(modules.values());
+
+  return (
+    <div className="space-y-4">
+      {list.length === 0 ? (
+        <div className="flex flex-col items-center gap-2 py-8 text-center text-muted-foreground">
+          <Package className="size-8 opacity-40" />
+          <p className="text-sm">No modules installed</p>
+        </div>
+      ) : (
+        <div className="divide-y divide-border">
+          {list.map((record, i) => (
+            <div key={record.manifest.id}>
+              <ModuleRow record={record} />
+              {i < list.length - 1 && <Separator />}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/titlebar/index.tsx
+++ b/src/components/titlebar/index.tsx
@@ -25,16 +25,27 @@ import { useWindowState } from './use-window-state';
 import { TitlebarWindowControls } from './window-controls';
 
 function MenuItems({ items, t }: { items: MenuItemDef[]; t: (key: string) => string }) {
-  return items.map((item) =>
-    item.type === 'separator' ? (
-      <MenubarSeparator key={crypto.randomUUID()} />
-    ) : (
+  return items.map((item, i) => {
+    if (item.type === 'separator') {
+      return <MenubarSeparator key={i} />;
+    }
+    if (item.type === 'submenu') {
+      return (
+        <MenubarSub key={item.label}>
+          <MenubarSubTrigger>{t(item.label)}</MenubarSubTrigger>
+          <MenubarSubContent>
+            <MenuItems items={item.items} t={t} />
+          </MenubarSubContent>
+        </MenubarSub>
+      );
+    }
+    return (
       <MenubarItem key={item.label} onClick={item.onClick}>
         {t(item.label)}
         {item.shortcut && <MenubarShortcut>{item.shortcut}</MenubarShortcut>}
       </MenubarItem>
-    )
-  );
+    );
+  });
 }
 
 export function TitleBar() {

--- a/src/components/titlebar/index.tsx
+++ b/src/components/titlebar/index.tsx
@@ -27,7 +27,7 @@ import { TitlebarWindowControls } from './window-controls';
 function MenuItems({ items, t }: { items: MenuItemDef[]; t: (key: string) => string }) {
   return items.map((item, i) => {
     if (item.type === 'separator') {
-      return <MenubarSeparator key={i} />;
+      return <MenubarSeparator key={item.id ?? `sep-${i}`} />;
     }
     if (item.type === 'submenu') {
       return (
@@ -219,7 +219,7 @@ export function TitleBar() {
           <button
             data-no-window-drag="true"
             type="button"
-            onClick={openCommand}
+            onClick={() => openCommand()}
             className="flex w-full max-w-md items-center gap-2 rounded-lg border border-border/70 bg-muted/45 px-3 py-1 text-xs transition-colors hover:bg-primary/10"
           >
             <Search className="size-3.5 shrink-0 text-muted-foreground" />

--- a/src/components/titlebar/menu-registry.ts
+++ b/src/components/titlebar/menu-registry.ts
@@ -11,7 +11,14 @@ export type MenuItemAction = {
   onClick?: () => void
 }
 
-export type MenuItemDef = MenuItemSeparator | MenuItemAction
+export type MenuItemSubmenu = {
+  type: 'submenu'
+  id?: string
+  label: string
+  items: MenuItemDef[]
+}
+
+export type MenuItemDef = MenuItemSeparator | MenuItemAction | MenuItemSubmenu
 
 export type MenuDef = {
   id: string

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -4,6 +4,7 @@ import { Button as ButtonPrimitive } from '@base-ui/react/button';
 import { cva, type VariantProps } from 'class-variance-authority';
 
 import { cn } from '@/lib/utils';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './tooltip';
 
 const buttonVariants = cva(
   "group/button inline-flex items-center justify-center gap-2 transition-colors whitespace-nowrap rounded-md text-sm font-medium transition-[color,box-shadow] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
@@ -44,15 +45,29 @@ function Button({
   className,
   variant = 'default',
   size = 'default',
+  title,
   ...props
 }: ButtonPrimitive.Props & VariantProps<typeof buttonVariants>) {
-  return (
+  const button = (
     <ButtonPrimitive
       data-slot="button"
       className={cn(buttonVariants({ variant, size, className }))}
       {...props}
     />
   );
+
+  if (title) {
+    return (
+      <TooltipProvider delay={600}>
+        <Tooltip>
+          <TooltipTrigger render={button} />
+          <TooltipContent>{title}</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  }
+
+  return button;
 }
 
 export { Button, buttonVariants };

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -1,177 +1,154 @@
-"use client";
+'use client';
 
-import { Command as CommandPrimitive } from "cmdk";
-import { SearchIcon } from "lucide-react";
-import type * as React from "react";
+import { Command as CommandPrimitive } from 'cmdk';
+import { SearchIcon } from 'lucide-react';
+import type * as React from 'react';
 import {
-	Dialog,
-	DialogContent,
-	DialogDescription,
-	DialogHeader,
-	DialogTitle,
-} from "@/components/ui/dialog";
-import { cn } from "@/lib/utils";
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { cn } from '@/lib/utils';
 
-function Command({
-	className,
-	...props
-}: React.ComponentProps<typeof CommandPrimitive>) {
-	return (
-		<CommandPrimitive
-			data-slot="command"
-			className={cn(
-				"bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md",
-				className,
-			)}
-			{...props}
-		/>
-	);
+function Command({ className, ...props }: React.ComponentProps<typeof CommandPrimitive>) {
+  return (
+    <CommandPrimitive
+      data-slot="command"
+      className={cn(
+        'text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-md',
+        className
+      )}
+      {...props}
+    />
+  );
 }
 
 function CommandDialog({
-	title = "Command Palette",
-	description = "Search for a command to run...",
-	children,
-	...props
-}: Omit<React.ComponentProps<typeof Dialog>, "children"> & {
-	title?: string;
-	description?: string;
-	children?: React.ReactNode;
+  title = 'Command Palette',
+  description = 'Search for a command to run...',
+  children,
+  ...props
+}: Omit<React.ComponentProps<typeof Dialog>, 'children'> & {
+  title?: string;
+  description?: string;
+  children?: React.ReactNode;
 }) {
-	return (
-		<Dialog {...props}>
-			<DialogHeader className="sr-only">
-				<DialogTitle>{title}</DialogTitle>
-				<DialogDescription>{description}</DialogDescription>
-			</DialogHeader>
-			<DialogContent className="overflow-hidden p-0">
-				<Command className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
-					{children}
-				</Command>
-			</DialogContent>
-		</Dialog>
-	);
+  return (
+    <Dialog {...props}>
+      <DialogHeader className="sr-only">
+        <DialogTitle>{title}</DialogTitle>
+        <DialogDescription>{description}</DialogDescription>
+      </DialogHeader>
+      <DialogContent className="overflow-hidden p-0">
+        <Command className="[&_[cmdk-group-heading]]:text-muted-foreground **:data-[slot=command-input-wrapper]:h-12 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+          {children}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  );
 }
 
 function CommandInput({
-	className,
-	...props
+  className,
+  ...props
 }: React.ComponentProps<typeof CommandPrimitive.Input>) {
-	return (
-		<div
-			data-slot="command-input-wrapper"
-			className="flex h-9 items-center gap-2 border-b px-3"
-		>
-			<SearchIcon className="size-4 shrink-0 opacity-50" />
-			<CommandPrimitive.Input
-				data-slot="command-input"
-				className={cn(
-					"placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
-					className,
-				)}
-				{...props}
-			/>
-		</div>
-	);
+  return (
+    <div data-slot="command-input-wrapper" className="flex h-9 items-center gap-2 border-b px-3">
+      <SearchIcon className="size-4 shrink-0 opacity-50" />
+      <CommandPrimitive.Input
+        data-slot="command-input"
+        className={cn(
+          'placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50',
+          className
+        )}
+        {...props}
+      />
+    </div>
+  );
 }
 
-function CommandList({
-	className,
-	...props
-}: React.ComponentProps<typeof CommandPrimitive.List>) {
-	return (
-		<CommandPrimitive.List
-			data-slot="command-list"
-			className={cn(
-				"max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto",
-				className,
-			)}
-			{...props}
-		/>
-	);
+function CommandList({ className, ...props }: React.ComponentProps<typeof CommandPrimitive.List>) {
+  return (
+    <CommandPrimitive.List
+      data-slot="command-list"
+      className={cn('scroll-py-1', className)}
+      {...props}
+    />
+  );
 }
 
-function CommandEmpty({
-	...props
-}: React.ComponentProps<typeof CommandPrimitive.Empty>) {
-	return (
-		<CommandPrimitive.Empty
-			data-slot="command-empty"
-			className="py-6 text-center text-sm"
-			{...props}
-		/>
-	);
+function CommandEmpty({ ...props }: React.ComponentProps<typeof CommandPrimitive.Empty>) {
+  return (
+    <CommandPrimitive.Empty
+      data-slot="command-empty"
+      className="py-6 text-center text-sm"
+      {...props}
+    />
+  );
 }
 
 function CommandGroup({
-	className,
-	...props
+  className,
+  ...props
 }: React.ComponentProps<typeof CommandPrimitive.Group>) {
-	return (
-		<CommandPrimitive.Group
-			data-slot="command-group"
-			className={cn(
-				"text-foreground [&_[cmdk-group-heading]]:text-muted-foreground overflow-hidden p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium",
-				className,
-			)}
-			{...props}
-		/>
-	);
+  return (
+    <CommandPrimitive.Group
+      data-slot="command-group"
+      className={cn(
+        'text-foreground [&_[cmdk-group-heading]]:text-muted-foreground overflow-hidden p-1 [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium',
+        className
+      )}
+      {...props}
+    />
+  );
 }
 
 function CommandSeparator({
-	className,
-	...props
+  className,
+  ...props
 }: React.ComponentProps<typeof CommandPrimitive.Separator>) {
-	return (
-		<CommandPrimitive.Separator
-			data-slot="command-separator"
-			className={cn("bg-border -mx-1 h-px", className)}
-			{...props}
-		/>
-	);
+  return (
+    <CommandPrimitive.Separator
+      data-slot="command-separator"
+      className={cn('bg-border -mx-1 h-px', className)}
+      {...props}
+    />
+  );
 }
 
-function CommandItem({
-	className,
-	...props
-}: React.ComponentProps<typeof CommandPrimitive.Item>) {
-	return (
-		<CommandPrimitive.Item
-			data-slot="command-item"
-			className={cn(
-				"data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
-				className,
-			)}
-			{...props}
-		/>
-	);
+function CommandItem({ className, ...props }: React.ComponentProps<typeof CommandPrimitive.Item>) {
+  return (
+    <CommandPrimitive.Item
+      data-slot="command-item"
+      className={cn(
+        "data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  );
 }
 
-function CommandShortcut({
-	className,
-	...props
-}: React.ComponentProps<"span">) {
-	return (
-		<span
-			data-slot="command-shortcut"
-			className={cn(
-				"text-muted-foreground ml-auto text-xs tracking-widest",
-				className,
-			)}
-			{...props}
-		/>
-	);
+function CommandShortcut({ className, ...props }: React.ComponentProps<'span'>) {
+  return (
+    <span
+      data-slot="command-shortcut"
+      className={cn('text-muted-foreground ml-auto text-xs tracking-widest', className)}
+      {...props}
+    />
+  );
 }
 
 export {
-	Command,
-	CommandDialog,
-	CommandInput,
-	CommandList,
-	CommandEmpty,
-	CommandGroup,
-	CommandItem,
-	CommandShortcut,
-	CommandSeparator,
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandShortcut,
+  CommandSeparator,
 };

--- a/src/hooks/use-modules.ts
+++ b/src/hooks/use-modules.ts
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import { bootModules, setOpenCommandPalette } from '@/modules/injector';
+import { useCommandStore } from '@/stores/command-store';
+
+export function useModules() {
+  const openCommandPalette = useCommandStore((s) => s.open);
+
+  useEffect(() => {
+    setOpenCommandPalette(openCommandPalette);
+    bootModules().catch((err) => {
+      console.error('[modules] boot failed:', err);
+    });
+  }, [openCommandPalette]);
+}

--- a/src/modules/apis/bus.ts
+++ b/src/modules/apis/bus.ts
@@ -1,0 +1,65 @@
+import type { BusAPI, Disposable } from '../types';
+
+type Handler = (payload: unknown) => void;
+
+const subscribers = new Map<string, Set<Handler>>();
+
+function emit<T = unknown>(topic: string, payload?: T): void {
+  const handlers = subscribers.get(topic);
+  if (!handlers) return;
+  for (const handler of handlers) {
+    try {
+      handler(payload as unknown);
+    } catch (err) {
+      console.error(`[bus] handler error on topic "${topic}":`, err);
+    }
+  }
+}
+
+function on<T = unknown>(topic: string, handler: (payload: T) => void): Disposable {
+  if (!subscribers.has(topic)) {
+    subscribers.set(topic, new Set());
+  }
+  subscribers.get(topic)!.add(handler as Handler);
+  return {
+    dispose() {
+      subscribers.get(topic)?.delete(handler as Handler);
+    },
+  };
+}
+
+export const globalBus: BusAPI = { emit, on };
+
+export function createBusAPI(): BusAPI {
+  return globalBus;
+}
+
+export function createEventsAPI(): BusAPI {
+  const localSubscribers = new Map<string, Set<Handler>>();
+
+  return {
+    emit<T = unknown>(topic: string, payload?: T): void {
+      const handlers = localSubscribers.get(topic);
+      if (!handlers) return;
+      for (const handler of handlers) {
+        try {
+          handler(payload as unknown);
+        } catch (err) {
+          console.error(`[events] handler error on topic "${topic}":`, err);
+        }
+      }
+    },
+
+    on<T = unknown>(topic: string, handler: (payload: T) => void): Disposable {
+      if (!localSubscribers.has(topic)) {
+        localSubscribers.set(topic, new Set());
+      }
+      localSubscribers.get(topic)!.add(handler as Handler);
+      return {
+        dispose() {
+          localSubscribers.get(topic)?.delete(handler as Handler);
+        },
+      };
+    },
+  };
+}

--- a/src/modules/apis/commands.ts
+++ b/src/modules/apis/commands.ts
@@ -1,0 +1,29 @@
+import type { CommandSpec, CommandsAPI, Disposable } from '../types';
+
+const registry = new Map<string, CommandSpec>();
+
+export function createCommandsAPI(): CommandsAPI {
+  return {
+    add(spec: CommandSpec): Disposable {
+      registry.set(spec.id, spec);
+      return {
+        dispose() {
+          registry.delete(spec.id);
+        },
+      };
+    },
+
+    invoke(id: string, args?: unknown): unknown {
+      const spec = registry.get(id);
+      if (!spec) {
+        console.warn(`[modules] command not found: ${id}`);
+        return undefined;
+      }
+      return spec.run(args);
+    },
+  };
+}
+
+export function getCommandRegistry(): ReadonlyMap<string, CommandSpec> {
+  return registry;
+}

--- a/src/modules/apis/commands.ts
+++ b/src/modules/apis/commands.ts
@@ -1,5 +1,5 @@
 import { useCommandStore } from '@/stores/command-store';
-import type { CommandSpec, CommandsAPI, Disposable } from '../types';
+import type { CommandSpec, CommandsAPI, Disposable, PrefixSpec } from '../types';
 
 export function createCommandsAPI(): CommandsAPI {
   return {
@@ -19,6 +19,15 @@ export function createCommandsAPI(): CommandsAPI {
         return undefined;
       }
       return spec.run?.(args);
+    },
+
+    addPrefix(spec: PrefixSpec): Disposable {
+      useCommandStore.getState()._registerPrefix(spec);
+      return {
+        dispose() {
+          useCommandStore.getState()._unregisterPrefix(spec.prefix);
+        },
+      };
     },
   };
 }

--- a/src/modules/apis/commands.ts
+++ b/src/modules/apis/commands.ts
@@ -1,29 +1,28 @@
+import { useCommandStore } from '@/stores/command-store';
 import type { CommandSpec, CommandsAPI, Disposable } from '../types';
-
-const registry = new Map<string, CommandSpec>();
 
 export function createCommandsAPI(): CommandsAPI {
   return {
     add(spec: CommandSpec): Disposable {
-      registry.set(spec.id, spec);
+      useCommandStore.getState()._register(spec);
       return {
         dispose() {
-          registry.delete(spec.id);
+          useCommandStore.getState()._unregister(spec.id);
         },
       };
     },
 
     invoke(id: string, args?: unknown): unknown {
-      const spec = registry.get(id);
+      const spec = useCommandStore.getState().commands.find((c) => c.id === id);
       if (!spec) {
         console.warn(`[modules] command not found: ${id}`);
         return undefined;
       }
-      return spec.run(args);
+      return spec.run?.(args);
     },
   };
 }
 
-export function getCommandRegistry(): ReadonlyMap<string, CommandSpec> {
-  return registry;
+export function getCommandRegistry(): readonly CommandSpec[] {
+  return useCommandStore.getState().commands;
 }

--- a/src/modules/apis/data.ts
+++ b/src/modules/apis/data.ts
@@ -1,0 +1,60 @@
+import { invoke } from '@tauri-apps/api/core';
+import type { DataAPI, DataJsonAPI, Migration, SqliteHandle } from '../types';
+
+function createJsonAPI(moduleId: string): DataJsonAPI {
+  return {
+    async load() {
+      return invoke<unknown>('module_data_json_load', { moduleId });
+    },
+
+    async save(value) {
+      await invoke('module_data_json_save', { moduleId, value });
+    },
+
+    async get<T = unknown>(key: string, fallback?: T): Promise<T> {
+      const data = await invoke<Record<string, unknown>>('module_data_json_load', { moduleId });
+      const val = data?.[key];
+      return (val !== undefined ? val : fallback) as T;
+    },
+
+    async set<T>(key: string, value: T) {
+      await invoke('module_data_json_set', { moduleId, key, value });
+    },
+
+    async delete(key: string) {
+      await invoke('module_data_json_delete', { moduleId, key });
+    },
+  };
+}
+
+function createSqliteHandle(moduleId: string): SqliteHandle {
+  return {
+    async exec(sql, params = []) {
+      await invoke('module_data_sqlite_exec', { moduleId, sql, params });
+    },
+
+    async query<T = unknown>(sql: string, params: unknown[] = []): Promise<T[]> {
+      return invoke<T[]>('module_data_sqlite_query', { moduleId, sql, params });
+    },
+
+    async migrate(versions: Migration[]) {
+      await invoke('module_data_sqlite_migrate', { moduleId, versions });
+    },
+  };
+}
+
+export function createDataAPI(moduleId: string): DataAPI {
+  let sqliteHandle: SqliteHandle | undefined;
+
+  return {
+    json: createJsonAPI(moduleId),
+
+    async sqlite(): Promise<SqliteHandle> {
+      if (!sqliteHandle) {
+        await invoke('module_data_sqlite_open', { moduleId });
+        sqliteHandle = createSqliteHandle(moduleId);
+      }
+      return sqliteHandle;
+    },
+  };
+}

--- a/src/modules/apis/domain.ts
+++ b/src/modules/apis/domain.ts
@@ -1,6 +1,11 @@
+import { lyricService } from '@/services/lyric-service';
+import { mediaDbService } from '@/services/media-db-service';
 import type {
   LibraryHostAPI,
   LyricsHostAPI,
+  MediaItem,
+  MediaRef,
+  MediaType as PublicMediaType,
   PlayerHostAPI,
   PresentationHostAPI,
   QueueHostAPI,
@@ -8,13 +13,38 @@ import type {
 } from '../types';
 import { globalBus } from './bus';
 
+function stripExt(name: string): string {
+  return name.replace(/\.[^/.]+$/, '');
+}
+
 export function createLyricsHostAPI(): LyricsHostAPI {
   return {
-    async list(_query) {
-      return [];
+    async list(query) {
+      const term = query?.search?.trim();
+      const hits = term
+        ? await mediaDbService.search(term, { mediaType: 'lyrics', fullContent: true, limit: 100 })
+        : await mediaDbService.listByType('lyrics', 200);
+      return hits.map((h) => ({
+        id: String(h.id),
+        title: stripExt(h.name),
+        artist: h.artist ?? undefined,
+      }));
     },
-    async get(_id) {
-      return null;
+    async get(id) {
+      const numId = Number(id);
+      if (!Number.isFinite(numId)) return null;
+      const hit = await mediaDbService.getById(numId);
+      if (!hit || hit.media_type !== 'lyrics') return null;
+      const data = await lyricService.load(hit.path);
+      return {
+        id,
+        title: data.metadata.name || stripExt(hit.name),
+        artist: data.metadata.author || hit.artist || undefined,
+        slides: data.slides.map((slide, index) => ({
+          index,
+          text: slide.lines.join('\n'),
+        })),
+      };
     },
     currentSlide() {
       return null;
@@ -56,11 +86,34 @@ export function createQueueHostAPI(): QueueHostAPI {
 
 export function createLibraryHostAPI(): LibraryHostAPI {
   return {
-    async list(_type, _query) {
-      return [];
+    async list(type, query) {
+      const term = query?.trim();
+      const hits = term
+        ? await mediaDbService.search(term, { mediaType: type, fullContent: false, limit: 100 })
+        : type
+          ? await mediaDbService.listByType(type, 200)
+          : [];
+      return hits.map<MediaRef>((h) => ({
+        id: String(h.id),
+        path: h.path,
+        name: h.name,
+        type: h.media_type as PublicMediaType,
+      }));
     },
-    async get(_id) {
-      return null;
+    async get(id) {
+      const numId = Number(id);
+      if (!Number.isFinite(numId)) return null;
+      const hit = await mediaDbService.getById(numId);
+      if (!hit) return null;
+      return {
+        id,
+        path: hit.path,
+        name: hit.name,
+        type: hit.media_type as PublicMediaType,
+        duration: hit.duration ?? undefined,
+        size: 0,
+        modifiedAt: new Date(hit.modified_at).toISOString(),
+      } satisfies MediaItem;
     },
     async metadata(_path) {
       return {};

--- a/src/modules/apis/domain.ts
+++ b/src/modules/apis/domain.ts
@@ -1,0 +1,135 @@
+import type {
+  LibraryHostAPI,
+  LyricsHostAPI,
+  PlayerHostAPI,
+  PresentationHostAPI,
+  QueueHostAPI,
+  ThemesHostAPI,
+} from '../types';
+import { globalBus } from './bus';
+
+export function createLyricsHostAPI(): LyricsHostAPI {
+  return {
+    async list(_query) {
+      return [];
+    },
+    async get(_id) {
+      return null;
+    },
+    currentSlide() {
+      return null;
+    },
+    advance() {
+      globalBus.emit('lyrics:advance');
+    },
+    back() {
+      globalBus.emit('lyrics:back');
+    },
+  };
+}
+
+export function createQueueHostAPI(): QueueHostAPI {
+  return {
+    items() {
+      return [];
+    },
+    currentIndex() {
+      return -1;
+    },
+    add(item, position) {
+      globalBus.emit('queue:add', { item, position });
+    },
+    remove(id) {
+      globalBus.emit('queue:remove', { id });
+    },
+    reorder(fromIndex, toIndex) {
+      globalBus.emit('queue:reorder', { fromIndex, toIndex });
+    },
+    shuffle() {
+      globalBus.emit('queue:shuffle');
+    },
+    markPlayed(id) {
+      globalBus.emit('queue:markPlayed', { id });
+    },
+  };
+}
+
+export function createLibraryHostAPI(): LibraryHostAPI {
+  return {
+    async list(_type, _query) {
+      return [];
+    },
+    async get(_id) {
+      return null;
+    },
+    async metadata(_path) {
+      return {};
+    },
+    async thumbnail(_path, _size) {
+      return '';
+    },
+  };
+}
+
+export function createPlayerHostAPI(): PlayerHostAPI {
+  return {
+    current() {
+      return null;
+    },
+    state() {
+      return 'idle';
+    },
+    play(track) {
+      globalBus.emit('player:play', { track });
+    },
+    pause() {
+      globalBus.emit('player:pause');
+    },
+    seek(seconds) {
+      globalBus.emit('player:seek', { seconds });
+    },
+    volume(value) {
+      if (value !== undefined) {
+        globalBus.emit('player:volume', { value });
+      }
+      return 1;
+    },
+    next() {
+      globalBus.emit('player:next');
+    },
+    prev() {
+      globalBus.emit('player:prev');
+    },
+  };
+}
+
+export function createPresentationHostAPI(): PresentationHostAPI {
+  return {
+    state() {
+      return 'idle';
+    },
+    project(viewId, props) {
+      globalBus.emit('presentation:project', { viewId, props });
+    },
+    clear() {
+      globalBus.emit('presentation:clear');
+    },
+    isWindowOpen() {
+      return false;
+    },
+  };
+}
+
+export function createThemesHostAPI(): ThemesHostAPI {
+  return {
+    current() {
+      return { id: 'default', name: 'Default', colorMode: 'dark', accentId: 'cyan' };
+    },
+    list() {
+      return [{ id: 'default', name: 'Default', colorMode: 'dark', accentId: 'cyan' }];
+    },
+    apply(id) {
+      globalBus.emit('themes:apply', { id });
+    },
+  };
+}

--- a/src/modules/apis/fs.ts
+++ b/src/modules/apis/fs.ts
@@ -1,0 +1,22 @@
+import { invoke } from '@tauri-apps/api/core';
+import type { FsAPI } from '../types';
+
+export function createFsAPI(moduleId: string): FsAPI {
+  return {
+    async read(path) {
+      return invoke<Uint8Array>('module_fs_read', { moduleId, path });
+    },
+    async write(path, data) {
+      await invoke('module_fs_write', { moduleId, path, data: Array.from(data) });
+    },
+    async exists(path) {
+      return invoke<boolean>('module_fs_exists', { moduleId, path });
+    },
+    async list(path) {
+      return invoke<string[]>('module_fs_list', { moduleId, path });
+    },
+    async remove(path) {
+      await invoke('module_fs_remove', { moduleId, path });
+    },
+  };
+}

--- a/src/modules/apis/i18n.ts
+++ b/src/modules/apis/i18n.ts
@@ -1,0 +1,13 @@
+import type { I18nAPI } from '../types';
+
+export function createI18nAPI(): I18nAPI {
+  return {
+    t(key, params) {
+      if (!params) return key;
+      return key.replace(/\{\{(\w+)\}\}/g, (_, k) => params[k] ?? `{{${k}}}`);
+    },
+    locale() {
+      return navigator.language;
+    },
+  };
+}

--- a/src/modules/apis/logger.ts
+++ b/src/modules/apis/logger.ts
@@ -1,0 +1,11 @@
+import type { LoggerAPI } from '../types';
+
+export function createLoggerAPI(moduleId: string): LoggerAPI {
+  const prefix = `[${moduleId}]`;
+  return {
+    debug: (...args) => console.debug(prefix, ...args),
+    info: (...args) => console.info(prefix, ...args),
+    warn: (...args) => console.warn(prefix, ...args),
+    error: (...args) => console.error(prefix, ...args),
+  };
+}

--- a/src/modules/apis/menus.ts
+++ b/src/modules/apis/menus.ts
@@ -1,0 +1,27 @@
+import { useMenuRegistry } from '@/components/titlebar/menu-registry';
+import type { Disposable, MenuItemAction, MenusAPI, MenuSpec } from '../types';
+
+export function createMenusAPI(): MenusAPI {
+  return {
+    register(spec: MenuSpec): Disposable {
+      useMenuRegistry.getState().registerMenu(
+        { id: spec.id, label: spec.label, items: spec.items ?? [] },
+        spec.priority,
+      );
+      return {
+        dispose() {
+          useMenuRegistry.getState().unregisterMenu(spec.id);
+        },
+      };
+    },
+
+    addItem(menuId: string, item: MenuItemAction, priority?: number): Disposable {
+      useMenuRegistry.getState().registerMenuItem(menuId, item, priority);
+      return {
+        dispose() {
+          useMenuRegistry.getState().unregisterMenuItem(menuId, item.id);
+        },
+      };
+    },
+  };
+}

--- a/src/modules/apis/net.ts
+++ b/src/modules/apis/net.ts
@@ -1,0 +1,22 @@
+import type { NetAPI } from '../types';
+
+export function createNetAPI(): NetAPI {
+  return {
+    async get<T = unknown>(url: string, opts?: RequestInit): Promise<T> {
+      const res = await fetch(url, { ...opts, method: 'GET' });
+      if (!res.ok) throw new Error(`[net] GET ${url} failed: ${res.status}`);
+      return res.json() as Promise<T>;
+    },
+
+    async post<T = unknown>(url: string, body: unknown, opts?: RequestInit): Promise<T> {
+      const res = await fetch(url, {
+        ...opts,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...(opts?.headers ?? {}) },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) throw new Error(`[net] POST ${url} failed: ${res.status}`);
+      return res.json() as Promise<T>;
+    },
+  };
+}

--- a/src/modules/apis/panels.ts
+++ b/src/modules/apis/panels.ts
@@ -1,0 +1,15 @@
+import { useModuleStore } from '../store';
+import type { Disposable, PanelSpec, PanelsAPI } from '../types';
+
+export function createPanelsAPI(moduleId: string): PanelsAPI {
+  return {
+    add(spec: PanelSpec): Disposable {
+      useModuleStore.getState().addPanel(moduleId, spec);
+      return {
+        dispose() {
+          useModuleStore.getState().removePanel(moduleId, spec.id);
+        },
+      };
+    },
+  };
+}

--- a/src/modules/apis/settings.ts
+++ b/src/modules/apis/settings.ts
@@ -1,0 +1,49 @@
+import type { Disposable, SettingSpec, SettingsAPI } from '../types';
+
+export function createSettingsAPI(moduleId: string): SettingsAPI {
+  const values = new Map<string, unknown>();
+  const specs = new Map<string, SettingSpec>();
+  const listeners = new Map<string, Set<(v: unknown) => void>>();
+
+  return {
+    register<T>(spec: SettingSpec<T>): Disposable {
+      specs.set(spec.key, spec as SettingSpec<unknown>);
+      if (!values.has(spec.key)) {
+        values.set(spec.key, spec.default);
+      }
+      return {
+        dispose() {
+          specs.delete(spec.key);
+        },
+      };
+    },
+
+    get<T>(key: string): T | undefined {
+      return values.get(key) as T | undefined;
+    },
+
+    set<T>(key: string, value: T) {
+      values.set(key, value);
+      const handlers = listeners.get(key);
+      if (handlers) {
+        for (const handler of handlers) {
+          try {
+            handler(value);
+          } catch (err) {
+            console.error(`[settings:${moduleId}] onChange error for key "${key}":`, err);
+          }
+        }
+      }
+    },
+
+    onChange<T>(key: string, handler: (value: T) => void): Disposable {
+      if (!listeners.has(key)) listeners.set(key, new Set());
+      listeners.get(key)!.add(handler as (v: unknown) => void);
+      return {
+        dispose() {
+          listeners.get(key)?.delete(handler as (v: unknown) => void);
+        },
+      };
+    },
+  };
+}

--- a/src/modules/apis/ui.ts
+++ b/src/modules/apis/ui.ts
@@ -1,0 +1,36 @@
+import { toast } from 'sonner';
+import type { UIAPI } from '../types';
+
+export function createUIAPI(openCommandPaletteFn: (prefilter?: string) => void): UIAPI {
+  return {
+    notify({ title, message, level = 'info' }) {
+      if (level === 'error') {
+        toast.error(message, { description: title });
+      } else if (level === 'warn') {
+        toast.warning(message, { description: title });
+      } else {
+        toast.info(message, { description: title });
+      }
+    },
+
+    async confirm({ title, message, danger: _danger }) {
+      return new Promise<boolean>((resolve) => {
+        if (window.confirm(`${title}\n\n${message}`)) {
+          resolve(true);
+        } else {
+          resolve(false);
+        }
+      });
+    },
+
+    async prompt({ title, placeholder, initial }) {
+      const result = window.prompt(`${title}`, initial ?? '');
+      if (result === null) return null;
+      return result || (placeholder ? null : result);
+    },
+
+    openCommandPalette(prefilter?: string) {
+      openCommandPaletteFn(prefilter);
+    },
+  };
+}

--- a/src/modules/components/ModuleErrorBoundary.tsx
+++ b/src/modules/components/ModuleErrorBoundary.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+interface Props {
+  moduleId: string;
+  panelId: string;
+  children: React.ReactNode;
+}
+
+interface State {
+  error: Error | null;
+}
+
+export class ModuleErrorBoundary extends React.Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error) {
+    console.error(
+      `[module:${this.props.moduleId}] panel "${this.props.panelId}" render error:`,
+      error,
+    );
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div className="flex flex-col items-center justify-center gap-2 p-4 text-center text-sm">
+          <span className="text-destructive font-medium">Module panel faulted</span>
+          <span className="text-muted-foreground text-xs">{this.props.moduleId}</span>
+          <button
+            type="button"
+            className="text-xs underline"
+            onClick={() => this.setState({ error: null })}
+          >
+            Retry
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/modules/components/PanelSlot.tsx
+++ b/src/modules/components/PanelSlot.tsx
@@ -1,0 +1,31 @@
+import { useModuleStore } from '../store';
+import type { PanelProps, SlotName } from '../types';
+import { ModuleErrorBoundary } from './ModuleErrorBoundary';
+
+interface PanelSlotProps {
+  slot: SlotName;
+  panelProps?: PanelProps;
+}
+
+export function PanelSlot({ slot, panelProps = {} }: PanelSlotProps) {
+  const panels = useModuleStore((s) => s.getPanelsForSlot(slot));
+
+  if (panels.length === 0) return null;
+
+  return (
+    <>
+      {panels.map((spec) => {
+        if (spec.when && !spec.when()) return null;
+
+        const moduleId = spec.id.split('.').slice(0, -1).join('.');
+        const Component = spec.component;
+
+        return (
+          <ModuleErrorBoundary key={spec.id} moduleId={moduleId} panelId={spec.id}>
+            <Component {...panelProps} />
+          </ModuleErrorBoundary>
+        );
+      })}
+    </>
+  );
+}

--- a/src/modules/host.ts
+++ b/src/modules/host.ts
@@ -1,6 +1,7 @@
 import { getVersion } from '@tauri-apps/api/app';
 import { createBusAPI, createEventsAPI } from './apis/bus';
 import { createCommandsAPI } from './apis/commands';
+import { createMenusAPI } from './apis/menus';
 import { createDataAPI } from './apis/data';
 import {
   createLibraryHostAPI,
@@ -33,6 +34,7 @@ export async function createHost(
 
     panels: createPanelsAPI(id),
     commands: createCommandsAPI(),
+    menus: createMenusAPI(),
     ui: createUIAPI(openCommandPalette),
 
     bus: createBusAPI(),

--- a/src/modules/host.ts
+++ b/src/modules/host.ts
@@ -1,0 +1,56 @@
+import { getVersion } from '@tauri-apps/api/app';
+import { createBusAPI, createEventsAPI } from './apis/bus';
+import { createCommandsAPI } from './apis/commands';
+import { createDataAPI } from './apis/data';
+import {
+  createLibraryHostAPI,
+  createLyricsHostAPI,
+  createPlayerHostAPI,
+  createPresentationHostAPI,
+  createQueueHostAPI,
+  createThemesHostAPI,
+} from './apis/domain';
+import { createFsAPI } from './apis/fs';
+import { createI18nAPI } from './apis/i18n';
+import { createLoggerAPI } from './apis/logger';
+import { createNetAPI } from './apis/net';
+import { createPanelsAPI } from './apis/panels';
+import { createSettingsAPI } from './apis/settings';
+import { createUIAPI } from './apis/ui';
+import type { LumenHost, ModuleManifest } from './types';
+
+export async function createHost(
+  manifest: ModuleManifest,
+  openCommandPalette: (prefilter?: string) => void,
+): Promise<LumenHost> {
+  const appVersion = await getVersion().catch(() => '0.0.0');
+  const id = manifest.id;
+
+  return {
+    meta: { id, version: manifest.version },
+    window: 'main',
+    app: { version: appVersion, locale: navigator.language },
+
+    panels: createPanelsAPI(id),
+    commands: createCommandsAPI(),
+    ui: createUIAPI(openCommandPalette),
+
+    bus: createBusAPI(),
+    events: createEventsAPI(),
+
+    data: createDataAPI(id),
+    settings: createSettingsAPI(id),
+
+    lyrics: createLyricsHostAPI(),
+    queue: createQueueHostAPI(),
+    library: createLibraryHostAPI(),
+    player: createPlayerHostAPI(),
+    presentation: createPresentationHostAPI(),
+    themes: createThemesHostAPI(),
+
+    fs: createFsAPI(id),
+    net: createNetAPI(),
+    i18n: createI18nAPI(),
+    log: createLoggerAPI(id),
+  };
+}

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -1,0 +1,7 @@
+export * from './types';
+export * from './store';
+export * from './injector';
+export { PanelSlot } from './components/PanelSlot';
+export { ModuleErrorBoundary } from './components/ModuleErrorBoundary';
+export { getCommandRegistry } from './apis/commands';
+export { globalBus } from './apis/bus';

--- a/src/modules/injector.ts
+++ b/src/modules/injector.ts
@@ -236,10 +236,9 @@ function wrapHostForTracking(
     commands: {
       ...host.commands,
       add(spec: Parameters<typeof host.commands.add>[0]) {
-        const wrappedSpec = {
-          ...spec,
-          run: wrapCallback(id, spec.run),
-        };
+        const wrappedSpec = spec.run
+          ? { ...spec, run: wrapCallback(id, spec.run) }
+          : spec;
         return track(host.commands.add(wrappedSpec));
       },
     },

--- a/src/modules/injector.ts
+++ b/src/modules/injector.ts
@@ -1,0 +1,239 @@
+import { invoke } from '@tauri-apps/api/core';
+import { createHost } from './host';
+import { useModuleStore } from './store';
+import type { Disposable, LumenPlugin, ModuleManifest } from './types';
+
+const CRASH_THRESHOLD = 5;
+const CRASH_WINDOW_MS = 10_000;
+
+interface LoadedModule {
+  plugin: LumenPlugin;
+  disposables: Disposable[];
+  errorTimestamps: number[];
+}
+
+const loaded = new Map<string, LoadedModule>();
+
+let openCommandPaletteFn: (prefilter?: string) => void = () => {};
+
+export function setOpenCommandPalette(fn: (prefilter?: string) => void) {
+  openCommandPaletteFn = fn;
+}
+
+export async function bootModules() {
+  let manifests: Array<{ manifest: ModuleManifest; source: string }> = [];
+
+  try {
+    manifests = await invoke<Array<{ manifest: ModuleManifest; source: string }>>(
+      'module_list_installed',
+    );
+  } catch (err) {
+    console.error('[injector] failed to list modules:', err);
+    return;
+  }
+
+  for (const { manifest, source } of manifests) {
+    useModuleStore.getState().registerModule({
+      manifest,
+      status: 'loading',
+      errorCount: 0,
+      source: source as 'bundled' | 'store' | 'sideload' | 'dev',
+    });
+    await loadModule(manifest);
+  }
+}
+
+export async function loadModule(manifest: ModuleManifest) {
+  const store = useModuleStore.getState();
+
+  try {
+    const mod = await import(/* @vite-ignore */ `lumen-module://${manifest.id}/${manifest.entry}`);
+    const PluginClass = mod.default as new () => LumenPlugin;
+
+    const plugin = new PluginClass();
+    plugin.manifest = manifest;
+
+    const disposables: Disposable[] = [];
+    const host = await createHost(manifest, openCommandPaletteFn);
+
+    const trackedHost = wrapHostForTracking(host, disposables);
+
+    await plugin.onload(trackedHost);
+
+    loaded.set(manifest.id, { plugin, disposables, errorTimestamps: [] });
+    store.setStatus(manifest.id, 'active');
+  } catch (err) {
+    console.error(`[injector] failed to load module ${manifest.id}:`, err);
+    store.setStatus(
+      manifest.id,
+      'faulted',
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+}
+
+export async function unloadModule(id: string) {
+  const entry = loaded.get(id);
+  if (!entry) return;
+
+  try {
+    await entry.plugin.onunload();
+  } catch (err) {
+    console.error(`[injector] onunload error for ${id}:`, err);
+  }
+
+  for (const disposable of entry.disposables) {
+    try {
+      disposable.dispose();
+    } catch (err) {
+      console.error(`[injector] dispose error for ${id}:`, err);
+    }
+  }
+
+  loaded.delete(id);
+  useModuleStore.getState().removePanelsForModule(id);
+  useModuleStore.getState().setStatus(id, 'disabled');
+}
+
+export async function reloadModule(id: string) {
+  await unloadModule(id);
+  const record = useModuleStore.getState().modules.get(id);
+  if (record) {
+    useModuleStore.getState().setStatus(id, 'loading');
+    await loadModule(record.manifest);
+  }
+}
+
+export async function installModule(path: string, devMode = false) {
+  await invoke('module_install', { path, devMode });
+  const result = await invoke<{ manifest: ModuleManifest; source: string }>(
+    'module_get',
+    { id: path },
+  ).catch(() => null);
+  if (!result) return;
+
+  useModuleStore.getState().registerModule({
+    manifest: result.manifest,
+    status: 'loading',
+    errorCount: 0,
+    source: result.source as 'bundled' | 'store' | 'sideload' | 'dev',
+  });
+  await loadModule(result.manifest);
+}
+
+export async function disableModule(id: string) {
+  await unloadModule(id);
+  await invoke('module_disable', { id });
+}
+
+export async function uninstallModule(id: string) {
+  await unloadModule(id);
+  await invoke('module_uninstall', { id });
+  useModuleStore.getState().removeModule(id);
+}
+
+function recordError(id: string) {
+  const entry = loaded.get(id);
+  if (!entry) return;
+
+  const now = Date.now();
+  entry.errorTimestamps = entry.errorTimestamps.filter((t) => now - t < CRASH_WINDOW_MS);
+  entry.errorTimestamps.push(now);
+  useModuleStore.getState().incrementErrorCount(id);
+
+  if (entry.errorTimestamps.length >= CRASH_THRESHOLD) {
+    console.error(`[injector] crash quota exceeded for ${id}, auto-disabling`);
+    unloadModule(id).then(() => {
+      useModuleStore.getState().setStatus(
+        id,
+        'faulted',
+        `Auto-disabled: ${CRASH_THRESHOLD} errors in ${CRASH_WINDOW_MS / 1000}s`,
+      );
+    });
+  }
+}
+
+function wrapCallback<T extends (...args: never[]) => unknown>(
+  id: string,
+  fn: T,
+): T {
+  return ((...args: Parameters<T>) => {
+    try {
+      return fn(...args);
+    } catch (err) {
+      console.error(`[injector] callback error in ${id}:`, err);
+      recordError(id);
+      return undefined;
+    }
+  }) as T;
+}
+
+function wrapDisposable(id: string, d: Disposable): Disposable {
+  return {
+    dispose() {
+      try {
+        d.dispose();
+      } catch (err) {
+        console.error(`[injector] dispose error in ${id}:`, err);
+      }
+    },
+  };
+}
+
+function wrapHostForTracking(
+  host: ReturnType<typeof createHost> extends Promise<infer T> ? T : never,
+  disposables: Disposable[],
+) {
+  const id = host.meta.id;
+
+  function track<T extends Disposable>(d: T): T {
+    const wrapped = wrapDisposable(id, d);
+    disposables.push(wrapped);
+    return d;
+  }
+
+  return {
+    ...host,
+
+    panels: {
+      add(spec: Parameters<typeof host.panels.add>[0]) {
+        return track(host.panels.add(spec));
+      },
+    },
+
+    commands: {
+      ...host.commands,
+      add(spec: Parameters<typeof host.commands.add>[0]) {
+        const wrappedSpec = {
+          ...spec,
+          run: wrapCallback(id, spec.run),
+        };
+        return track(host.commands.add(wrappedSpec));
+      },
+    },
+
+    bus: {
+      emit: host.bus.emit.bind(host.bus),
+      on<T = unknown>(topic: string, handler: (payload: T) => void) {
+        return track(host.bus.on(topic, wrapCallback(id, handler)));
+      },
+    },
+
+    events: {
+      emit: host.events.emit.bind(host.events),
+      on<T = unknown>(topic: string, handler: (payload: T) => void) {
+        return track(host.events.on(topic, wrapCallback(id, handler)));
+      },
+    },
+
+    settings: {
+      ...host.settings,
+      register(spec: Parameters<typeof host.settings.register>[0]) {
+        return track(host.settings.register(spec));
+      },
+      onChange<T>(key: string, handler: (value: T) => void) {
+        return track(host.settings.onChange(key, wrapCallback(id, handler)));
+      },
+    },
+  } as typeof host;
+}

--- a/src/modules/injector.ts
+++ b/src/modules/injector.ts
@@ -244,6 +244,18 @@ function wrapHostForTracking(
       },
     },
 
+    menus: {
+      register(spec: Parameters<typeof host.menus.register>[0]) {
+        return track(host.menus.register(spec));
+      },
+      addItem(menuId: string, item: Parameters<typeof host.menus.addItem>[1], priority?: number) {
+        const wrappedItem = item.onClick
+          ? { ...item, onClick: wrapCallback(id, item.onClick) }
+          : item;
+        return track(host.menus.addItem(menuId, wrappedItem, priority));
+      },
+    },
+
     bus: {
       emit: host.bus.emit.bind(host.bus),
       on<T = unknown>(topic: string, handler: (payload: T) => void) {

--- a/src/modules/injector.ts
+++ b/src/modules/injector.ts
@@ -6,6 +6,8 @@ import type { Disposable, LumenPlugin, ModuleManifest } from './types';
 const CRASH_THRESHOLD = 5;
 const CRASH_WINDOW_MS = 10_000;
 
+let globalHandlersInstalled = false;
+
 interface LoadedModule {
   plugin: LumenPlugin;
   disposables: Disposable[];
@@ -20,7 +22,37 @@ export function setOpenCommandPalette(fn: (prefilter?: string) => void) {
   openCommandPaletteFn = fn;
 }
 
+function attributeToModule(error: Error | null | undefined): string | null {
+  const stack = error?.stack ?? '';
+  const match = stack.match(/lumen-module:\/\/([^/\s]+)/);
+  return match?.[1] ?? null;
+}
+
+function installGlobalErrorHandlers() {
+  window.addEventListener('error', (event) => {
+    const id = attributeToModule(event.error instanceof Error ? event.error : null);
+    if (id) {
+      recordError(id);
+      event.preventDefault();
+    }
+  });
+
+  window.addEventListener('unhandledrejection', (event) => {
+    const err = event.reason instanceof Error ? event.reason : null;
+    const id = attributeToModule(err);
+    if (id) {
+      recordError(id);
+      event.preventDefault();
+    }
+  });
+}
+
 export async function bootModules() {
+  if (!globalHandlersInstalled) {
+    installGlobalErrorHandlers();
+    globalHandlersInstalled = true;
+  }
+
   let manifests: Array<{ manifest: ModuleManifest; source: string }> = [];
 
   try {

--- a/src/modules/store.ts
+++ b/src/modules/store.ts
@@ -1,0 +1,104 @@
+import { create } from 'zustand';
+import type { ModuleRecord, ModuleStatus, PanelSpec } from './types';
+
+interface ModuleStore {
+  modules: Map<string, ModuleRecord>;
+  panels: Map<string, PanelSpec[]>;
+
+  registerModule(record: ModuleRecord): void;
+  setStatus(id: string, status: ModuleStatus, error?: string): void;
+  incrementErrorCount(id: string): void;
+  removeModule(id: string): void;
+
+  addPanel(moduleId: string, spec: PanelSpec): void;
+  removePanel(moduleId: string, panelId: string): void;
+  removePanelsForModule(moduleId: string): void;
+  getPanelsForSlot(slot: string): PanelSpec[];
+}
+
+export const useModuleStore = create<ModuleStore>((set, get) => ({
+  modules: new Map(),
+  panels: new Map(),
+
+  registerModule(record) {
+    set((s) => {
+      const next = new Map(s.modules);
+      next.set(record.manifest.id, record);
+      return { modules: next };
+    });
+  },
+
+  setStatus(id, status, error) {
+    set((s) => {
+      const record = s.modules.get(id);
+      if (!record) return s;
+      const next = new Map(s.modules);
+      next.set(id, {
+        ...record,
+        status,
+        error,
+        errorAt: error ? new Date().toISOString() : record.errorAt,
+      });
+      return { modules: next };
+    });
+  },
+
+  incrementErrorCount(id) {
+    set((s) => {
+      const record = s.modules.get(id);
+      if (!record) return s;
+      const next = new Map(s.modules);
+      next.set(id, { ...record, errorCount: record.errorCount + 1 });
+      return { modules: next };
+    });
+  },
+
+  removeModule(id) {
+    set((s) => {
+      const nextModules = new Map(s.modules);
+      const nextPanels = new Map(s.panels);
+      nextModules.delete(id);
+      nextPanels.delete(id);
+      return { modules: nextModules, panels: nextPanels };
+    });
+  },
+
+  addPanel(moduleId, spec) {
+    set((s) => {
+      const next = new Map(s.panels);
+      const existing = next.get(moduleId) ?? [];
+      next.set(moduleId, [...existing, spec]);
+      return { panels: next };
+    });
+  },
+
+  removePanel(moduleId, panelId) {
+    set((s) => {
+      const next = new Map(s.panels);
+      const existing = next.get(moduleId) ?? [];
+      next.set(moduleId, existing.filter((p) => p.id !== panelId));
+      return { panels: next };
+    });
+  },
+
+  removePanelsForModule(moduleId) {
+    set((s) => {
+      const next = new Map(s.panels);
+      next.delete(moduleId);
+      return { panels: next };
+    });
+  },
+
+  getPanelsForSlot(slot) {
+    const { panels } = get();
+    const result: PanelSpec[] = [];
+    for (const specs of panels.values()) {
+      for (const spec of specs) {
+        if (spec.slot === slot) {
+          result.push(spec);
+        }
+      }
+    }
+    return result;
+  },
+}));

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -25,11 +25,21 @@ export interface PanelSpec {
   when?: () => boolean;
 }
 
+export interface CommanderAppProps {
+  onClose: () => void;
+  onBack: () => void;
+}
+
 export interface CommandSpec {
   id: string;
   title: string;
+  subtitle?: string;
+  icon?: React.ComponentType<{ className?: string }>;
   keybinding?: string;
-  run: (args?: unknown) => unknown;
+  keywords?: string[];
+  type?: 'action' | 'app';
+  run?: (args?: unknown) => unknown;
+  component?: React.ComponentType<CommanderAppProps>;
 }
 
 export interface PanelsAPI {

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -1,0 +1,300 @@
+import type React from 'react';
+
+export interface Disposable {
+  dispose(): void;
+}
+
+export type SlotName =
+  | 'sidebar.right.tabs'
+  | 'dialog'
+  | 'presenter.content'
+  | 'toolbar'
+  | 'statusbar';
+
+export interface PanelProps {
+  close?: () => void;
+  [key: string]: unknown;
+}
+
+export interface PanelSpec {
+  id: string;
+  slot: SlotName;
+  title?: string;
+  icon?: string;
+  component: React.ComponentType<PanelProps>;
+  when?: () => boolean;
+}
+
+export interface CommandSpec {
+  id: string;
+  title: string;
+  keybinding?: string;
+  run: (args?: unknown) => unknown;
+}
+
+export interface PanelsAPI {
+  add(spec: PanelSpec): Disposable;
+}
+
+export interface CommandsAPI {
+  add(spec: CommandSpec): Disposable;
+  invoke(id: string, args?: unknown): unknown;
+}
+
+export interface UIAPI {
+  notify(opts: { title?: string; message: string; level?: 'info' | 'warn' | 'error' }): void;
+  confirm(opts: { title: string; message: string; danger?: boolean }): Promise<boolean>;
+  prompt(opts: { title: string; placeholder?: string; initial?: string }): Promise<string | null>;
+  openCommandPalette(prefilter?: string): void;
+}
+
+export interface BusAPI {
+  emit<T = unknown>(topic: string, payload?: T): void;
+  on<T = unknown>(topic: string, handler: (payload: T) => void): Disposable;
+}
+
+export type EventsAPI = BusAPI;
+
+export interface DataJsonAPI {
+  load(): Promise<unknown>;
+  save(value: unknown): Promise<void>;
+  get<T = unknown>(key: string, fallback?: T): Promise<T>;
+  set<T>(key: string, value: T): Promise<void>;
+  delete(key: string): Promise<void>;
+}
+
+export interface Migration {
+  version: number;
+  up: string;
+}
+
+export interface SqliteHandle {
+  exec(sql: string, params?: unknown[]): Promise<void>;
+  query<T = unknown>(sql: string, params?: unknown[]): Promise<T[]>;
+  migrate(versions: Migration[]): Promise<void>;
+}
+
+export interface DataAPI {
+  json: DataJsonAPI;
+  sqlite(): Promise<SqliteHandle>;
+}
+
+export interface SettingSpec<T = unknown> {
+  key: string;
+  label: string;
+  description?: string;
+  type: 'boolean' | 'string' | 'number' | 'select';
+  default: T;
+  options?: Array<{ value: T; label: string }>;
+}
+
+export interface SettingsAPI {
+  register<T>(spec: SettingSpec<T>): Disposable;
+  get<T>(key: string): T | undefined;
+  set<T>(key: string, value: T): void;
+  onChange<T>(key: string, handler: (value: T) => void): Disposable;
+}
+
+export interface LyricsRef {
+  id: string;
+  title: string;
+  artist?: string;
+}
+
+export interface SlideRef {
+  index: number;
+  text: string;
+}
+
+export interface Lyrics {
+  id: string;
+  title: string;
+  artist?: string;
+  slides: SlideRef[];
+}
+
+export interface LyricsQuery {
+  search?: string;
+}
+
+export interface LyricsHostAPI {
+  list(query?: LyricsQuery): Promise<LyricsRef[]>;
+  get(id: string): Promise<Lyrics | null>;
+  currentSlide(): SlideRef | null;
+  advance(): void;
+  back(): void;
+}
+
+export interface QueueItem {
+  id: string;
+  title: string;
+  path: string;
+  type: 'audio' | 'video' | 'image';
+  played: boolean;
+}
+
+export interface QueueHostAPI {
+  items(): QueueItem[];
+  currentIndex(): number;
+  add(item: QueueItem, position?: number): void;
+  remove(id: string): void;
+  reorder(fromIndex: number, toIndex: number): void;
+  shuffle(): void;
+  markPlayed(id: string): void;
+}
+
+export type MediaType = 'audio' | 'video' | 'image';
+
+export interface MediaRef {
+  id: string;
+  path: string;
+  name: string;
+  type: MediaType;
+}
+
+export interface MediaItem extends MediaRef {
+  duration?: number;
+  size: number;
+  modifiedAt: string;
+}
+
+export interface MediaMetadata {
+  title?: string;
+  artist?: string;
+  album?: string;
+  duration?: number;
+  width?: number;
+  height?: number;
+}
+
+export interface LibraryHostAPI {
+  list(type?: MediaType, query?: string): Promise<MediaRef[]>;
+  get(id: string): Promise<MediaItem | null>;
+  metadata(path: string): Promise<MediaMetadata>;
+  thumbnail(path: string, size?: number): Promise<string>;
+}
+
+export interface TrackRef {
+  id: string;
+  path: string;
+  title?: string;
+  artist?: string;
+}
+
+export interface PlayerHostAPI {
+  current(): TrackRef | null;
+  state(): 'playing' | 'paused' | 'idle';
+  play(track?: TrackRef): void;
+  pause(): void;
+  seek(seconds: number): void;
+  volume(value?: number): number;
+  next(): void;
+  prev(): void;
+}
+
+export interface PresentationHostAPI {
+  state(): 'idle' | 'live';
+  project(viewId: string, props?: unknown): void;
+  clear(): void;
+  isWindowOpen(): boolean;
+}
+
+export interface ThemeRef {
+  id: string;
+  name: string;
+  colorMode: 'dark' | 'light';
+  accentId: string;
+}
+
+export interface ThemesHostAPI {
+  current(): ThemeRef;
+  list(): ThemeRef[];
+  apply(id: string): void;
+}
+
+export interface FsAPI {
+  read(path: string): Promise<Uint8Array>;
+  write(path: string, data: Uint8Array): Promise<void>;
+  exists(path: string): Promise<boolean>;
+  list(path: string): Promise<string[]>;
+  remove(path: string): Promise<void>;
+}
+
+export interface NetAPI {
+  get<T = unknown>(url: string, opts?: RequestInit): Promise<T>;
+  post<T = unknown>(url: string, body: unknown, opts?: RequestInit): Promise<T>;
+}
+
+export interface I18nAPI {
+  t(key: string, params?: Record<string, string>): string;
+  locale(): string;
+}
+
+export interface LoggerAPI {
+  debug(...args: unknown[]): void;
+  info(...args: unknown[]): void;
+  warn(...args: unknown[]): void;
+  error(...args: unknown[]): void;
+}
+
+export interface LumenHost {
+  meta: { id: string; version: string };
+  window: 'main' | 'presenter';
+  app: { version: string; locale: string };
+
+  panels: PanelsAPI;
+  commands: CommandsAPI;
+  ui: UIAPI;
+
+  bus: BusAPI;
+  events: EventsAPI;
+
+  data: DataAPI;
+  settings: SettingsAPI;
+
+  lyrics: LyricsHostAPI;
+  queue: QueueHostAPI;
+  library: LibraryHostAPI;
+  player: PlayerHostAPI;
+  presentation: PresentationHostAPI;
+  themes: ThemesHostAPI;
+
+  fs: FsAPI;
+  net: NetAPI;
+  i18n: I18nAPI;
+  log: LoggerAPI;
+}
+
+export abstract class LumenPlugin {
+  manifest!: ModuleManifest;
+
+  abstract onload(host: LumenHost): Promise<void>;
+
+  async onunload(): Promise<void> {}
+}
+
+export interface ModuleManifest {
+  id: string;
+  name: string;
+  version: string;
+  api: string;
+  minLumenVersion?: string;
+  description?: string;
+  author?: { name: string; url?: string };
+  entry: string;
+  icon?: string;
+  homepage?: string;
+  repository?: string;
+  license?: string;
+}
+
+export type ModuleStatus = 'loading' | 'active' | 'faulted' | 'disabled';
+
+export interface ModuleRecord {
+  manifest: ModuleManifest;
+  status: ModuleStatus;
+  error?: string;
+  errorAt?: string;
+  errorCount: number;
+  source: 'bundled' | 'store' | 'sideload' | 'dev';
+}

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -46,9 +46,27 @@ export interface PanelsAPI {
   add(spec: PanelSpec): Disposable;
 }
 
+export interface PrefixResult {
+  id: string;
+  title: string;
+  subtitle?: string;
+  badge?: string;
+  run?: () => void;
+  component?: React.ComponentType<CommanderAppProps>;
+}
+
+export interface PrefixSpec {
+  prefix: string;
+  title: string;
+  icon?: React.ComponentType<{ className?: string }>;
+  placeholder?: string;
+  handle(query: string): PrefixResult[] | Promise<PrefixResult[]>;
+}
+
 export interface CommandsAPI {
   add(spec: CommandSpec): Disposable;
   invoke(id: string, args?: unknown): unknown;
+  addPrefix(spec: PrefixSpec): Disposable;
 }
 
 export interface UIAPI {

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -61,7 +61,14 @@ export interface MenuItemAction {
   onClick?: () => void;
 }
 
-export type MenuItemDef = MenuItemSeparator | MenuItemAction;
+export interface MenuItemSubmenu {
+  type: 'submenu';
+  id?: string;
+  label: string;
+  items: MenuItemDef[];
+}
+
+export type MenuItemDef = MenuItemSeparator | MenuItemAction | MenuItemSubmenu;
 
 export interface MenuSpec {
   id: string;

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -48,6 +48,33 @@ export interface UIAPI {
   openCommandPalette(prefilter?: string): void;
 }
 
+export interface MenuItemSeparator {
+  type: 'separator';
+  id?: string;
+}
+
+export interface MenuItemAction {
+  type: 'action';
+  id: string;
+  label: string;
+  shortcut?: string;
+  onClick?: () => void;
+}
+
+export type MenuItemDef = MenuItemSeparator | MenuItemAction;
+
+export interface MenuSpec {
+  id: string;
+  label: string;
+  items?: MenuItemDef[];
+  priority?: number;
+}
+
+export interface MenusAPI {
+  register(spec: MenuSpec): Disposable;
+  addItem(menuId: string, item: MenuItemAction, priority?: number): Disposable;
+}
+
 export interface BusAPI {
   emit<T = unknown>(topic: string, payload?: T): void;
   on<T = unknown>(topic: string, handler: (payload: T) => void): Disposable;
@@ -244,6 +271,7 @@ export interface LumenHost {
 
   panels: PanelsAPI;
   commands: CommandsAPI;
+  menus: MenusAPI;
   ui: UIAPI;
 
   bus: BusAPI;

--- a/src/services/lyric-service.ts
+++ b/src/services/lyric-service.ts
@@ -100,6 +100,17 @@ function parseSlides(body: string): LyricSlide[] {
   }, []);
 }
 
+export function buildLyricSearchContent(data: LyricData): string {
+  const parts: string[] = [];
+  if (data.metadata.notes) parts.push(data.metadata.notes);
+  for (const slide of data.slides) {
+    for (const line of slide.lines) {
+      if (line.trim()) parts.push(line);
+    }
+  }
+  return parts.join('\n');
+}
+
 export function parseLyricFile(content: string): LyricData {
   const { metadata, body } = parseFrontmatter(content);
   const slides = parseSlides(body);
@@ -164,6 +175,7 @@ class LyricService {
 
     const meta = await stat(filePath);
     const name = filePath.split(/[\\/]/).pop() || fileName;
+    const indexedContent = buildLyricSearchContent(data);
     await mediaDbService.insertFile(
       {
         name,
@@ -173,7 +185,8 @@ class LyricService {
         extension: 'md',
         artist: data.metadata.author || undefined,
       },
-      'lyrics'
+      'lyrics',
+      indexedContent
     );
 
     return filePath;

--- a/src/services/media-db-service.ts
+++ b/src/services/media-db-service.ts
@@ -14,6 +14,18 @@ interface DbRow {
   media_type: string;
   duration: number | null;
   artist: string | null;
+  content: string | null;
+}
+
+export interface SearchHit {
+  id: number;
+  name: string;
+  path: string;
+  media_type: MediaType;
+  artist: string | null;
+  duration: number | null;
+  modified_at: number;
+  rank: number;
 }
 
 class MediaDbService {
@@ -44,11 +56,57 @@ class MediaDbService {
         media_type  TEXT    NOT NULL,
         duration    REAL,
         artist      TEXT,
+        content     TEXT,
         created_at  INTEGER NOT NULL DEFAULT (unixepoch())
       )
     `);
     await db.execute(`CREATE INDEX IF NOT EXISTS idx_mf_type ON media_files (media_type)`);
     await db.execute(`CREATE INDEX IF NOT EXISTS idx_mf_name ON media_files (name COLLATE NOCASE)`);
+
+    const cols = await db.select<{ name: string }[]>('PRAGMA table_info(media_files)');
+    if (!cols.some((c) => c.name === 'content')) {
+      await db.execute(`ALTER TABLE media_files ADD COLUMN content TEXT`);
+    }
+
+    await db.execute(`
+      CREATE VIRTUAL TABLE IF NOT EXISTS media_search USING fts5(
+        name,
+        artist,
+        content,
+        content='media_files',
+        content_rowid='id',
+        tokenize='unicode61 remove_diacritics 2'
+      )
+    `);
+
+    await db.execute(`
+      CREATE TRIGGER IF NOT EXISTS media_files_ai AFTER INSERT ON media_files BEGIN
+        INSERT INTO media_search (rowid, name, artist, content)
+        VALUES (new.id, new.name, COALESCE(new.artist, ''), COALESCE(new.content, ''));
+      END
+    `);
+    await db.execute(`
+      CREATE TRIGGER IF NOT EXISTS media_files_ad AFTER DELETE ON media_files BEGIN
+        INSERT INTO media_search (media_search, rowid, name, artist, content)
+        VALUES ('delete', old.id, old.name, COALESCE(old.artist, ''), COALESCE(old.content, ''));
+      END
+    `);
+    await db.execute(`
+      CREATE TRIGGER IF NOT EXISTS media_files_au AFTER UPDATE ON media_files BEGIN
+        INSERT INTO media_search (media_search, rowid, name, artist, content)
+        VALUES ('delete', old.id, old.name, COALESCE(old.artist, ''), COALESCE(old.content, ''));
+        INSERT INTO media_search (rowid, name, artist, content)
+        VALUES (new.id, new.name, COALESCE(new.artist, ''), COALESCE(new.content, ''));
+      END
+    `);
+
+    const ftsCount = await db.select<{ n: number }[]>('SELECT COUNT(*) AS n FROM media_search');
+    if ((ftsCount[0]?.n ?? 0) === 0) {
+      await db.execute(`
+        INSERT INTO media_search (rowid, name, artist, content)
+        SELECT id, name, COALESCE(artist, ''), COALESCE(content, '') FROM media_files
+      `);
+    }
 
     await db.execute(`
       CREATE TABLE IF NOT EXISTS theme_files (
@@ -88,8 +146,8 @@ class MediaDbService {
         } catch {}
 
         await db.execute(
-          `INSERT OR IGNORE INTO media_files (name, path, size, modified_at, extension, media_type, duration, artist)
-           VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+          `INSERT OR IGNORE INTO media_files (name, path, size, modified_at, extension, media_type, duration, artist, content)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
           [
             file.name,
             file.path,
@@ -99,6 +157,7 @@ class MediaDbService {
             mediaType,
             metadata.duration ?? null,
             metadata.artist ?? null,
+            null,
           ]
         );
       }
@@ -130,7 +189,7 @@ class MediaDbService {
     return rows.map(rowToFileInfo);
   }
 
-  async insertFile(file: FileInfo, mediaType: MediaType): Promise<void> {
+  async insertFile(file: FileInfo, mediaType: MediaType, content?: string): Promise<void> {
     const db = await this.ready();
 
     let metadata: { duration?: number; artist?: string } = {};
@@ -139,8 +198,16 @@ class MediaDbService {
     } catch {}
 
     await db.execute(
-      `INSERT OR IGNORE INTO media_files (name, path, size, modified_at, extension, media_type, duration, artist)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+      `INSERT INTO media_files (name, path, size, modified_at, extension, media_type, duration, artist, content)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+       ON CONFLICT(path) DO UPDATE SET
+         name        = excluded.name,
+         size        = excluded.size,
+         modified_at = excluded.modified_at,
+         extension   = excluded.extension,
+         duration    = excluded.duration,
+         artist      = excluded.artist,
+         content     = COALESCE(excluded.content, media_files.content)`,
       [
         file.name,
         file.path,
@@ -150,8 +217,78 @@ class MediaDbService {
         mediaType,
         metadata.duration ?? null,
         metadata.artist ?? null,
+        content ?? null,
       ]
     );
+  }
+
+  async search(
+    query: string,
+    opts: { mediaType?: MediaType; fullContent?: boolean; limit?: number } = {}
+  ): Promise<SearchHit[]> {
+    const db = await this.ready();
+    const limit = opts.limit ?? 50;
+    const term = sanitizeFtsTerm(query);
+    if (!term) return [];
+
+    const columns = opts.fullContent ? 'name OR artist OR content' : 'name OR artist';
+    const matchExpr = `{${columns}} : ${term}`;
+
+    const params: unknown[] = [matchExpr];
+    let typeFilter = '';
+    if (opts.mediaType) {
+      typeFilter = ' AND mf.media_type = $2';
+      params.push(opts.mediaType);
+    }
+    params.push(limit);
+    const limitIdx = params.length;
+
+    const rows = await db.select<SearchHit[]>(
+      `SELECT mf.id, mf.name, mf.path, mf.media_type, mf.artist, mf.duration, mf.modified_at,
+              bm25(media_search) AS rank
+         FROM media_search
+         JOIN media_files mf ON mf.id = media_search.rowid
+        WHERE media_search MATCH $1${typeFilter}
+        ORDER BY rank
+        LIMIT $${limitIdx}`,
+      params
+    );
+    return rows;
+  }
+
+  async listByType(mediaType: MediaType, limit = 50): Promise<SearchHit[]> {
+    const db = await this.ready();
+    const rows = await db.select<SearchHit[]>(
+      `SELECT id, name, path, media_type, artist, duration, modified_at, 0 AS rank
+         FROM media_files
+        WHERE media_type = $1
+        ORDER BY name COLLATE NOCASE
+        LIMIT $2`,
+      [mediaType, limit]
+    );
+    return rows;
+  }
+
+  async getById(id: number): Promise<SearchHit | null> {
+    const db = await this.ready();
+    const rows = await db.select<SearchHit[]>(
+      `SELECT id, name, path, media_type, artist, duration, modified_at, 0 AS rank
+         FROM media_files
+        WHERE id = $1`,
+      [id]
+    );
+    return rows[0] ?? null;
+  }
+
+  async getByPath(path: string): Promise<SearchHit | null> {
+    const db = await this.ready();
+    const rows = await db.select<SearchHit[]>(
+      `SELECT id, name, path, media_type, artist, duration, modified_at, 0 AS rank
+         FROM media_files
+        WHERE path = $1`,
+      [path]
+    );
+    return rows[0] ?? null;
   }
 
   async deleteFile(path: string): Promise<void> {
@@ -236,6 +373,17 @@ function rowToFileInfo(row: DbRow): FileInfo {
 
 function escapeLike(s: string): string {
   return s.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_');
+}
+
+function sanitizeFtsTerm(raw: string): string {
+  const tokens = raw
+    .normalize('NFKD')
+    .replace(/[^\p{L}\p{N}\s]+/gu, ' ')
+    .split(/\s+/)
+    .map((t) => t.trim())
+    .filter(Boolean);
+  if (tokens.length === 0) return '';
+  return tokens.map((t) => `"${t.replace(/"/g, '""')}"*`).join(' AND ');
 }
 
 export const mediaDbService = new MediaDbService();

--- a/src/services/media-db-service.ts
+++ b/src/services/media-db-service.ts
@@ -45,6 +45,10 @@ class MediaDbService {
     }
 
     const db = await Database.load(await getDbPath());
+    await db.execute(`DROP TRIGGER IF EXISTS mf_ai`);
+    await db.execute(`DROP TRIGGER IF EXISTS mf_au`);
+    await db.execute(`DROP TRIGGER IF EXISTS mf_ad`);
+    await db.execute(`DROP TABLE IF EXISTS media_search`);
     await db.execute(`
       CREATE TABLE IF NOT EXISTS media_files (
         id          INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -66,46 +70,6 @@ class MediaDbService {
     const cols = await db.select<{ name: string }[]>('PRAGMA table_info(media_files)');
     if (!cols.some((c) => c.name === 'content')) {
       await db.execute(`ALTER TABLE media_files ADD COLUMN content TEXT`);
-    }
-
-    await db.execute(`
-      CREATE VIRTUAL TABLE IF NOT EXISTS media_search USING fts5(
-        name,
-        artist,
-        content,
-        content='media_files',
-        content_rowid='id',
-        tokenize='unicode61 remove_diacritics 2'
-      )
-    `);
-
-    await db.execute(`
-      CREATE TRIGGER IF NOT EXISTS media_files_ai AFTER INSERT ON media_files BEGIN
-        INSERT INTO media_search (rowid, name, artist, content)
-        VALUES (new.id, new.name, COALESCE(new.artist, ''), COALESCE(new.content, ''));
-      END
-    `);
-    await db.execute(`
-      CREATE TRIGGER IF NOT EXISTS media_files_ad AFTER DELETE ON media_files BEGIN
-        INSERT INTO media_search (media_search, rowid, name, artist, content)
-        VALUES ('delete', old.id, old.name, COALESCE(old.artist, ''), COALESCE(old.content, ''));
-      END
-    `);
-    await db.execute(`
-      CREATE TRIGGER IF NOT EXISTS media_files_au AFTER UPDATE ON media_files BEGIN
-        INSERT INTO media_search (media_search, rowid, name, artist, content)
-        VALUES ('delete', old.id, old.name, COALESCE(old.artist, ''), COALESCE(old.content, ''));
-        INSERT INTO media_search (rowid, name, artist, content)
-        VALUES (new.id, new.name, COALESCE(new.artist, ''), COALESCE(new.content, ''));
-      END
-    `);
-
-    const ftsCount = await db.select<{ n: number }[]>('SELECT COUNT(*) AS n FROM media_search');
-    if ((ftsCount[0]?.n ?? 0) === 0) {
-      await db.execute(`
-        INSERT INTO media_search (rowid, name, artist, content)
-        SELECT id, name, COALESCE(artist, ''), COALESCE(content, '') FROM media_files
-      `);
     }
 
     await db.execute(`
@@ -182,7 +146,7 @@ class MediaDbService {
   async searchFiles(mediaType: MediaType, query: string): Promise<FileInfo[]> {
     const db = await this.ready();
     const rows = await db.select<DbRow[]>(
-      `SELECT * FROM media_files WHERE media_type = $1 AND name LIKE $2 ESCAPE '\\'
+      `SELECT * FROM media_files WHERE media_type = $1 AND name LIKE $2 ESCAPE '#'
        ORDER BY name COLLATE NOCASE`,
       [mediaType, `%${escapeLike(query)}%`]
     );
@@ -228,32 +192,54 @@ class MediaDbService {
   ): Promise<SearchHit[]> {
     const db = await this.ready();
     const limit = opts.limit ?? 50;
-    const term = sanitizeFtsTerm(query);
-    if (!term) return [];
+    const trimmed = query.trim();
+    if (!trimmed) return [];
 
-    const columns = opts.fullContent ? 'name OR artist OR content' : 'name OR artist';
-    const matchExpr = `{${columns}} : ${term}`;
+    const terms = trimmed.split(/\s+/).filter(Boolean);
+    const conditions: string[] = [];
+    const params: unknown[] = [];
+    let paramIdx = 1;
 
-    const params: unknown[] = [matchExpr];
+    for (const term of terms) {
+      const like = `%${escapeLike(term)}%`;
+      if (opts.fullContent) {
+        conditions.push(
+          `(name LIKE $${paramIdx} ESCAPE '#' OR COALESCE(artist, '') LIKE $${paramIdx + 1} ESCAPE '#' OR COALESCE(content, '') LIKE $${paramIdx + 2} ESCAPE '#')`
+        );
+        params.push(like, like, like);
+        paramIdx += 3;
+      } else {
+        conditions.push(
+          `(name LIKE $${paramIdx} ESCAPE '#' OR COALESCE(artist, '') LIKE $${paramIdx + 1} ESCAPE '#')`
+        );
+        params.push(like, like);
+        paramIdx += 2;
+      }
+    }
+
     let typeFilter = '';
     if (opts.mediaType) {
-      typeFilter = ' AND mf.media_type = $2';
+      typeFilter = ` AND media_type = $${paramIdx}`;
       params.push(opts.mediaType);
+      paramIdx++;
     }
     params.push(limit);
-    const limitIdx = params.length;
 
-    const rows = await db.select<SearchHit[]>(
-      `SELECT mf.id, mf.name, mf.path, mf.media_type, mf.artist, mf.duration, mf.modified_at,
-              bm25(media_search) AS rank
-         FROM media_search
-         JOIN media_files mf ON mf.id = media_search.rowid
-        WHERE media_search MATCH $1${typeFilter}
-        ORDER BY rank
-        LIMIT $${limitIdx}`,
+    const rows = await db.select<DbRow[]>(
+      `SELECT * FROM media_files WHERE ${conditions.join(' AND ')}${typeFilter}
+       ORDER BY name COLLATE NOCASE LIMIT $${paramIdx}`,
       params
     );
-    return rows;
+    return rows.map((r) => ({
+      id: r.id,
+      name: r.name,
+      path: r.path,
+      media_type: r.media_type as MediaType,
+      artist: r.artist,
+      duration: r.duration,
+      modified_at: r.modified_at,
+      rank: 0,
+    }));
   }
 
   async listByType(mediaType: MediaType, limit = 50): Promise<SearchHit[]> {
@@ -372,18 +358,8 @@ function rowToFileInfo(row: DbRow): FileInfo {
 }
 
 function escapeLike(s: string): string {
-  return s.replace(/\\/g, '\\\\').replace(/%/g, '\\%').replace(/_/g, '\\_');
+  return s.replace(/#/g, '##').replace(/%/g, '#%').replace(/_/g, '#_');
 }
 
-function sanitizeFtsTerm(raw: string): string {
-  const tokens = raw
-    .normalize('NFKD')
-    .replace(/[^\p{L}\p{N}\s]+/gu, ' ')
-    .split(/\s+/)
-    .map((t) => t.trim())
-    .filter(Boolean);
-  if (tokens.length === 0) return '';
-  return tokens.map((t) => `"${t.replace(/"/g, '""')}"*`).join(' AND ');
-}
 
 export const mediaDbService = new MediaDbService();

--- a/src/services/search-service.ts
+++ b/src/services/search-service.ts
@@ -1,4 +1,4 @@
-import type { CommandSpec } from '@/modules/types';
+import type { CommandSpec, PrefixSpec } from '@/modules/types';
 import { mediaDbService, type SearchHit } from './media-db-service';
 import type { MediaType } from './types';
 
@@ -22,6 +22,7 @@ export interface SearchResults {
   lyrics: SearchResult[];
   media: SearchResult[];
   commands: SearchResult[];
+  activePrefix?: PrefixSpec;
   total: number;
 }
 
@@ -30,6 +31,7 @@ export interface SearchOpts {
   scope: SearchScope;
   fullContent: boolean;
   commands: CommandSpec[];
+  prefixes?: PrefixSpec[];
   limitPerGroup?: number;
 }
 
@@ -93,9 +95,39 @@ function commandToResult(spec: CommandSpec): SearchResult {
   };
 }
 
+function prefixResultToSearchResult(r: import('@/modules/types').PrefixResult, spec: PrefixSpec): SearchResult {
+  return {
+    source: r.component ? 'app' : 'command',
+    id: `prefix:${spec.prefix}:${r.id}`,
+    title: r.title,
+    subtitle: r.subtitle,
+    badge: r.badge ?? spec.title.toUpperCase(),
+    commandSpec: {
+      id: r.id,
+      title: r.title,
+      subtitle: r.subtitle,
+      type: r.component ? 'app' : 'action',
+      run: r.run,
+      component: r.component,
+    },
+  };
+}
+
 export async function search(opts: SearchOpts): Promise<SearchResults> {
   const limit = opts.limitPerGroup ?? 12;
   const trimmed = opts.query.trim();
+
+  for (const spec of opts.prefixes ?? []) {
+    const lower = trimmed.toLowerCase();
+    const pfx = spec.prefix.toLowerCase();
+    if (lower.startsWith(`${pfx} `) || lower === pfx) {
+      const rest = trimmed.slice(spec.prefix.length).trimStart();
+      const raw = await spec.handle(rest);
+      const results = raw.map((r) => prefixResultToSearchResult(r, spec));
+      return { lyrics: [], media: [], commands: results, activePrefix: spec, total: results.length };
+    }
+  }
+
   const tokens = trimmed ? normalize(trimmed).split(/\s+/).filter(Boolean) : [];
 
   const wantLyrics = opts.scope === 'all' || opts.scope === 'lyrics';

--- a/src/services/search-service.ts
+++ b/src/services/search-service.ts
@@ -1,0 +1,138 @@
+import type { CommandSpec } from '@/modules/types';
+import { mediaDbService, type SearchHit } from './media-db-service';
+import type { MediaType } from './types';
+
+export type SearchSource = 'lyric' | 'audio' | 'video' | 'image' | 'command' | 'app';
+
+export type SearchScope = 'all' | 'lyrics' | 'media' | 'commands';
+
+export interface SearchResult {
+  source: SearchSource;
+  id: string;
+  title: string;
+  subtitle?: string;
+  badge: string;
+  shortcut?: string;
+  path?: string;
+  artist?: string;
+  commandSpec?: CommandSpec;
+}
+
+export interface SearchResults {
+  lyrics: SearchResult[];
+  media: SearchResult[];
+  commands: SearchResult[];
+  total: number;
+}
+
+export interface SearchOpts {
+  query: string;
+  scope: SearchScope;
+  fullContent: boolean;
+  commands: CommandSpec[];
+  limitPerGroup?: number;
+}
+
+const SEARCHABLE_MEDIA: MediaType[] = ['audio', 'video', 'image'];
+
+function badgeForMediaType(type: string): string {
+  switch (type) {
+    case 'lyrics': return 'LYRIC';
+    case 'audio':  return 'AUDIO';
+    case 'video':  return 'VIDEO';
+    case 'image':  return 'IMAGE';
+    default:       return type.toUpperCase();
+  }
+}
+
+function sourceForMediaType(type: string): SearchSource {
+  switch (type) {
+    case 'lyrics': return 'lyric';
+    case 'audio':  return 'audio';
+    case 'video':  return 'video';
+    case 'image':  return 'image';
+    default:       return 'audio';
+  }
+}
+
+function hitToResult(hit: SearchHit): SearchResult {
+  const source = sourceForMediaType(hit.media_type);
+  return {
+    source,
+    id: `media:${hit.id}`,
+    title: hit.name.replace(/\.[^/.]+$/, ''),
+    subtitle: hit.artist ?? undefined,
+    badge: badgeForMediaType(hit.media_type),
+    path: hit.path,
+    artist: hit.artist ?? undefined,
+  };
+}
+
+export function normalize(s: string): string {
+  return s.normalize('NFKD').replace(/\p{M}+/gu, '').toLowerCase();
+}
+
+function commandMatches(spec: CommandSpec, tokens: string[]): boolean {
+  if (tokens.length === 0) return true;
+  const haystack = normalize(
+    [spec.title, spec.subtitle ?? '', (spec.keywords ?? []).join(' ')].join(' ')
+  );
+  return tokens.every((t) => haystack.includes(t));
+}
+
+function commandToResult(spec: CommandSpec): SearchResult {
+  const isApp = spec.type === 'app';
+  return {
+    source: isApp ? 'app' : 'command',
+    id: `cmd:${spec.id}`,
+    title: spec.title,
+    subtitle: spec.subtitle,
+    badge: isApp ? 'APP' : 'COMMAND',
+    shortcut: spec.keybinding,
+    commandSpec: spec,
+  };
+}
+
+export async function search(opts: SearchOpts): Promise<SearchResults> {
+  const limit = opts.limitPerGroup ?? 12;
+  const trimmed = opts.query.trim();
+  const tokens = trimmed ? normalize(trimmed).split(/\s+/).filter(Boolean) : [];
+
+  const wantLyrics = opts.scope === 'all' || opts.scope === 'lyrics';
+  const wantMedia = opts.scope === 'all' || opts.scope === 'media';
+  const wantCommands = opts.scope === 'all' || opts.scope === 'commands';
+
+  const lyricsPromise: Promise<SearchHit[]> = wantLyrics
+    ? trimmed
+      ? mediaDbService.search(trimmed, { mediaType: 'lyrics', fullContent: opts.fullContent, limit })
+      : mediaDbService.listByType('lyrics', limit)
+    : Promise.resolve([]);
+
+  const mediaPromise: Promise<SearchHit[]> = wantMedia
+    ? trimmed
+      ? Promise.all(
+          SEARCHABLE_MEDIA.map((t) =>
+            mediaDbService.search(trimmed, { mediaType: t, fullContent: opts.fullContent, limit })
+          )
+        ).then((arrs) => arrs.flat().slice(0, limit))
+      : Promise.all(SEARCHABLE_MEDIA.map((t) => mediaDbService.listByType(t, Math.ceil(limit / 3)))).then(
+          (arrs) => arrs.flat().slice(0, limit)
+        )
+    : Promise.resolve([]);
+
+  const [lyricsHits, mediaHits] = await Promise.all([lyricsPromise, mediaPromise]);
+
+  const commandResults: SearchResult[] = wantCommands
+    ? opts.commands.filter((c) => commandMatches(c, tokens)).slice(0, limit).map(commandToResult)
+    : [];
+
+  const lyricsResults = lyricsHits.map(hitToResult);
+  const mediaResults = mediaHits.map(hitToResult);
+
+  return {
+    lyrics: lyricsResults,
+    media: mediaResults,
+    commands: commandResults,
+    total: lyricsResults.length + mediaResults.length + commandResults.length,
+  };
+}

--- a/src/stores/command-store.ts
+++ b/src/stores/command-store.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import type { CommanderAppProps, CommandSpec } from '@/modules/types';
+import type { CommanderAppProps, CommandSpec, PrefixSpec } from '@/modules/types';
 import type React from 'react';
 
 export interface ActiveApp {
@@ -13,6 +13,7 @@ interface CommandStore {
   prefilter: string;
   activeApp: ActiveApp | null;
   commands: CommandSpec[];
+  prefixes: PrefixSpec[];
   open: (prefilter?: string) => void;
   close: () => void;
   toggle: () => void;
@@ -20,6 +21,8 @@ interface CommandStore {
   popApp: () => void;
   _register: (spec: CommandSpec) => void;
   _unregister: (id: string) => void;
+  _registerPrefix: (spec: PrefixSpec) => void;
+  _unregisterPrefix: (prefix: string) => void;
 }
 
 export const useCommandStore = create<CommandStore>((set) => ({
@@ -27,6 +30,7 @@ export const useCommandStore = create<CommandStore>((set) => ({
   prefilter: '',
   activeApp: null,
   commands: [],
+  prefixes: [],
 
   open: (prefilter = '') => set({ isOpen: true, prefilter, activeApp: null }),
   close: () => set({ isOpen: false, prefilter: '', activeApp: null }),
@@ -48,4 +52,13 @@ export const useCommandStore = create<CommandStore>((set) => ({
     })),
   _unregister: (id) =>
     set((s) => ({ commands: s.commands.filter((c) => c.id !== id) })),
+
+  _registerPrefix: (spec) =>
+    set((s) => ({
+      prefixes: s.prefixes.some((p) => p.prefix === spec.prefix)
+        ? s.prefixes.map((p) => (p.prefix === spec.prefix ? spec : p))
+        : [...s.prefixes, spec],
+    })),
+  _unregisterPrefix: (prefix) =>
+    set((s) => ({ prefixes: s.prefixes.filter((p) => p.prefix !== prefix) })),
 }));

--- a/src/stores/command-store.ts
+++ b/src/stores/command-store.ts
@@ -1,15 +1,51 @@
 import { create } from 'zustand';
+import type { CommanderAppProps, CommandSpec } from '@/modules/types';
+import type React from 'react';
+
+export interface ActiveApp {
+  commandId: string;
+  title: string;
+  component: React.ComponentType<CommanderAppProps>;
+}
 
 interface CommandStore {
   isOpen: boolean;
-  open: () => void;
+  prefilter: string;
+  activeApp: ActiveApp | null;
+  commands: CommandSpec[];
+  open: (prefilter?: string) => void;
   close: () => void;
   toggle: () => void;
+  pushApp: (app: ActiveApp) => void;
+  popApp: () => void;
+  _register: (spec: CommandSpec) => void;
+  _unregister: (id: string) => void;
 }
 
 export const useCommandStore = create<CommandStore>((set) => ({
   isOpen: false,
-  open: () => set({ isOpen: true }),
-  close: () => set({ isOpen: false }),
-  toggle: () => set((s) => ({ isOpen: !s.isOpen })),
+  prefilter: '',
+  activeApp: null,
+  commands: [],
+
+  open: (prefilter = '') => set({ isOpen: true, prefilter, activeApp: null }),
+  close: () => set({ isOpen: false, prefilter: '', activeApp: null }),
+  toggle: () =>
+    set((s) =>
+      s.isOpen
+        ? { isOpen: false, prefilter: '', activeApp: null }
+        : { isOpen: true },
+    ),
+
+  pushApp: (app) => set({ activeApp: app }),
+  popApp: () => set({ activeApp: null }),
+
+  _register: (spec) =>
+    set((s) => ({
+      commands: s.commands.some((c) => c.id === spec.id)
+        ? s.commands.map((c) => (c.id === spec.id ? spec : c))
+        : [...s.commands, spec],
+    })),
+  _unregister: (id) =>
+    set((s) => ({ commands: s.commands.filter((c) => c.id !== id) })),
 }));

--- a/src/stores/player-store.ts
+++ b/src/stores/player-store.ts
@@ -25,6 +25,7 @@ interface PlayerStore {
   currentLyricPath: string | null;
   currentLyricSlideIndex: number;
   currentLyricTotalSlides: number;
+  currentImagePath: string | null;
 
   initWs: () => () => void;
   initListeners: () => () => void;
@@ -43,6 +44,7 @@ interface PlayerStore {
   setIsDragging: (dragging: boolean) => void;
   loadFile: (filePath: string, seekTime?: number) => Promise<void>;
   presentLyric: (filePath: string) => Promise<void>;
+  presentImage: (filePath: string) => Promise<void>;
   restoreLastMedia: () => Promise<void>;
 }
 
@@ -111,6 +113,7 @@ export const usePlayerStore = create<PlayerStore>((set, get) => ({
   currentLyricPath: null,
   currentLyricSlideIndex: 0,
   currentLyricTotalSlides: 0,
+  currentImagePath: null,
 
   initWs: () => {
     const socket = new WebSocket('ws://localhost:8080');
@@ -482,6 +485,29 @@ export const usePlayerStore = create<PlayerStore>((set, get) => ({
       currentLyricTotalSlides: 0,
     });
     void broadcastPlayerSync(get, 'load_lyric');
+
+    if (win) {
+      await win.show();
+      set({ isScreenOpen: true });
+    }
+  },
+
+  presentImage: async (filePath: string) => {
+    let win = await getMediaWindow();
+    if (!win) {
+      try {
+        const readyPromise = waitForMediaWindowReady();
+        await invoke('create_window', { label: 'media-window', title: 'Media Player' });
+        await readyPromise;
+        win = await getMediaWindow();
+      } catch {
+        return;
+      }
+    }
+
+    const { emit } = await import('@tauri-apps/api/event');
+    await emit('load-image', { url: filePath });
+    set({ currentImagePath: filePath });
 
     if (win) {
       await win.show();

--- a/src/stores/settings-store.ts
+++ b/src/stores/settings-store.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 
-export type SettingsSection = 'theme' | 'remote_general' | 'remote_permissions' | 'advanced' | 'about';
+export type SettingsSection = 'theme' | 'remote_general' | 'remote_permissions' | 'advanced' | 'about' | 'modules';
 
 interface SettingsStore {
   isOpen: boolean;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,7 @@ import tailwindcss from '@tailwindcss/vite';
 import { tanstackRouter } from '@tanstack/router-plugin/vite';
 import react from '@vitejs/plugin-react-swc';
 import { defineConfig } from 'vite';
+import { lumenHostModules } from './scripts/vite-plugin-lumen-host-modules';
 
 // @ts-expect-error process is a nodejs global
 const host = process.env.TAURI_DEV_HOST;
@@ -17,6 +18,7 @@ export default defineConfig({
     tanstackRouter({
       routesDirectory: "./src/app",
     }),
+    lumenHostModules(),
   ],
 
   define: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,6 +25,12 @@ export default defineConfig({
     __BUILD_DATE__: JSON.stringify(buildDate),
   },
 
+  build: {
+    rollupOptions: {
+      external: ['react', 'react-dom', 'react-dom/client'],
+    },
+  },
+
   clearScreen: false,
 
   resolve: {


### PR DESCRIPTION
## 📋 Description

Full implementation of the Lumen module/extension system, as specified in \docs/architecture/module-system-architecture.md\ and \docs/architecture/module-sdk-architecture.md\. Includes the runtime foundation, all host APIs, validation fixes, the developer API reference, and the Commander (command palette) with unified search, playback and queue support.

### What was changed?

**Rust / Tauri (\src-tauri/src/module_runtime/\)**
- \manifest.rs\ — manifest parser and semver validation
- \egistry.rs\ — module state in SQLite (\nabled\, \source\, \path\, \ersion\)
- \install.rs\ — \.lumenpack\ zip extraction and dev-mode directory install
- \protocol.rs\ — \lumen-module://\ handler serving module files with enabled-check
- \dev_server.rs\ — local HTTP server on \127.0.0.1:5179\ (dev only) for CLI integration
- \mod.rs\ — all Tauri commands: \module_list_installed\, \module_install\, \module_get\, \module_enable\, \module_disable\, \module_uninstall\, JSON data API, scoped fs API
- \lib.rs\ — protocol registration, plugin setup, \ModuleRuntime\ state management

**TypeScript / Frontend (\src/modules/\)**
- \	ypes.ts\ — complete interfaces: \LumenHost\, \LumenPlugin\, \ModuleManifest\, \ModuleRecord\, \Disposable\, all host APIs including \PrefixSpec\/\PrefixResult\
- \store.ts\ — Zustand store with \modules: Map\ and \panels: Map\, crash counter
- \pis/\ — per-API implementations: bus, commands (add, invoke, addPrefix), data, domain stubs, fs, i18n, logger, menus, net, panels, settings, ui
- \host.ts\ — assembles \LumenHost\ per module instance
- \injector.ts\ — lifecycle engine: boot, load, unload, reload, install, disable, uninstall; crash quota (5 errors in 10 s → auto-disable); Disposable tracking
- \components/ModuleErrorBoundary.tsx\ — per-panel error boundary with Retry button
- \components/PanelSlot.tsx\ — renders panels contributed by modules into named slots

**Commander (command palette) — closes #42**
- Global Ctrl+K palette with unified search across lyrics, media (audio/video/image) and registered commands/apps
- Scoped filter tabs (All / Lyrics / Media / Commands), Title vs Global Search toggle
- TanStack Virtual list — renders only visible rows, handles 500+ results without DOM cost
- Keyboard nav: ↑↓ navigate, Tab cycles scope, Enter plays, Shift+Enter queues, Esc closes
- Enter/click → \lumen:commander-open\ with \ction: 'play'\: audio/video → \loadFile()\, lyrics → \presentLyric()\, image → \presentImage()\ (overlay on media window, over video)
- Shift+Enter/Shift+click → \ction: 'queue'\ → \queue.addToQueue()\
- **Prefix search** — built-in scope aliases (\lyric <q>\, \media <q>\, \cmd <q>\, etc.) + module \ddPrefix\ API for custom handlers (e.g. \ible 1jo 2:1\)
- Footer hints: icon-only keyboard shortcuts with tooltip on hover showing written shortcut (e.g. \Shift + Enter\)
- Removed FTS5 (unavailable in \@tauri-apps/plugin-sql\); replaced with LIKE + \#\ escape char
- Drops legacy FTS5 triggers on \connect()\ for existing databases
- Removed cmdk dependency (caused \Array.from\ crash with virtual items); plain div + manual nav

**UI**
- \Button\ component: \	itle\ prop now renders a Tooltip instead of the native browser tooltip

**Titlebar menu system**
- \host.menus.register()\ — registers a full menu in the titlebar
- \host.menus.addItem()\ — injects items into any existing menu by id
- Full submenu support, disposables tracked by injector

**Build / Infra**
- \scripts/vite-plugin-lumen-host-modules.ts\ — serves \/__lumen/\ shared modules
- \ite.config.ts\ — externalizes \eact\, \eact-dom\ from Rollup in production
- \index.html\ — import map with \eact\, \eact-dom\, \@lumen/ui\, \@lumen/module-sdk\

**Settings UI**
- \components/settings/modules-section.tsx\ — installed modules list with status badge, Reload/Disable/Uninstall buttons

**Documentation**
- \docs/module-api-reference.md\ — full API reference including commands, prefix search (with built-in aliases + \ddPrefix\ API), panels, menus, bus, data, ui and all domain stubs

### Why?
- Implements the module architecture from the design docs, allowing third-party modules to extend Lumen with panels, commands, menus, and integrations without modifying the host
- Commander provides fast access to all content and actions without leaving the keyboard
- Prefix search allows modules to create custom search experiences (e.g. bible references, contact lookup) directly inside the commander

## 🔗 Related Issues

- Closes #40
- Closes #42

## 🧪 How to Test

1. Run \pnpm tauri dev\
2. Press **Ctrl+K** to open the Commander — verify search returns lyrics, media and commands
3. Type \lyric <name>\ — results should filter to lyrics only automatically
4. Type \cmd <name>\ — results should filter to commands only
5. Press **Enter** on a result — audio/video should play, lyrics present, image shows on media window
6. Press **Shift+Enter** — item should be added to queue
7. Hover the footer shortcut badges — tooltip should show written shortcut (e.g. \Shift + Enter\)
8. Open Settings → Modules
9. Install a module via a local \.lumenpack\ or directory path
10. Verify module appears with status \ctive\ and its commands show up in the Commander

## ✅ Checklist

- [x] UX/API/contract impact covered
- [x] Docs or release notes updated
- [ ] Migrations/Seeds applied (if any)
- [x] Self-reviewed

## 📝 Additional Notes

- Cross-window bus sync (via existing WebSocket) is not yet wired to the module bus — planned follow-up
- \module_data_sqlite_*\ Rust commands are not yet registered — planned follow-up
- Dev mode toggle in Settings is future work

🤖 Generated with [Claude Code](https://claude.com/claude-code)