### PR TITLE
feat/add-new-apis-suport

### DIFF
--- a/docs/module-api-reference.md
+++ b/docs/module-api-reference.md
@@ -527,6 +527,47 @@ Exposed on the host but still only wired via bus — read methods return empty/d
 
 ---
 
+## `host.themes` — background APIs ✅
+
+Two methods on `host.themes` are fully implemented and read real profile state.
+
+### `defaultBackground()`
+
+Returns the active profile's default background, or `null` if none is set.
+
+```ts
+const bg = host.themes.defaultBackground()
+// { type: 'theme' | 'image' | 'video', src: string, name: string } | null
+```
+
+> **Do not call this at `onload` and store the result.** The profile store may not be hydrated yet when the module loads — `defaultBackground()` can return `null` even when a background is configured. Use `onDefaultBackgroundChange` instead.
+
+### `onDefaultBackgroundChange(handler)`
+
+Subscribes to background changes and fires immediately with the current value once the profile store is ready. The handler receives a blob URL — the host reads the file using Lumen's own filesystem access before calling back.
+
+```ts
+// In onload:
+const hostExt = host as unknown as {
+  themes: {
+    onDefaultBackgroundChange?: (
+      handler: (bg: { src: string; type: string; name: string } | null) => void
+    ) => { dispose(): void }
+  }
+}
+
+hostExt.themes.onDefaultBackgroundChange?.((bg) => {
+  if (!bg) return
+  // bg.src is already a blob URL — safe to use directly in <img> or CSS
+})
+```
+
+**Why the cast?** This method is not yet in the public SDK types (`ThemesHostAPI`). It exists on the Lumen runtime but is accessed via `as unknown as` until the next SDK minor adds it.
+
+**Why not use `host.fs.read()` yourself?** Module file access (`host.fs`) is sandboxed to the module's own data directory. Reading arbitrary paths from the host filesystem (e.g. theme image files stored under `lumen/files/media/themes/`) will throw `path traversal attempt blocked`. The host reads those files on your behalf and delivers a blob URL.
+
+---
+
 ## `host.menus` ✅
 
 Registers menus and menu items in the application titlebar.

--- a/docs/module-api-reference.md
+++ b/docs/module-api-reference.md
@@ -756,7 +756,7 @@ host.menus.register({
 
 ## `host.queue.registerTrigger`
 
-Registers a custom trigger in the queue. Active triggers fire whenever any queue item plays.
+Registers a queue trigger. Triggers are placed **between** items in the queue and intercept the auto-advance flow — when the item before the trigger finishes playing, the trigger fires before the next item loads.
 
 ```ts
 import { Timer } from 'lucide-react'
@@ -765,33 +765,69 @@ host.queue.registerTrigger({
   id: 'my-module.timer',
   label: 'Countdown Timer',
   icon: Timer,
-  ConfigComponent: TimerConfig,   // React component for configuration UI
+  ConfigComponent: TimerConfig,
+  SummaryComponent: TimerSummary,   // optional — shown inline in the queue item
   defaultConfig: { totalSeconds: 300 },
   onFire(config) {
-    // called when the queue item this trigger is attached to starts playing
     startMyTimer(config.totalSeconds)
+    // call host.queue.next() when done to advance to the next queue item
   },
 })
 ```
 
+### Auto-advance flow
+
+Triggers intercept the queue's auto-advance — they do **not** fire when the user manually plays an item.
+
+```
+[Video A ends] → advanceQueue() finds trigger T between A and B
+              → calls T.onFire(config)          ← your module runs
+              → queue pauses here
+              → module calls host.queue.next()  ← when done
+              → advanceQueue() resumes, finds Video B
+              → Video B plays
+```
+
+The trigger is responsible for calling `host.queue.next()` when it's done — that's what unblocks the queue. Multiple triggers between the same two items fire in order, each waiting for `next()` before the next fires.
+
 ### How it works in the app
 
-1. User right-clicks anywhere in the queue area → context menu shows registered triggers directly
-2. User clicks a trigger → a dialog opens with `ConfigComponent` rendered
-3. User configures and confirms → trigger instance saved to the queue
-4. Any queue item plays → Lumen calls `onFire(config)` for all active trigger instances
-5. Active triggers are shown in a "Queue Triggers" section at the bottom of the queue panel
+1. User right-clicks anywhere in the queue panel → context menu shows registered trigger types
+2. User selects a trigger type → config dialog opens with `ConfigComponent` rendered
+3. User confirms → trigger instance is inserted into the queue as a draggable item
+4. Trigger instances can be dragged to any position between queue items
+5. Each trigger item has a label toggle (tag icon) — hides or shows the spec label text
+6. `SummaryComponent` (if provided) renders inside the item to show config values compactly
 
 ### `QueueTriggerSpec<T>`
 
 | Field | Type | Required | Description |
 |---|---|---|---|
 | `id` | `string` | ✓ | Unique identifier (`module-id.name`) |
-| `label` | `string` | ✓ | Displayed in the context menu and chip badge |
+| `label` | `string` | ✓ | Shown in the context menu and togglable in the queue item |
 | `icon` | `ComponentType` | | Lucide or custom icon |
-| `ConfigComponent` | `ComponentType<{ value: T; onChange: (v: T) => void }>` | ✓ | Rendered in the config popover |
+| `ConfigComponent` | `ComponentType<{ value: T; onChange: (v: T) => void }>` | ✓ | Rendered in the config dialog |
+| `SummaryComponent` | `ComponentType<{ value: T; onEdit: () => void }>` | | Compact inline display of the config — rendered inside the queue item |
 | `defaultConfig` | `T` | ✓ | Initial value for new trigger instances |
-| `onFire` | `(config: T) => void` | ✓ | Called when the queue item plays |
+| `onFire` | `(config: T) => void` | ✓ | Called when the queue auto-advances past this trigger |
+
+### `SummaryComponent`
+
+When provided, `SummaryComponent` is rendered inside the trigger's queue item instead of (or alongside) the label. Use it to show a compact representation of the current config — e.g. a countdown module showing `"5:00"` instead of `"Wait (Countdown)"`.
+
+```tsx
+function TimerSummary({ value, onEdit }: { value: TimerConfig; onEdit: () => void }) {
+  const mins = Math.floor(value.totalSeconds / 60)
+  const secs = value.totalSeconds % 60
+  return (
+    <button onClick={onEdit} className="font-mono text-sm text-primary">
+      {mins}:{String(secs).padStart(2, '0')}
+    </button>
+  )
+}
+```
+
+`onEdit` opens the standard config dialog when called. The summary is display-only by default — clicking it is the recommended way to open the edit dialog from a custom component.
 
 Returns a `Disposable` — registered trigger is removed on module unload.
 

--- a/docs/module-api-reference.md
+++ b/docs/module-api-reference.md
@@ -754,9 +754,9 @@ host.menus.register({
 
 ---
 
-## `host.queue.registerTrigger` 🚧 (planned)
+## `host.queue.registerTrigger`
 
-Registers a custom trigger that users can attach to queue items. When the queue item plays, Lumen calls `onFire` with the saved config.
+Registers a custom trigger in the queue. Active triggers fire whenever any queue item plays.
 
 ```ts
 import { Timer } from 'lucide-react'
@@ -776,11 +776,11 @@ host.queue.registerTrigger({
 
 ### How it works in the app
 
-1. User right-clicks a queue item → context menu shows a "Triggers" submenu listing registered triggers
-2. User selects a trigger → a popover opens with `ConfigComponent` rendered
-3. User configures and confirms → trigger instance saved on that queue item
-4. Queue item plays → Lumen calls `onFire(config)`
-5. Queue item shows a small chip badge indicating a trigger is attached
+1. User right-clicks anywhere in the queue area → context menu shows registered triggers directly
+2. User clicks a trigger → a dialog opens with `ConfigComponent` rendered
+3. User configures and confirms → trigger instance saved to the queue
+4. Any queue item plays → Lumen calls `onFire(config)` for all active trigger instances
+5. Active triggers are shown in a "Queue Triggers" section at the bottom of the queue panel
 
 ### `QueueTriggerSpec<T>`
 
@@ -795,7 +795,6 @@ host.queue.registerTrigger({
 
 Returns a `Disposable` — registered trigger is removed on module unload.
 
-> 🚧 `registerTrigger` is not yet implemented in the Lumen app or the SDK. The spec and module-side implementation can be written in advance. See `docs/plan.md` for the full design.
 
 ---
 

--- a/docs/module-api-reference.md
+++ b/docs/module-api-reference.md
@@ -282,7 +282,36 @@ if (name !== null) { /* user confirmed */ }
 // Open command palette
 host.ui.openCommandPalette();
 host.ui.openCommandPalette('search');  // with prefilter
+
+// Open the background picker — lets the user choose a theme/image/video background
+host.ui.openBackgroundPicker((bg) => {
+  // bg: { type: 'theme' | 'image' | 'video', src: string, name: string }
+  console.log('Selected background:', bg.src)
+})
+
+// Open the media picker — lets the user choose a library item (image, audio, video, lyric, presentation)
+host.ui.openMediaPicker((item) => {
+  // item: LibraryItem
+  console.log('Selected media:', item.id, item.title, item.type)
+})
 ```
+
+### `LibraryItem`
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | `string` | Library item ID |
+| `title` | `string` | Display name |
+| `type` | `'image' \| 'audio' \| 'video' \| 'lyric' \| 'presentation'` | Media type |
+| `thumbnail` | `string` (optional) | Thumbnail URL/blob |
+
+### `SelectedBackground`
+
+| Field | Type | Description |
+|---|---|---|
+| `type` | `'theme' \| 'image' \| 'video'` | Background type |
+| `src` | `string` | Blob URL or theme identifier |
+| `name` | `string` | Display name |
 
 ---
 
@@ -512,18 +541,80 @@ const locale = host.i18n.locale();
 
 ---
 
+## `host.queue` ⚠️
+
+Read state and navigate the playback queue.
+
+```ts
+// Read current state
+const state = host.queue.state()
+// { items: QueueItem[], currentIndex: number | null }
+
+// Subscribe to changes
+const unsub = host.queue.onChange((state) => {
+  console.log('Current item:', state.items[state.currentIndex ?? 0])
+})
+unsub.dispose()
+
+// Navigation
+host.queue.next()
+host.queue.previous()
+host.queue.goTo(2)   // 0-based index
+```
+
+### `QueueItem`
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | `string` | Unique item identifier |
+| `title` | `string` | Display title |
+
+### `QueueHostAPI`
+
+| Method | Returns | Description |
+|---|---|---|
+| `state()` | `QueueState` | Current items + currentIndex |
+| `onChange(handler)` | `Disposable` | Subscribe to state changes |
+| `next()` | `void` | Advance to next item |
+| `previous()` | `void` | Go to previous item |
+| `goTo(index)` | `void` | Jump to specific index |
+
+> ⚠️ `state()` read and `onChange` work. Write navigation methods (`next`, `previous`, `goTo`) emit via the app event bus.
+
+---
+
+## `host.player` ⚠️
+
+Control the active media player.
+
+```ts
+// Advance to next slide (for presentations/lyrics)
+host.player.nextSlide()
+
+// Play a specific library item by ID
+host.player.play('media-item-id')
+```
+
+### `PlayerHostAPI`
+
+| Method | Returns | Description |
+|---|---|---|
+| `nextSlide()` | `void` | Advances to next slide in the active presentation/lyric |
+| `play(itemId)` | `void` | Plays the library item with the given ID |
+
+> ⚠️ Methods emit via bus — full read state (`current()`, `state()`, `volume()`) not yet wired.
+
+---
+
 ## Domain APIs 🚧
 
-Exposed on the host but still only wired via bus — read methods return empty/default data. Use them only to emit events for now; to react to real app state, prefer `host.bus.on(...)`.
+Still only wired via bus — read methods return empty/default data.
 
 | API | Read methods | Write methods |
 |---|---|---|
 | `host.lyrics` | `list()` → `[]`, `get()` → `null`, `currentSlide()` → `null` | `advance()`, `back()` emit on bus |
-| `host.queue` | `items()` → `[]`, `currentIndex()` → `-1` | `add()`, `remove()`, `reorder()`, `shuffle()`, `markPlayed()` emit on bus |
 | `host.library` | `list()` → `[]`, `get()` → `null` | — |
-| `host.player` | `current()` → `null`, `state()` → `'idle'`, `volume()` → `1` | `play()`, `pause()`, `seek()`, `next()`, `prev()` emit on bus |
 | `host.presentation` | `state()` → `'idle'`, `isWindowOpen()` → `false` | `project()`, `clear()` emit on bus |
-| `host.themes` | `current()` → default theme, `list()` → `[default theme]` | `apply()` emits on bus |
 
 ---
 
@@ -660,6 +751,51 @@ host.menus.register({
 | `'live'` | Live |
 | `'modules'` | Modules |
 | `'help'` | Help |
+
+---
+
+## `host.queue.registerTrigger` 🚧 (planned)
+
+Registers a custom trigger that users can attach to queue items. When the queue item plays, Lumen calls `onFire` with the saved config.
+
+```ts
+import { Timer } from 'lucide-react'
+
+host.queue.registerTrigger({
+  id: 'my-module.timer',
+  label: 'Countdown Timer',
+  icon: Timer,
+  ConfigComponent: TimerConfig,   // React component for configuration UI
+  defaultConfig: { totalSeconds: 300 },
+  onFire(config) {
+    // called when the queue item this trigger is attached to starts playing
+    startMyTimer(config.totalSeconds)
+  },
+})
+```
+
+### How it works in the app
+
+1. User right-clicks a queue item → context menu shows a "Triggers" submenu listing registered triggers
+2. User selects a trigger → a popover opens with `ConfigComponent` rendered
+3. User configures and confirms → trigger instance saved on that queue item
+4. Queue item plays → Lumen calls `onFire(config)`
+5. Queue item shows a small chip badge indicating a trigger is attached
+
+### `QueueTriggerSpec<T>`
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | `string` | ✓ | Unique identifier (`module-id.name`) |
+| `label` | `string` | ✓ | Displayed in the context menu and chip badge |
+| `icon` | `ComponentType` | | Lucide or custom icon |
+| `ConfigComponent` | `ComponentType<{ value: T; onChange: (v: T) => void }>` | ✓ | Rendered in the config popover |
+| `defaultConfig` | `T` | ✓ | Initial value for new trigger instances |
+| `onFire` | `(config: T) => void` | ✓ | Called when the queue item plays |
+
+Returns a `Disposable` — registered trigger is removed on module unload.
+
+> 🚧 `registerTrigger` is not yet implemented in the Lumen app or the SDK. The spec and module-side implementation can be written in advance. See `docs/plan.md` for the full design.
 
 ---
 

--- a/docs/module-api-reference.md
+++ b/docs/module-api-reference.md
@@ -100,13 +100,17 @@ host.panels.add({
 
 | Value | Position |
 |---|---|
-| `'sidebar.right.tabs'` | Right sidebar tab |
-| `'toolbar'` | Toolbar |
-| `'statusbar'` | Bottom status bar |
-| `'presenter.content'` | Presenter window |
-| `'dialog'` | Modal over content |
+| `'sidebar.left.tabs'` | Left sidebar tab area |
+| `'sidebar.right.tabs'` | Right sidebar tab area |
+| `'main.center'` | Main center content area |
+| `'dialog'` | Modal content opened through `host.ui.openDialog(id)` |
+| `'presenter.content'` | Presenter/media output surface |
+| `'settings.section'` | Settings page section |
+| `'command-palette.section'` | Section inside the command palette |
+| `'editor.lyrics.toolbar'` | Lyrics editor toolbar area |
+| `'app.header.trailing'` | Compact slot at the start of the header's right-side controls |
 
-> ⚠️ No `<PanelSlot>` is placed in the app layout yet. Panels register successfully but are not visually rendered until slots are inserted.
+The host only renders some slots today. `dialog`, `presenter.content`, and `app.header.trailing` are active surfaces in the current app shell; the remaining slots are part of the typed contract and may be wired progressively.
 
 ---
 
@@ -879,3 +883,5 @@ export default class ExamplePlugin extends LumenPlugin {
   }
 }
 ```
+
+

--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.5.0",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@radix-ui/react-progress": "^1.1.7",
     "@radix-ui/react-slider": "^1.3.6",
     "@radix-ui/react-slot": "^1.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,18 @@ importers:
       '@base-ui/react':
         specifier: ^1.5.0
         version: 1.5.0(@date-fns/tz@1.4.1)(@types/react@19.1.10)(date-fns@4.1.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@dnd-kit/modifiers':
+        specifier: ^9.0.0
+        version: 9.0.0(@dnd-kit/core@6.3.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.1.1)
       '@radix-ui/react-progress':
         specifier: ^1.1.7
         version: 1.1.7(@types/react-dom@19.1.7(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -527,6 +539,34 @@ packages:
 
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/modifiers@9.0.0':
+    resolution: {integrity: sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@esbuild/aix-ppc64@0.25.9':
     resolution: {integrity: sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==}
@@ -3318,6 +3358,38 @@ snapshots:
     optional: true
 
   '@date-fns/tz@1.4.1': {}
+
+  '@dnd-kit/accessibility@3.1.1(react@19.1.1)':
+    dependencies:
+      react: 19.1.1
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.1.1)
+      '@dnd-kit/utilities': 3.2.2(react@19.1.1)
+      react: 19.1.1
+      react-dom: 19.1.1(react@19.1.1)
+      tslib: 2.8.1
+
+  '@dnd-kit/modifiers@9.0.0(@dnd-kit/core@6.3.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@dnd-kit/utilities': 3.2.2(react@19.1.1)
+      react: 19.1.1
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react@19.1.1)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@dnd-kit/utilities': 3.2.2(react@19.1.1)
+      react: 19.1.1
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.1.1)':
+    dependencies:
+      react: 19.1.1
+      tslib: 2.8.1
 
   '@esbuild/aix-ppc64@0.25.9':
     optional: true

--- a/scripts/vite-plugin-lumen-host-modules.ts
+++ b/scripts/vite-plugin-lumen-host-modules.ts
@@ -24,7 +24,7 @@ export class LumenPlugin {
 
 const HOST_DEPS_PROD: Record<string, string> = {
   'react.js': 'react',
-  'react-dom.js': 'react-dom/client',
+  'react-dom.js': 'react-dom',
   'react-jsx-runtime.js': 'react/jsx-runtime',
   'react-jsx-dev-runtime.js': 'react/jsx-dev-runtime',
 };
@@ -166,7 +166,7 @@ export function lumenHostModules(): Plugin {
 
         const DEV_WRAPPERS: Record<string, string> = {
           'react.js': 'react',
-          'react-dom.js': 'react-dom/client',
+          'react-dom.js': 'react-dom',
           'react-jsx-runtime.js': 'react/jsx-runtime',
           'react-jsx-dev-runtime.js': 'react/jsx-dev-runtime',
         };

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -34,6 +34,7 @@
     "core:window:allow-is-fullscreen",
     "core:window:allow-inner-position",
     "core:window:allow-close",
+    "core:window:allow-destroy",
     "core:window:allow-minimize",
     "core:window:allow-unminimize",
     "core:window:allow-toggle-maximize",

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -4,7 +4,8 @@
   "description": "Capability for the main window",
   "windows": [
     "main",
-    "media-window"
+    "media-window",
+    "module-overlay-window"
   ],
   "permissions": [
     "core:default",

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -61,15 +61,22 @@ async fn create_window(
     label: String,
     title: String,
     route: Option<String>,
+    fullscreen: Option<bool>,
+    decorations: Option<bool>,
+    width: Option<f64>,
+    height: Option<f64>,
     window_state: State<'_, WindowState>,
 ) -> Result<(), String> {
     let main_window = app_handle
         .get_webview_window("main")
         .ok_or_else(|| "Main window not found".to_string())?;
 
-    let saved_position = {
+    let open_fullscreen = fullscreen.unwrap_or(true);
+    let saved_position = if open_fullscreen {
         let positions = window_state.positions.lock().unwrap();
         positions.get(&label).cloned()
+    } else {
+        None
     };
 
     let target_position = if let Some((saved_x, saved_y)) = saved_position {
@@ -77,7 +84,7 @@ async fn create_window(
             x: saved_x,
             y: saved_y,
         }
-    } else {
+    } else if open_fullscreen {
         let current_monitor = main_window
             .current_monitor()
             .map_err(|e| format!("Failed to get current monitor: {}", e))?
@@ -106,16 +113,25 @@ async fn create_window(
             x: monitor_position.x,
             y: monitor_position.y,
         }
-    };
+    } else {
+        let main_position = main_window
+            .outer_position()
+            .map_err(|e| format!("Failed to get main window position: {}", e))?;
 
+        tauri::PhysicalPosition {
+            x: main_position.x + 80,
+            y: main_position.y + 80,
+        }
+    };
     let window = tauri::WebviewWindowBuilder::new(
         &app_handle,
         &label,
         tauri::WebviewUrl::App(route.unwrap_or_else(|| "/media-window".to_string()).into()),
     )
     .title(&title)
-    .decorations(false)
-    .fullscreen(true)
+    .decorations(decorations.unwrap_or(!open_fullscreen))
+    .fullscreen(open_fullscreen)
+    .inner_size(width.unwrap_or(960.0), height.unwrap_or(540.0))
     .visible(false)
     .build()
     .map_err(|e| format!("Failed to create window: {}", e))?;
@@ -124,13 +140,15 @@ async fn create_window(
         .set_position(tauri::Position::Physical(target_position))
         .map_err(|e| format!("Failed to set window position: {}", e))?;
 
-    window
-        .set_fullscreen(true)
-        .map_err(|e| format!("Failed to set fullscreen: {}", e))?;
+    if open_fullscreen {
+        window
+            .set_fullscreen(true)
+            .map_err(|e| format!("Failed to set fullscreen: {}", e))?;
 
-    {
-        let mut positions = window_state.positions.lock().unwrap();
-        positions.insert(label.clone(), (target_position.x, target_position.y));
+        {
+            let mut positions = window_state.positions.lock().unwrap();
+            positions.insert(label.clone(), (target_position.x, target_position.y));
+        }
     }
 
     Ok(())

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -160,6 +160,7 @@ async fn create_overlay_window(
     .decorations(true)
     .fullscreen(false)
     .inner_size(960.0, 540.0)
+    .min_inner_size(720.0, 405.0)
     .visible(false)
     .build()
     .map_err(|e| format!("Failed to create overlay window: {}", e))?;
@@ -402,3 +403,4 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -61,22 +61,15 @@ async fn create_window(
     label: String,
     title: String,
     route: Option<String>,
-    fullscreen: Option<bool>,
-    decorations: Option<bool>,
-    width: Option<f64>,
-    height: Option<f64>,
     window_state: State<'_, WindowState>,
 ) -> Result<(), String> {
     let main_window = app_handle
         .get_webview_window("main")
         .ok_or_else(|| "Main window not found".to_string())?;
 
-    let open_fullscreen = fullscreen.unwrap_or(true);
-    let saved_position = if open_fullscreen {
+    let saved_position = {
         let positions = window_state.positions.lock().unwrap();
         positions.get(&label).cloned()
-    } else {
-        None
     };
 
     let target_position = if let Some((saved_x, saved_y)) = saved_position {
@@ -84,7 +77,7 @@ async fn create_window(
             x: saved_x,
             y: saved_y,
         }
-    } else if open_fullscreen {
+    } else {
         let current_monitor = main_window
             .current_monitor()
             .map_err(|e| format!("Failed to get current monitor: {}", e))?
@@ -113,25 +106,16 @@ async fn create_window(
             x: monitor_position.x,
             y: monitor_position.y,
         }
-    } else {
-        let main_position = main_window
-            .outer_position()
-            .map_err(|e| format!("Failed to get main window position: {}", e))?;
-
-        tauri::PhysicalPosition {
-            x: main_position.x + 80,
-            y: main_position.y + 80,
-        }
     };
+
     let window = tauri::WebviewWindowBuilder::new(
         &app_handle,
         &label,
         tauri::WebviewUrl::App(route.unwrap_or_else(|| "/media-window".to_string()).into()),
     )
     .title(&title)
-    .decorations(decorations.unwrap_or(!open_fullscreen))
-    .fullscreen(open_fullscreen)
-    .inner_size(width.unwrap_or(960.0), height.unwrap_or(540.0))
+    .decorations(false)
+    .fullscreen(true)
     .visible(false)
     .build()
     .map_err(|e| format!("Failed to create window: {}", e))?;
@@ -140,16 +124,52 @@ async fn create_window(
         .set_position(tauri::Position::Physical(target_position))
         .map_err(|e| format!("Failed to set window position: {}", e))?;
 
-    if open_fullscreen {
-        window
-            .set_fullscreen(true)
-            .map_err(|e| format!("Failed to set fullscreen: {}", e))?;
+    window
+        .set_fullscreen(true)
+        .map_err(|e| format!("Failed to set fullscreen: {}", e))?;
 
-        {
-            let mut positions = window_state.positions.lock().unwrap();
-            positions.insert(label.clone(), (target_position.x, target_position.y));
-        }
+    {
+        let mut positions = window_state.positions.lock().unwrap();
+        positions.insert(label.clone(), (target_position.x, target_position.y));
     }
+
+    Ok(())
+}
+
+#[tauri::command]
+async fn create_overlay_window(
+    app_handle: tauri::AppHandle,
+    label: String,
+    title: String,
+    route: Option<String>,
+) -> Result<(), String> {
+    let main_window = app_handle
+        .get_webview_window("main")
+        .ok_or_else(|| "Main window not found".to_string())?;
+
+    let main_position = main_window
+        .outer_position()
+        .map_err(|e| format!("Failed to get main window position: {}", e))?;
+
+    let window = tauri::WebviewWindowBuilder::new(
+        &app_handle,
+        &label,
+        tauri::WebviewUrl::App(route.unwrap_or_else(|| "/module-overlay-window".to_string()).into()),
+    )
+    .title(&title)
+    .decorations(true)
+    .fullscreen(false)
+    .inner_size(960.0, 540.0)
+    .visible(false)
+    .build()
+    .map_err(|e| format!("Failed to create overlay window: {}", e))?;
+
+    window
+        .set_position(tauri::Position::Physical(tauri::PhysicalPosition {
+            x: main_position.x + 80,
+            y: main_position.y + 80,
+        }))
+        .map_err(|e| format!("Failed to set overlay window position: {}", e))?;
 
     Ok(())
 }
@@ -339,6 +359,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             get_exe_dir,
             open_folder,
             create_window,
+            create_overlay_window,
             save_window_position,
             get_system_fonts,
             get_system_info,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -60,6 +60,7 @@ async fn create_window(
     app_handle: tauri::AppHandle,
     label: String,
     title: String,
+    route: Option<String>,
     window_state: State<'_, WindowState>,
 ) -> Result<(), String> {
     let main_window = app_handle
@@ -110,7 +111,7 @@ async fn create_window(
     let window = tauri::WebviewWindowBuilder::new(
         &app_handle,
         &label,
-        tauri::WebviewUrl::App("/media-window".into()),
+        tauri::WebviewUrl::App(route.unwrap_or_else(|| "/media-window".to_string()).into()),
     )
     .title(&title)
     .decorations(false)

--- a/src/App.css
+++ b/src/App.css
@@ -112,6 +112,18 @@
 }
 
 @layer base {
+  html,
+  body,
+  #root {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+  }
+
+  body {
+    overflow: hidden;
+  }
+
   [data-tauri-drag-region] {
     app-region: drag;
   }

--- a/src/app/__root.tsx
+++ b/src/app/__root.tsx
@@ -15,21 +15,29 @@ export const Route = createRootRoute({
   component: RootComponent,
 });
 
+const AUXILIARY_WINDOW_PATHS = new Set(['/media-window', '/module-overlay-window']);
+
 function RootComponent() {
-  useSingleInstance();
+  const isAuxiliaryWindow = AUXILIARY_WINDOW_PATHS.has(window.location.pathname);
+
+  useSingleInstance(!isAuxiliaryWindow);
   useTheme();
   useProfiles();
-  useModules();
+  useModules(!isAuxiliaryWindow);
 
   return (
     <React.Fragment>
       <Outlet />
-      <Toaster />
-      <GlobalAlert />
-      <QuickShortcutsModal />
-      <LyricModal />
-      <DialogSlot />
-      <BackgroundPickerSlot />
+      {!isAuxiliaryWindow && (
+        <React.Fragment>
+          <Toaster />
+          <GlobalAlert />
+          <QuickShortcutsModal />
+          <LyricModal />
+          <DialogSlot />
+          <BackgroundPickerSlot />
+        </React.Fragment>
+      )}
     </React.Fragment>
   );
 }

--- a/src/app/media-window.tsx
+++ b/src/app/media-window.tsx
@@ -2,14 +2,13 @@ import { createFileRoute } from '@tanstack/react-router';
 import { invoke } from '@tauri-apps/api/core';
 import { emit, listen } from '@tauri-apps/api/event';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { PresenterBackdrop, PresenterSlot } from '@/modules/components/PresenterSlot';
+import { PresenterSlot } from '@/modules/components/PresenterSlot';
 import { bootPresenterModules } from '@/modules/presenter-injector';
 import { useModuleStore } from '@/modules/store';
 import { useDebounceCallback, useEventListener, useInterval } from 'usehooks-ts';
 
 import { LyricPresentation } from '@/components/lyric-presentation';
 import { Videoplayer } from '@/components/ui/videoplayer';
-import { usePlayerStore } from '@/stores/player-store';
 
 function StreamOverlay() {
   const videoRef = useRef<HTMLVideoElement | null>(null);
@@ -128,8 +127,6 @@ function MediaWindowComponent() {
   const [lyricStartIndex, setLyricStartIndex] = useState(0);
   const [imagePath, setImagePath] = useState<string | null>(null);
   const [streamOverlayActive, setStreamOverlayActive] = useState(false);
-  const currentFilePath = usePlayerStore((s) => s.currentFilePath);
-  const localMediaType = usePlayerStore((s) => s.localMediaType);
 
   const saveCurrentPosition = useCallback(async () => {
     try {
@@ -305,15 +302,8 @@ function MediaWindowComponent() {
     isFullscreen ? null : 1000
   );
 
-  const hostVisualActive =
-    Boolean(imagePath) ||
-    (mode === 'lyric' && Boolean(lyricPath)) ||
-    streamOverlayActive ||
-    (localMediaType === 'video' && Boolean(currentFilePath));
-
   return (
-    <div className="relative h-dvh w-dvw bg-black">
-      {!hostVisualActive && <PresenterBackdrop />}
+    <div className="fixed inset-0 h-dvh w-dvw overflow-hidden bg-black">
       <Videoplayer className="h-full w-full" url="" autoplay muted={false} interactive={false} />
       {imagePath && mode !== 'lyric' && (
         <button
@@ -339,7 +329,7 @@ function MediaWindowComponent() {
           <StreamOverlay />
         </div>
       )}
-      <PresenterSlot renderBackdrop={false} />
+      <PresenterSlot />
     </div>
   );
 }

--- a/src/app/media-window.tsx
+++ b/src/app/media-window.tsx
@@ -2,13 +2,14 @@ import { createFileRoute } from '@tanstack/react-router';
 import { invoke } from '@tauri-apps/api/core';
 import { emit, listen } from '@tauri-apps/api/event';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { PresenterSlot } from '@/modules/components/PresenterSlot';
+import { PresenterBackdrop, PresenterSlot } from '@/modules/components/PresenterSlot';
 import { bootPresenterModules } from '@/modules/presenter-injector';
 import { useModuleStore } from '@/modules/store';
 import { useDebounceCallback, useEventListener, useInterval } from 'usehooks-ts';
 
 import { LyricPresentation } from '@/components/lyric-presentation';
 import { Videoplayer } from '@/components/ui/videoplayer';
+import { usePlayerStore } from '@/stores/player-store';
 
 function StreamOverlay() {
   const videoRef = useRef<HTMLVideoElement | null>(null);
@@ -127,6 +128,8 @@ function MediaWindowComponent() {
   const [lyricStartIndex, setLyricStartIndex] = useState(0);
   const [imagePath, setImagePath] = useState<string | null>(null);
   const [streamOverlayActive, setStreamOverlayActive] = useState(false);
+  const currentFilePath = usePlayerStore((s) => s.currentFilePath);
+  const localMediaType = usePlayerStore((s) => s.localMediaType);
 
   const saveCurrentPosition = useCallback(async () => {
     try {
@@ -302,8 +305,15 @@ function MediaWindowComponent() {
     isFullscreen ? null : 1000
   );
 
+  const hostVisualActive =
+    Boolean(imagePath) ||
+    (mode === 'lyric' && Boolean(lyricPath)) ||
+    streamOverlayActive ||
+    (localMediaType === 'video' && Boolean(currentFilePath));
+
   return (
     <div className="relative h-dvh w-dvw bg-black">
+      {!hostVisualActive && <PresenterBackdrop />}
       <Videoplayer className="h-full w-full" url="" autoplay muted={false} interactive={false} />
       {imagePath && mode !== 'lyric' && (
         <button
@@ -329,8 +339,7 @@ function MediaWindowComponent() {
           <StreamOverlay />
         </div>
       )}
-      <PresenterSlot />
+      <PresenterSlot renderBackdrop={false} />
     </div>
   );
 }
-

--- a/src/app/media-window.tsx
+++ b/src/app/media-window.tsx
@@ -198,23 +198,24 @@ function MediaWindowComponent() {
     }
   };
 
-  const checkFullscreenState = async () => {
+  const ensureDefaultWindowMode = useCallback(async () => {
     try {
       const { getCurrentWebviewWindow } = await import('@tauri-apps/api/webviewWindow');
       const window = getCurrentWebviewWindow();
 
       if (window) {
-        const fullscreen = await window.isFullscreen();
-        setIsFullscreen(fullscreen);
+        await window.setFullscreen(true);
+        await setDecorations(false);
+        setIsFullscreen(true);
       }
     } catch (error) {
-      console.error('Failed to check fullscreen state:', error);
+      console.error('Failed to enforce media window defaults:', error);
     }
-  };
+  }, []);
 
   useEffect(() => {
-    checkFullscreenState();
-  }, []);
+    void ensureDefaultWindowMode();
+  }, [ensureDefaultWindowMode]);
 
   useEffect(() => {
     emit('media-window-ready').catch(() => {});
@@ -332,3 +333,4 @@ function MediaWindowComponent() {
     </div>
   );
 }
+

--- a/src/app/module-overlay-window.tsx
+++ b/src/app/module-overlay-window.tsx
@@ -20,9 +20,22 @@ function ModuleOverlayWindow() {
   }, []);
 
   useEffect(() => {
-    const onUnload = () => emit('module:overlay-window-closed').catch(() => {});
-    window.addEventListener('beforeunload', onUnload);
-    return () => window.removeEventListener('beforeunload', onUnload);
+    let detachCloseListener: (() => void) | undefined;
+
+    import('@tauri-apps/api/window')
+      .then(({ getCurrentWindow }) => getCurrentWindow().onCloseRequested(() => {
+        emit('module:overlay-window-closed').catch(() => {});
+      }))
+      .then((unlisten) => {
+        detachCloseListener = unlisten;
+      })
+      .catch((error) => {
+        console.error('Failed to bind overlay close listener:', error);
+      });
+
+    return () => {
+      detachCloseListener?.();
+    };
   }, []);
 
   useEffect(() => {

--- a/src/app/module-overlay-window.tsx
+++ b/src/app/module-overlay-window.tsx
@@ -1,0 +1,43 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { emit, listen } from '@tauri-apps/api/event';
+import { useEffect } from 'react';
+import { PresenterSlot } from '@/modules/components/PresenterSlot';
+import { bootPresenterModules } from '@/modules/presenter-injector';
+import { useModuleStore } from '@/modules/store';
+
+export const Route = createFileRoute('/module-overlay-window')({
+  component: ModuleOverlayWindow,
+});
+
+function ModuleOverlayWindow() {
+  useEffect(() => {
+    const onUnload = () => emit('module:overlay-window-closed').catch(() => {});
+    window.addEventListener('beforeunload', onUnload);
+    return () => window.removeEventListener('beforeunload', onUnload);
+  }, []);
+
+  useEffect(() => {
+    bootPresenterModules()
+      .then(() => emit('module:overlay-ready').catch(() => {}))
+      .catch(console.error);
+
+    const unlistenProject = listen<{ viewId: string; props: unknown }>('module:overlay-project', (event) => {
+      useModuleStore.getState().projectPanel(event.payload.viewId, event.payload.props);
+    });
+
+    const unlistenClear = listen('module:overlay-clear', () => {
+      useModuleStore.getState().clearPresenter();
+    });
+
+    return () => {
+      unlistenProject.then((dispose) => dispose());
+      unlistenClear.then((dispose) => dispose());
+    };
+  }, []);
+
+  return (
+    <div className="relative h-dvh w-dvw bg-transparent overflow-hidden">
+      <PresenterSlot />
+    </div>
+  );
+}

--- a/src/app/module-overlay-window.tsx
+++ b/src/app/module-overlay-window.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { emit, listen } from '@tauri-apps/api/event';
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { PresenterSlot } from '@/modules/components/PresenterSlot';
 import { bootPresenterModules } from '@/modules/presenter-injector';
 import { useModuleStore } from '@/modules/store';
@@ -10,6 +10,15 @@ export const Route = createFileRoute('/module-overlay-window')({
 });
 
 function ModuleOverlayWindow() {
+  const closeWindow = useCallback(async () => {
+    try {
+      const { getCurrentWebviewWindow } = await import('@tauri-apps/api/webviewWindow');
+      await getCurrentWebviewWindow().close();
+    } catch (error) {
+      console.error('Failed to close overlay window:', error);
+    }
+  }, []);
+
   useEffect(() => {
     const onUnload = () => emit('module:overlay-window-closed').catch(() => {});
     window.addEventListener('beforeunload', onUnload);
@@ -17,26 +26,54 @@ function ModuleOverlayWindow() {
   }, []);
 
   useEffect(() => {
-    bootPresenterModules()
-      .then(() => emit('module:overlay-ready').catch(() => {}))
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return;
+      event.preventDefault();
+      void closeWindow();
+    };
+
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [closeWindow]);
+
+  useEffect(() => {
+    let cancelled = false;
+    let disposeProject: (() => void) | null = null;
+    let disposeClear: (() => void) | null = null;
+
+    Promise.all([
+      listen<{ viewId: string; props: unknown }>('module:overlay-project', (event) => {
+        useModuleStore.getState().projectPanel(event.payload.viewId, event.payload.props);
+      }),
+      listen('module:overlay-clear', () => {
+        useModuleStore.getState().clearPresenter();
+      }),
+    ])
+      .then(([unlistenProject, unlistenClear]) => {
+        if (cancelled) {
+          unlistenProject();
+          unlistenClear();
+          return;
+        }
+
+        disposeProject = unlistenProject;
+        disposeClear = unlistenClear;
+        return bootPresenterModules();
+      })
+      .then(() => {
+        if (!cancelled) emit('module:overlay-ready').catch(() => {});
+      })
       .catch(console.error);
 
-    const unlistenProject = listen<{ viewId: string; props: unknown }>('module:overlay-project', (event) => {
-      useModuleStore.getState().projectPanel(event.payload.viewId, event.payload.props);
-    });
-
-    const unlistenClear = listen('module:overlay-clear', () => {
-      useModuleStore.getState().clearPresenter();
-    });
-
     return () => {
-      unlistenProject.then((dispose) => dispose());
-      unlistenClear.then((dispose) => dispose());
+      cancelled = true;
+      disposeProject?.();
+      disposeClear?.();
     };
   }, []);
 
   return (
-    <div className="relative h-dvh w-dvw bg-transparent overflow-hidden">
+    <div className="fixed inset-0 h-dvh w-dvw overflow-hidden bg-black">
       <PresenterSlot />
     </div>
   );

--- a/src/app/module-overlay-window.tsx
+++ b/src/app/module-overlay-window.tsx
@@ -19,12 +19,34 @@ function ModuleOverlayWindow() {
     }
   }, []);
 
+  const setDecorations = useCallback(async (decorated: boolean) => {
+    try {
+      const { getCurrentWebviewWindow } = await import('@tauri-apps/api/webviewWindow');
+      await getCurrentWebviewWindow().setDecorations(decorated);
+    } catch (error) {
+      console.error('Failed to set overlay window decorations:', error);
+    }
+  }, []);
+
+  const toggleFullscreen = useCallback(async () => {
+    try {
+      const { getCurrentWebviewWindow } = await import('@tauri-apps/api/webviewWindow');
+      const window = getCurrentWebviewWindow();
+      const nextFullscreen = !(await window.isFullscreen());
+
+      await window.setFullscreen(nextFullscreen);
+      await setDecorations(!nextFullscreen);
+    } catch (error) {
+      console.error('Failed to toggle overlay fullscreen:', error);
+    }
+  }, [setDecorations]);
+
   useEffect(() => {
     let detachCloseListener: (() => void) | undefined;
 
     import('@tauri-apps/api/window')
       .then(({ getCurrentWindow }) => getCurrentWindow().onCloseRequested(() => {
-        emit('module:overlay-window-closed').catch(() => {});
+        emit('module:overlay-window-closed').catch(() => { });
       }))
       .then((unlisten) => {
         detachCloseListener = unlisten;
@@ -40,6 +62,12 @@ function ModuleOverlayWindow() {
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'F11') {
+        event.preventDefault();
+        void toggleFullscreen();
+        return;
+      }
+
       if (event.key !== 'Escape') return;
       event.preventDefault();
       void closeWindow();
@@ -47,11 +75,11 @@ function ModuleOverlayWindow() {
 
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [closeWindow]);
+  }, [closeWindow, toggleFullscreen]);
 
   useEffect(() => {
     bootPresenterModules()
-      .then(() => emit('module:overlay-ready').catch(() => {}))
+      .then(() => emit('module:overlay-ready').catch(() => { }))
       .catch(console.error);
 
     const unlistenProject = listen<{ viewId: string; props: unknown }>('module:overlay-project', (event) => {

--- a/src/app/module-overlay-window.tsx
+++ b/src/app/module-overlay-window.tsx
@@ -37,38 +37,20 @@ function ModuleOverlayWindow() {
   }, [closeWindow]);
 
   useEffect(() => {
-    let cancelled = false;
-    let disposeProject: (() => void) | null = null;
-    let disposeClear: (() => void) | null = null;
-
-    Promise.all([
-      listen<{ viewId: string; props: unknown }>('module:overlay-project', (event) => {
-        useModuleStore.getState().projectPanel(event.payload.viewId, event.payload.props);
-      }),
-      listen('module:overlay-clear', () => {
-        useModuleStore.getState().clearPresenter();
-      }),
-    ])
-      .then(([unlistenProject, unlistenClear]) => {
-        if (cancelled) {
-          unlistenProject();
-          unlistenClear();
-          return;
-        }
-
-        disposeProject = unlistenProject;
-        disposeClear = unlistenClear;
-        return bootPresenterModules();
-      })
-      .then(() => {
-        if (!cancelled) emit('module:overlay-ready').catch(() => {});
-      })
+    bootPresenterModules()
+      .then(() => emit('module:overlay-ready').catch(() => {}))
       .catch(console.error);
 
+    const unlistenProject = listen<{ viewId: string; props: unknown }>('module:overlay-project', (event) => {
+      useModuleStore.getState().projectPanel(event.payload.viewId, event.payload.props);
+    });
+    const unlistenClear = listen('module:overlay-clear', () => {
+      useModuleStore.getState().clearPresenter();
+    });
+
     return () => {
-      cancelled = true;
-      disposeProject?.();
-      disposeClear?.();
+      unlistenProject.then((f) => f());
+      unlistenClear.then((f) => f());
     };
   }, []);
 

--- a/src/components/app-header.tsx
+++ b/src/components/app-header.tsx
@@ -2,6 +2,7 @@ import { Link, useRouterState } from '@tanstack/react-router';
 import { Monitor, Star, Volume2, Wifi } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { HeaderTrailingSlot } from '@/modules/components/HeaderTrailingSlot';
 import { cn } from '@/lib/utils';
 import { SettingsDialog } from './settings-dialog';
 import { Card } from './ui/card';
@@ -83,10 +84,11 @@ export function AppHeader() {
           )}
         </nav>
 
-        <div className="flex items-center gap-3 w-40 justify-end">
-          <Wifi className="size-4 text-muted-foreground" />
-          <Monitor className="size-4 text-muted-foreground" />
-          <Volume2 className="size-4 text-muted-foreground" />
+        <div className="flex min-w-0 items-center justify-end gap-3 w-56">
+          <HeaderTrailingSlot />
+          <Wifi className="size-4 shrink-0 text-muted-foreground" />
+          <Monitor className="size-4 shrink-0 text-muted-foreground" />
+          <Volume2 className="size-4 shrink-0 text-muted-foreground" />
           <SettingsDialog />
           <Avatar size="sm">
             <AvatarImage src="" alt="User" />

--- a/src/components/aside-panel.tsx
+++ b/src/components/aside-panel.tsx
@@ -1,17 +1,57 @@
-import { CheckCircle2, ListX } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import {
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import { restrictToParentElement, restrictToVerticalAxis } from '@dnd-kit/modifiers';
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { CheckCircle2, ListX, X, Zap } from 'lucide-react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import {
   ContextMenu,
   ContextMenuContent,
   ContextMenuItem,
+  ContextMenuGroup,
+  ContextMenuLabel,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
   ContextMenuTrigger,
 } from '@/components/ui/context-menu';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { ScrollArea } from '@/components/ui/scroll-area';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { cn } from '@/lib/utils';
+import { useModuleStore } from '@/modules/store';
+
 import { usePlayerStore } from '@/stores/player-store';
 import { type QueueItem, useQueueStore } from '@/stores/queue-store';
+
+type TriggerInstance = { id: string; triggerId: string; config: unknown };
+type TriggerDialog = {
+  triggerId: string;
+  config: unknown;
+  instanceId: string | null;
+} | null;
 
 type TabValue = 'queue' | 'notes' | 'themes';
 
@@ -22,7 +62,7 @@ const TABS: { value: TabValue; label: string }[] = [
 ];
 
 export function AsidePanel() {
-  const { queue, removeFromQueue, markPlayed, togglePlayed, loadFromDb, clearQueue, shuffleQueue } =
+  const { queue, removeFromQueue, markPlayed, togglePlayed, loadFromDb, clearQueue, shuffleQueue, reorderQueue } =
     useQueueStore();
   const loadFile = usePlayerStore((s) => s.loadFile);
 
@@ -40,14 +80,9 @@ export function AsidePanel() {
     const activeBtn = triggerRefs.current.get(activeTab);
     const nav = navRef.current;
     if (!activeBtn || !nav) return;
-
     const navRect = nav.getBoundingClientRect();
     const btnRect = activeBtn.getBoundingClientRect();
-
-    setIndicatorStyle({
-      left: btnRect.left - navRect.left,
-      width: btnRect.width,
-    });
+    setIndicatorStyle({ left: btnRect.left - navRect.left, width: btnRect.width });
     setReady(true);
   }, [activeTab]);
 
@@ -76,7 +111,6 @@ export function AsidePanel() {
               </TabsTrigger>
             ))}
           </TabsList>
-
           {ready && (
             <span
               className="absolute bottom-0 h-0.5 bg-primary rounded-full"
@@ -96,6 +130,7 @@ export function AsidePanel() {
             onTogglePlayed={togglePlayed}
             onClear={clearQueue}
             onShuffle={shuffleQueue}
+            onReorder={reorderQueue}
             onPlay={(item) => {
               loadFile(item.file.path);
               markPlayed(item.id);
@@ -125,6 +160,7 @@ function QueueTab({
   onTogglePlayed,
   onClear,
   onShuffle,
+  onReorder,
   onPlay,
 }: {
   queue: QueueItem[];
@@ -132,9 +168,86 @@ function QueueTab({
   onTogglePlayed: (id: number) => void;
   onClear: () => Promise<void>;
   onShuffle: () => Promise<void>;
+  onReorder: (orderedIds: number[]) => Promise<void>;
   onPlay: (item: QueueItem) => void;
 }) {
   const currentFilePath = usePlayerStore((s) => s.currentFilePath);
+  const triggerSpecsMap = useModuleStore((s) => s.queueTriggerSpecs);
+  const triggerSpecs = Array.from(triggerSpecsMap.values());
+  const [triggerInstances, setTriggerInstances] = useState<TriggerInstance[]>([]);
+  const [triggerDialog, setTriggerDialog] = useState<TriggerDialog>(null);
+  const [contextTargetItem, setContextTargetItem] = useState<QueueItem | null>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const oldIndex = queue.findIndex((i) => String(i.id) === String(active.id));
+    const newIndex = queue.findIndex((i) => String(i.id) === String(over.id));
+    if (oldIndex === -1 || newIndex === -1) return;
+    onReorder(arrayMove(queue, oldIndex, newIndex).map((i) => i.id));
+  }
+
+  function openAddTrigger(triggerId: string) {
+    const spec = triggerSpecs.find((s) => s.id === triggerId);
+    if (!spec) return;
+    setTriggerDialog({ triggerId, config: spec.defaultConfig, instanceId: null });
+  }
+
+  function openEditTrigger(inst: TriggerInstance) {
+    setTriggerDialog({ triggerId: inst.triggerId, config: inst.config, instanceId: inst.id });
+  }
+
+  function saveTrigger() {
+    if (!triggerDialog) return;
+    const { triggerId, config, instanceId } = triggerDialog;
+    setTriggerInstances((prev) => {
+      if (instanceId) {
+        return prev.map((i) => (i.id === instanceId ? { ...i, config } : i));
+      }
+      return [...prev, { id: crypto.randomUUID(), triggerId, config }];
+    });
+    setTriggerDialog(null);
+  }
+
+  function removeTriggerInstance(instanceId: string) {
+    setTriggerInstances((prev) => prev.filter((i) => i.id !== instanceId));
+  }
+
+  function handlePlay(item: QueueItem) {
+    onPlay(item);
+    const specs = useModuleStore.getState().getQueueTriggerSpecs();
+    for (const inst of triggerInstances) {
+      const spec = specs.find((s) => s.id === inst.triggerId);
+      spec?.onFire(inst.config);
+    }
+  }
+
+  const formatDuration = (seconds?: number) => {
+    if (!seconds) return '';
+    const mins = Math.floor(seconds / 60);
+    const secs = Math.floor(seconds % 60);
+    return `${mins}:${secs.toString().padStart(2, '0')}`;
+  };
+
+  const dialogSpec = triggerDialog ? triggerSpecs.find((s) => s.id === triggerDialog.triggerId) : null;
+  const ConfigComp = dialogSpec?.ConfigComponent as
+    | React.ComponentType<{ value: unknown; onChange: (v: unknown) => void }>
+    | undefined;
+
+  const currentItemIndex = currentFilePath
+    ? queue.findIndex((item) => item.file.path === currentFilePath)
+    : -1;
+
+  const isPlaying = currentItemIndex >= 0;
+  const currentItem = isPlaying ? queue[currentItemIndex] : null;
+  const upNextItems = isPlaying
+    ? [...queue.slice(0, currentItemIndex), ...queue.slice(currentItemIndex + 1)]
+    : queue;
 
   if (queue.length === 0) {
     return (
@@ -144,136 +257,249 @@ function QueueTab({
     );
   }
 
-  const currentItemIndex = currentFilePath
-    ? queue.findIndex((item) => item.file.path === currentFilePath)
-    : -1;
-
-  const currentItem = currentItemIndex >= 0 ? queue[currentItemIndex] : queue[0];
-  const upNextItems =
-    currentItemIndex >= 0
-      ? [...queue.slice(0, currentItemIndex), ...queue.slice(currentItemIndex + 1)]
-      : queue.slice(1);
-
-  const formatDuration = (seconds?: number) => {
-    if (!seconds) return '';
-    const mins = Math.floor(seconds / 60);
-    const secs = Math.floor(seconds % 60);
-    return `${mins}:${secs.toString().padStart(2, '0')}`;
-  };
-
   return (
-    <div className="flex flex-col h-full">
-      <div className="flex-1 overflow-auto">
-        <div className="p-4 pb-2">
-          <h3 className="text-xs font-semibold text-muted-foreground mb-3 uppercase tracking-widest">
-            Now Playing
-          </h3>
-          <ContextMenu>
-            <ContextMenuTrigger>
-              <Button
-                variant="ghost"
-                className="w-full justify-between text-left p-3 h-auto gap-3 border border-primary/40 rounded-lg bg-primary/5 hover:bg-primary/10 hover:border-primary/60"
-                onDoubleClick={() => onPlay(currentItem)}
+    <>
+      <ContextMenu onOpenChange={(open) => { if (!open) setContextTargetItem(null); }}>
+        <ContextMenuTrigger className="flex flex-col h-full flex-1 min-h-0">
+          <ScrollArea className="flex-1">
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={handleDragEnd}
+              modifiers={[restrictToVerticalAxis, restrictToParentElement]}
+            >
+              <SortableContext
+                items={queue.map((i) => String(i.id))}
+                strategy={verticalListSortingStrategy}
               >
-                <div className="flex-1 min-w-0">
-                  <div
-                    className={cn(
-                      'font-semibold text-sm text-primary leading-tight line-clamp-1 text-ellipsis',
-                      currentItem.played && 'line-through opacity-60'
+                {currentItem && (
+                  <div className="px-4 pt-4 pb-2">
+                    <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-widest mb-2">
+                      Now Playing
+                    </h3>
+                    <SortableQueueItem
+                      item={currentItem}
+                      isCurrent
+                      onPlay={handlePlay}
+                      onContextMenu={() => setContextTargetItem(currentItem)}
+                      formatDuration={formatDuration}
+                    />
+                  </div>
+                )}
+
+                {upNextItems.length > 0 && (
+                  <div className="px-4 pb-4 pt-2">
+                    {isPlaying && (
+                      <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-widest mb-2">
+                        Up Next
+                      </h3>
                     )}
-                  >
-                    {currentItem.file.title || currentItem.file.name}
+                    <div className="space-y-1">
+                      {upNextItems.map((item, idx) => (
+                        <SortableQueueItem
+                          key={item.id}
+                          item={item}
+                          isCurrent={false}
+                          index={isPlaying ? (idx < currentItemIndex ? idx : idx + 1) : idx}
+                          onPlay={handlePlay}
+                          onContextMenu={() => setContextTargetItem(item)}
+                          formatDuration={formatDuration}
+                        />
+                      ))}
+                    </div>
                   </div>
-                  <div className="text-xs text-muted-foreground mt-1">
-                    {currentItem.file.artist ||
-                      currentItem.file.name.split('.').pop()?.toUpperCase()}
-                  </div>
+                )}
+              </SortableContext>
+            </DndContext>
+
+            {triggerInstances.length > 0 && (
+              <div className="px-4 pb-3">
+                <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-widest mb-2">
+                  Queue Triggers
+                </h3>
+                <div className="flex flex-col gap-1">
+                  {triggerInstances.map((inst) => {
+                    const spec = triggerSpecs.find((s) => s.id === inst.triggerId);
+                    if (!spec) return null;
+                    return (
+                      <div
+                        key={inst.id}
+                        className="flex items-center gap-2 px-2 py-1.5 rounded-md text-[11px] font-medium"
+                        style={{
+                          background: 'color-mix(in srgb, var(--primary) 10%, transparent)',
+                          color: 'var(--primary)',
+                        }}
+                      >
+                        {spec.icon ? <spec.icon size={11} /> : <Zap size={11} />}
+                        <button
+                          type="button"
+                          onClick={() => openEditTrigger(inst)}
+                          className="bg-transparent border-none p-0 cursor-pointer flex-1 text-left"
+                          style={{ color: 'inherit' }}
+                        >
+                          {spec.label}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => removeTriggerInstance(inst.id)}
+                          className="bg-transparent border-none p-0 cursor-pointer opacity-50 hover:opacity-100"
+                          style={{ color: 'inherit' }}
+                        >
+                          <X size={10} />
+                        </button>
+                      </div>
+                    );
+                  })}
                 </div>
-                <div className="text-xs text-muted-foreground font-medium shrink-0">
-                  {formatDuration(currentItem.file.duration)}
-                </div>
-              </Button>
-            </ContextMenuTrigger>
-            <ContextMenuContent side="bottom">
-              <ContextMenuItem onClick={() => onTogglePlayed(currentItem.id)}>
+              </div>
+            )}
+          </ScrollArea>
+
+          <div className="border-t border-border p-3 shrink-0 flex gap-2">
+            <Button variant="secondary" size="sm" className="flex-1 rounded-md" onClick={onClear}>
+              Clear
+            </Button>
+            <Button variant="secondary" size="sm" className="flex-1 rounded-md" onClick={onShuffle}>
+              Shuffle
+            </Button>
+          </div>
+        </ContextMenuTrigger>
+
+        <ContextMenuContent>
+          {contextTargetItem && (
+            <>
+              <ContextMenuItem onClick={() => onTogglePlayed(contextTargetItem.id)}>
                 <CheckCircle2 className="h-4 w-4" />
-                {currentItem.played ? 'Mark as unplayed' : 'Mark as played'}
+                {contextTargetItem.played ? 'Mark as unplayed' : 'Mark as played'}
               </ContextMenuItem>
-              <ContextMenuItem onClick={() => onRemove(currentItem.id)} variant="destructive">
+              <ContextMenuItem onClick={() => onRemove(contextTargetItem.id)} variant="destructive">
                 <ListX className="h-4 w-4" />
                 Remove from queue
               </ContextMenuItem>
-            </ContextMenuContent>
-          </ContextMenu>
-        </div>
+            </>
+          )}
+          {!contextTargetItem && triggerSpecs.length > 0 && triggerSpecs.length <= 6 && (
+            <ContextMenuGroup>
+              <ContextMenuLabel>Queue Triggers</ContextMenuLabel>
+              {triggerSpecs.map((spec) => (
+                <ContextMenuItem key={spec.id} onClick={() => openAddTrigger(spec.id)}>
+                  {spec.icon ? <spec.icon size={14} /> : <Zap className="h-4 w-4" />}
+                  {spec.label}
+                </ContextMenuItem>
+              ))}
+            </ContextMenuGroup>
+          )}
+          {!contextTargetItem && triggerSpecs.length > 6 && (
+            <ContextMenuGroup>
+              <ContextMenuLabel>Queue Triggers</ContextMenuLabel>
+              <ContextMenuSub>
+                <ContextMenuSubTrigger>
+                  <Zap className="h-4 w-4" />
+                  Add Queue Trigger
+                </ContextMenuSubTrigger>
+                <ContextMenuSubContent>
+                  {triggerSpecs.map((spec) => (
+                    <ContextMenuItem key={spec.id} onClick={() => openAddTrigger(spec.id)}>
+                      {spec.icon ? <spec.icon size={14} /> : <Zap className="h-4 w-4" />}
+                      {spec.label}
+                    </ContextMenuItem>
+                  ))}
+                </ContextMenuSubContent>
+              </ContextMenuSub>
+            </ContextMenuGroup>
+          )}
+        </ContextMenuContent>
+      </ContextMenu>
 
-        {upNextItems.length > 0 && (
-          <div className="px-4 pb-4 pt-2">
-            <h3 className="text-xs font-semibold text-muted-foreground mb-3 uppercase tracking-widest">
-              Up Next
-            </h3>
-            <div className="space-y-2">
-              {upNextItems.map((item) => {
-                const originalIndex = queue.findIndex((q) => q.id === item.id);
-                return (
-                  <ContextMenu key={item.id}>
-                    <ContextMenuTrigger>
-                      <Button
-                        variant="ghost"
-                        className={cn(
-                          'w-full justify-between text-left p-3 h-auto gap-2 rounded-lg hover:bg-accent/50 transition-colors',
-                          item.played && 'opacity-50'
-                        )}
-                        onDoubleClick={() => onPlay(item)}
-                      >
-                        <div className="flex items-start gap-1 flex-1 min-w-0">
-                          <span className="text-sm font-medium text-muted-foreground w-5 shrink-0 pt-0.5">
-                            {originalIndex + 1}
-                          </span>
-                          <div className="flex-1 min-w-0">
-                            <div
-                              className={cn(
-                                'font-medium text-sm text-foreground leading-tight line-clamp-1 text-ellipsis',
-                                item.played && 'line-through opacity-60'
-                              )}
-                            >
-                              {item.file.title || item.file.name}
-                            </div>
-                            <div className="text-xs text-muted-foreground mt-0.5">
-                              {item.file.artist || item.file.name.split('.').pop()?.toUpperCase()}
-                            </div>
-                          </div>
-                        </div>
-                        <div className="text-xs text-muted-foreground font-medium shrink-0">
-                          {formatDuration(item.file.duration)}
-                        </div>
-                      </Button>
-                    </ContextMenuTrigger>
-                    <ContextMenuContent side="bottom">
-                      <ContextMenuItem onClick={() => onTogglePlayed(item.id)}>
-                        <CheckCircle2 className="h-4 w-4" />
-                        {item.played ? 'Mark as unplayed' : 'Mark as played'}
-                      </ContextMenuItem>
-                      <ContextMenuItem onClick={() => onRemove(item.id)} variant="destructive">
-                        <ListX className="h-4 w-4" />
-                        Remove from queue
-                      </ContextMenuItem>
-                    </ContextMenuContent>
-                  </ContextMenu>
-                );
-              })}
+      <Dialog open={!!triggerDialog} onOpenChange={(open) => !open && setTriggerDialog(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{dialogSpec?.label ?? 'Configure Trigger'}</DialogTitle>
+          </DialogHeader>
+          <div className="py-2">
+            {ConfigComp && triggerDialog && (
+              <ConfigComp
+                value={triggerDialog.config}
+                onChange={(config) => setTriggerDialog((d) => (d ? { ...d, config } : d))}
+              />
+            )}
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setTriggerDialog(null)}>
+              Cancel
+            </Button>
+            <Button onClick={saveTrigger}>
+              {triggerDialog?.instanceId ? 'Save' : 'Add Trigger'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}
+
+function SortableQueueItem({
+  item,
+  isCurrent,
+  index,
+  onPlay,
+  onContextMenu,
+  formatDuration,
+}: {
+  item: QueueItem;
+  isCurrent: boolean;
+  index?: number;
+  onPlay: (item: QueueItem) => void;
+  onContextMenu: () => void;
+  formatDuration: (s?: number) => string;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: String(item.id),
+  });
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition, opacity: isDragging ? 0.4 : 1 }}
+    >
+      <div
+        {...attributes}
+        {...listeners}
+        onContextMenu={onContextMenu}
+        onDoubleClick={() => onPlay(item)}
+        className={cn(
+          'flex items-center rounded-lg touch-none select-none',
+          isCurrent
+            ? 'border border-primary/40 bg-primary/5'
+            : 'hover:bg-accent/50 transition-colors'
+        )}
+      >
+        <div className="flex flex-1 items-center justify-between min-w-0 px-3 py-2">
+          <div className="flex items-start gap-1 min-w-0">
+            {!isCurrent && index !== undefined && (
+              <span className="text-sm font-medium text-muted-foreground w-5 shrink-0 pt-0.5">
+                {index + 1}
+              </span>
+            )}
+            <div className="min-w-0">
+              <div
+                className={cn(
+                  'font-semibold text-sm leading-tight line-clamp-1',
+                  isCurrent ? 'text-primary' : 'text-foreground',
+                  item.played && 'line-through opacity-60'
+                )}
+              >
+                {item.file.title || item.file.name}
+              </div>
+              <div className="text-xs text-muted-foreground mt-0.5">
+                {item.file.artist || item.file.name.split('.').pop()?.toUpperCase()}
+              </div>
             </div>
           </div>
-        )}
-      </div>
-
-      <div className="border-t border-border p-3 shrink-0 flex gap-2">
-        <Button variant="secondary" size="sm" className="flex-1 rounded-md" onClick={onClear}>
-          Clear
-        </Button>
-        <Button variant="secondary" size="sm" className="flex-1 rounded-md" onClick={onShuffle}>
-          Shuffle
-        </Button>
+          <div className="text-xs text-muted-foreground font-medium shrink-0 ml-2">
+            {formatDuration(item.file.duration)}
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/components/aside-panel.tsx
+++ b/src/components/aside-panel.tsx
@@ -16,7 +16,7 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { CheckCircle2, ListX, X, Zap } from 'lucide-react';
+import { CheckCircle2, ListX, Tag, X, Zap } from 'lucide-react';
 import React, { useEffect, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
@@ -42,11 +42,11 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { cn } from '@/lib/utils';
 import { useModuleStore } from '@/modules/store';
-
+import type { QueueTriggerSpec } from '@/modules/types';
+import { useQueueEntriesStore, type ListEntry, type TriggerInstance } from '@/stores/queue-entries-store';
 import { usePlayerStore } from '@/stores/player-store';
 import { type QueueItem, useQueueStore } from '@/stores/queue-store';
 
-type TriggerInstance = { id: string; triggerId: string; config: unknown };
 type TriggerDialog = {
   triggerId: string;
   config: unknown;
@@ -174,9 +174,16 @@ function QueueTab({
   const currentFilePath = usePlayerStore((s) => s.currentFilePath);
   const triggerSpecsMap = useModuleStore((s) => s.queueTriggerSpecs);
   const triggerSpecs = Array.from(triggerSpecsMap.values());
-  const [triggerInstances, setTriggerInstances] = useState<TriggerInstance[]>([]);
+
+  const entries = useQueueEntriesStore((s) => s.entries);
+  const { syncQueue, setEntries } = useQueueEntriesStore.getState();
+
   const [triggerDialog, setTriggerDialog] = useState<TriggerDialog>(null);
   const [contextTargetItem, setContextTargetItem] = useState<QueueItem | null>(null);
+
+  useEffect(() => {
+    syncQueue(queue);
+  }, [queue]);
 
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -186,10 +193,15 @@ function QueueTab({
   function handleDragEnd(event: DragEndEvent) {
     const { active, over } = event;
     if (!over || active.id === over.id) return;
-    const oldIndex = queue.findIndex((i) => String(i.id) === String(active.id));
-    const newIndex = queue.findIndex((i) => String(i.id) === String(over.id));
-    if (oldIndex === -1 || newIndex === -1) return;
-    onReorder(arrayMove(queue, oldIndex, newIndex).map((i) => i.id));
+    const oldIdx = entries.findIndex((e) => e.id === String(active.id));
+    const newIdx = entries.findIndex((e) => e.id === String(over.id));
+    if (oldIdx === -1 || newIdx === -1) return;
+    const next = arrayMove(entries, oldIdx, newIdx);
+    setEntries(next);
+    const orderedQueueIds = next
+      .filter((e): e is Extract<ListEntry, { kind: 'item' }> => e.kind === 'item')
+      .map((e) => e.item.id);
+    onReorder(orderedQueueIds);
   }
 
   function openAddTrigger(triggerId: string) {
@@ -205,26 +217,23 @@ function QueueTab({
   function saveTrigger() {
     if (!triggerDialog) return;
     const { triggerId, config, instanceId } = triggerDialog;
-    setTriggerInstances((prev) => {
-      if (instanceId) {
-        return prev.map((i) => (i.id === instanceId ? { ...i, config } : i));
-      }
-      return [...prev, { id: crypto.randomUUID(), triggerId, config }];
-    });
+    if (instanceId) {
+      setEntries(
+        entries.map((e) =>
+          e.kind === 'trigger' && e.id === instanceId
+            ? { ...e, inst: { ...e.inst, config } }
+            : e
+        )
+      );
+    } else {
+      const newInst: TriggerInstance = { id: crypto.randomUUID(), triggerId, config, showLabel: false };
+      setEntries([...entries, { kind: 'trigger', id: newInst.id, inst: newInst }]);
+    }
     setTriggerDialog(null);
   }
 
-  function removeTriggerInstance(instanceId: string) {
-    setTriggerInstances((prev) => prev.filter((i) => i.id !== instanceId));
-  }
-
-  function handlePlay(item: QueueItem) {
-    onPlay(item);
-    const specs = useModuleStore.getState().getQueueTriggerSpecs();
-    for (const inst of triggerInstances) {
-      const spec = specs.find((s) => s.id === inst.triggerId);
-      spec?.onFire(inst.config);
-    }
+  function removeTriggerInstance(entryId: string) {
+    setEntries(entries.filter((e) => e.id !== entryId));
   }
 
   const formatDuration = (seconds?: number) => {
@@ -239,15 +248,11 @@ function QueueTab({
     | React.ComponentType<{ value: unknown; onChange: (v: unknown) => void }>
     | undefined;
 
-  const currentItemIndex = currentFilePath
-    ? queue.findIndex((item) => item.file.path === currentFilePath)
-    : -1;
-
-  const isPlaying = currentItemIndex >= 0;
-  const currentItem = isPlaying ? queue[currentItemIndex] : null;
-  const upNextItems = isPlaying
-    ? [...queue.slice(0, currentItemIndex), ...queue.slice(currentItemIndex + 1)]
-    : queue;
+  const itemPositions = new Map<string, number>();
+  let pos = 0;
+  for (const entry of entries) {
+    if (entry.kind === 'item') itemPositions.set(entry.id, pos++);
+  }
 
   if (queue.length === 0) {
     return (
@@ -269,90 +274,50 @@ function QueueTab({
               modifiers={[restrictToVerticalAxis, restrictToParentElement]}
             >
               <SortableContext
-                items={queue.map((i) => String(i.id))}
+                items={entries.map((e) => e.id)}
                 strategy={verticalListSortingStrategy}
               >
-                {currentItem && (
-                  <div className="px-4 pt-4 pb-2">
-                    <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-widest mb-2">
-                      Now Playing
-                    </h3>
-                    <SortableQueueItem
-                      item={currentItem}
-                      isCurrent
-                      onPlay={handlePlay}
-                      onContextMenu={() => setContextTargetItem(currentItem)}
-                      formatDuration={formatDuration}
-                    />
-                  </div>
-                )}
-
-                {upNextItems.length > 0 && (
-                  <div className="px-4 pb-4 pt-2">
-                    {isPlaying && (
-                      <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-widest mb-2">
-                        Up Next
-                      </h3>
-                    )}
-                    <div className="space-y-1">
-                      {upNextItems.map((item, idx) => (
+                <div className="px-4 py-3 space-y-1">
+                  {entries.map((entry) => {
+                    if (entry.kind === 'item') {
+                      const isCurrent = entry.item.file.path === currentFilePath;
+                      return (
                         <SortableQueueItem
-                          key={item.id}
-                          item={item}
-                          isCurrent={false}
-                          index={isPlaying ? (idx < currentItemIndex ? idx : idx + 1) : idx}
-                          onPlay={handlePlay}
-                          onContextMenu={() => setContextTargetItem(item)}
+                          key={entry.id}
+                          sortableId={entry.id}
+                          item={entry.item}
+                          isCurrent={isCurrent}
+                          index={itemPositions.get(entry.id) ?? 0}
+                          onPlay={onPlay}
+                          onContextMenu={() => setContextTargetItem(entry.item)}
                           formatDuration={formatDuration}
                         />
-                      ))}
-                    </div>
-                  </div>
-                )}
-              </SortableContext>
-            </DndContext>
-
-            {triggerInstances.length > 0 && (
-              <div className="px-4 pb-3">
-                <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-widest mb-2">
-                  Queue Triggers
-                </h3>
-                <div className="flex flex-col gap-1">
-                  {triggerInstances.map((inst) => {
-                    const spec = triggerSpecs.find((s) => s.id === inst.triggerId);
+                      );
+                    }
+                    const spec = triggerSpecs.find((s) => s.id === entry.inst.triggerId);
                     if (!spec) return null;
                     return (
-                      <div
-                        key={inst.id}
-                        className="flex items-center gap-2 px-2 py-1.5 rounded-md text-[11px] font-medium"
-                        style={{
-                          background: 'color-mix(in srgb, var(--primary) 10%, transparent)',
-                          color: 'var(--primary)',
-                        }}
-                      >
-                        {spec.icon ? <spec.icon size={11} /> : <Zap size={11} />}
-                        <button
-                          type="button"
-                          onClick={() => openEditTrigger(inst)}
-                          className="bg-transparent border-none p-0 cursor-pointer flex-1 text-left"
-                          style={{ color: 'inherit' }}
-                        >
-                          {spec.label}
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => removeTriggerInstance(inst.id)}
-                          className="bg-transparent border-none p-0 cursor-pointer opacity-50 hover:opacity-100"
-                          style={{ color: 'inherit' }}
-                        >
-                          <X size={10} />
-                        </button>
-                      </div>
+                      <SortableTriggerItem
+                        key={entry.id}
+                        inst={entry.inst}
+                        spec={spec}
+                        onEdit={() => openEditTrigger(entry.inst)}
+                        onRemove={() => removeTriggerInstance(entry.id)}
+                        onToggleLabel={() =>
+                          setEntries(
+                            entries.map((e) =>
+                              e.id === entry.id && e.kind === 'trigger'
+                                ? { ...e, inst: { ...e.inst, showLabel: !e.inst.showLabel } }
+                                : e
+                            )
+                          )
+                        }
+                      />
                     );
                   })}
                 </div>
-              </div>
-            )}
+              </SortableContext>
+            </DndContext>
           </ScrollArea>
 
           <div className="border-t border-border p-3 shrink-0 flex gap-2">
@@ -439,6 +404,7 @@ function QueueTab({
 }
 
 function SortableQueueItem({
+  sortableId,
   item,
   isCurrent,
   index,
@@ -446,6 +412,7 @@ function SortableQueueItem({
   onContextMenu,
   formatDuration,
 }: {
+  sortableId: string;
   item: QueueItem;
   isCurrent: boolean;
   index?: number;
@@ -454,7 +421,7 @@ function SortableQueueItem({
   formatDuration: (s?: number) => string;
 }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
-    id: String(item.id),
+    id: sortableId,
   });
 
   return (
@@ -498,6 +465,83 @@ function SortableQueueItem({
           </div>
           <div className="text-xs text-muted-foreground font-medium shrink-0 ml-2">
             {formatDuration(item.file.duration)}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SortableTriggerItem({
+  inst,
+  spec,
+  onEdit,
+  onRemove,
+  onToggleLabel,
+}: {
+  inst: TriggerInstance;
+  spec: QueueTriggerSpec;
+  onEdit: () => void;
+  onRemove: () => void;
+  onToggleLabel: () => void;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: inst.id,
+  });
+
+  const SummaryComp = spec.SummaryComponent as
+    | React.ComponentType<{ value: unknown; onEdit: () => void }>
+    | undefined;
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition, opacity: isDragging ? 0.4 : 1 }}
+    >
+      <div
+        {...attributes}
+        {...listeners}
+        onDoubleClick={onEdit}
+        className="flex items-center rounded-lg touch-none select-none border border-primary/40 bg-primary/5 hover:bg-primary/10 transition-colors"
+      >
+        <div className="flex flex-1 items-center justify-between min-w-0 px-3 py-2">
+          <div className="flex items-center gap-2 min-w-0">
+            {spec.icon ? (
+              <spec.icon size={14} className="text-primary shrink-0" />
+            ) : (
+              <Zap size={14} className="text-primary shrink-0" />
+            )}
+            <div className="flex flex-col min-w-0">
+              {inst.showLabel && (
+                <span className="font-semibold text-sm text-primary leading-tight line-clamp-1">
+                  {spec.label}
+                </span>
+              )}
+              {SummaryComp && (
+                <SummaryComp value={inst.config} onEdit={onEdit} />
+              )}
+            </div>
+          </div>
+          <div className="flex items-center gap-0.5 shrink-0 ml-2">
+            <button
+              type="button"
+              onPointerDown={(e) => e.stopPropagation()}
+              onClick={onToggleLabel}
+              className={cn(
+                'p-0.5 rounded bg-transparent border-none cursor-pointer text-primary transition-opacity',
+                inst.showLabel ? 'opacity-70 hover:opacity-100' : 'opacity-25 hover:opacity-60'
+              )}
+            >
+              <Tag size={11} />
+            </button>
+            <button
+              type="button"
+              onPointerDown={(e) => e.stopPropagation()}
+              onClick={onRemove}
+              className="p-0.5 rounded opacity-50 hover:opacity-100 text-primary bg-transparent border-none cursor-pointer"
+            >
+              <X size={12} />
+            </button>
           </div>
         </div>
       </div>

--- a/src/components/aside-panel.tsx
+++ b/src/components/aside-panel.tsx
@@ -1,30 +1,31 @@
 import {
+  closestCenter,
   DndContext,
+  type DragEndEvent,
   KeyboardSensor,
   PointerSensor,
-  closestCenter,
   useSensor,
   useSensors,
-  type DragEndEvent,
 } from '@dnd-kit/core';
 import { restrictToParentElement, restrictToVerticalAxis } from '@dnd-kit/modifiers';
 import {
-  SortableContext,
   arrayMove,
+  SortableContext,
   sortableKeyboardCoordinates,
   useSortable,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { CheckCircle2, ListX, Tag, X, Zap } from 'lucide-react';
-import React, { useEffect, useRef, useState } from 'react';
+import type React from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import {
   ContextMenu,
   ContextMenuContent,
-  ContextMenuItem,
   ContextMenuGroup,
+  ContextMenuItem,
   ContextMenuLabel,
   ContextMenuSub,
   ContextMenuSubContent,
@@ -43,8 +44,12 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { cn } from '@/lib/utils';
 import { useModuleStore } from '@/modules/store';
 import type { QueueTriggerSpec } from '@/modules/types';
-import { useQueueEntriesStore, type ListEntry, type TriggerInstance } from '@/stores/queue-entries-store';
 import { usePlayerStore } from '@/stores/player-store';
+import {
+  type ListEntry,
+  type TriggerInstance,
+  useQueueEntriesStore,
+} from '@/stores/queue-entries-store';
 import { type QueueItem, useQueueStore } from '@/stores/queue-store';
 
 type TriggerDialog = {
@@ -62,8 +67,16 @@ const TABS: { value: TabValue; label: string }[] = [
 ];
 
 export function AsidePanel() {
-  const { queue, removeFromQueue, markPlayed, togglePlayed, loadFromDb, clearQueue, shuffleQueue, reorderQueue } =
-    useQueueStore();
+  const {
+    queue,
+    removeFromQueue,
+    markPlayed,
+    togglePlayed,
+    loadFromDb,
+    clearQueue,
+    shuffleQueue,
+    reorderQueue,
+  } = useQueueStore();
   const loadFile = usePlayerStore((s) => s.loadFile);
 
   const [activeTab, setActiveTab] = useState<TabValue>('queue');
@@ -183,7 +196,7 @@ function QueueTab({
 
   useEffect(() => {
     syncQueue(queue);
-  }, [queue]);
+  }, [queue, syncQueue]);
 
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -220,13 +233,16 @@ function QueueTab({
     if (instanceId) {
       setEntries(
         entries.map((e) =>
-          e.kind === 'trigger' && e.id === instanceId
-            ? { ...e, inst: { ...e.inst, config } }
-            : e
+          e.kind === 'trigger' && e.id === instanceId ? { ...e, inst: { ...e.inst, config } } : e
         )
       );
     } else {
-      const newInst: TriggerInstance = { id: crypto.randomUUID(), triggerId, config, showLabel: false };
+      const newInst: TriggerInstance = {
+        id: crypto.randomUUID(),
+        triggerId,
+        config,
+        showLabel: false,
+      };
       setEntries([...entries, { kind: 'trigger', id: newInst.id, inst: newInst }]);
     }
     setTriggerDialog(null);
@@ -243,7 +259,9 @@ function QueueTab({
     return `${mins}:${secs.toString().padStart(2, '0')}`;
   };
 
-  const dialogSpec = triggerDialog ? triggerSpecs.find((s) => s.id === triggerDialog.triggerId) : null;
+  const dialogSpec = triggerDialog
+    ? triggerSpecs.find((s) => s.id === triggerDialog.triggerId)
+    : null;
   const ConfigComp = dialogSpec?.ConfigComponent as
     | React.ComponentType<{ value: unknown; onChange: (v: unknown) => void }>
     | undefined;
@@ -264,7 +282,11 @@ function QueueTab({
 
   return (
     <>
-      <ContextMenu onOpenChange={(open) => { if (!open) setContextTargetItem(null); }}>
+      <ContextMenu
+        onOpenChange={(open) => {
+          if (!open) setContextTargetItem(null);
+        }}
+      >
         <ContextMenuTrigger className="flex flex-col h-full flex-1 min-h-0">
           <ScrollArea className="flex-1">
             <DndContext
@@ -427,13 +449,19 @@ function SortableQueueItem({
   return (
     <div
       ref={setNodeRef}
-      style={{ transform: CSS.Transform.toString(transform), transition, opacity: isDragging ? 0.4 : 1 }}
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+        opacity: isDragging ? 0.4 : 1,
+      }}
     >
       <div
         {...attributes}
         {...listeners}
         onContextMenu={onContextMenu}
         onDoubleClick={() => onPlay(item)}
+        role="button"
+        tabIndex={0}
         className={cn(
           'flex items-center rounded-lg touch-none select-none',
           isCurrent
@@ -496,12 +524,18 @@ function SortableTriggerItem({
   return (
     <div
       ref={setNodeRef}
-      style={{ transform: CSS.Transform.toString(transform), transition, opacity: isDragging ? 0.4 : 1 }}
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+        opacity: isDragging ? 0.4 : 1,
+      }}
     >
       <div
         {...attributes}
         {...listeners}
         onDoubleClick={onEdit}
+        role="button"
+        tabIndex={0}
         className="flex items-center rounded-lg touch-none select-none border border-primary/40 bg-primary/5 hover:bg-primary/10 transition-colors"
       >
         <div className="flex flex-1 items-center justify-between min-w-0 px-3 py-2">
@@ -517,9 +551,7 @@ function SortableTriggerItem({
                   {spec.label}
                 </span>
               )}
-              {SummaryComp && (
-                <SummaryComp value={inst.config} onEdit={onEdit} />
-              )}
+              {SummaryComp && <SummaryComp value={inst.config} onEdit={onEdit} />}
             </div>
           </div>
           <div className="flex items-center gap-0.5 shrink-0 ml-2">

--- a/src/components/lyric-background-modal.tsx
+++ b/src/components/lyric-background-modal.tsx
@@ -1,7 +1,7 @@
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { join } from '@tauri-apps/api/path';
 import { exists, mkdir, readDir, remove, stat, writeFile } from '@tauri-apps/plugin-fs';
-import { useTranslation } from '@/lib/i18n';
+import { t, useTranslation } from '@/lib/i18n';
 import {
   CheckIcon,
   DownloadIcon,
@@ -155,7 +155,7 @@ function MediaThumbnail({ file, selected, onClick, onDelete }: MediaThumbnailPro
 
     thumbnailService.getThumbnail(file.path).then((url) => {
       if (!cancelled) setDisplaySrc(url);
-    }).catch(() => {});
+    }).catch(() => { });
 
     return () => {
       cancelled = true;

--- a/src/components/lyric-background-modal.tsx
+++ b/src/components/lyric-background-modal.tsx
@@ -137,6 +137,14 @@ const DEFAULT_IMAGES: UnsplashPhoto[] = [
       small: 'https://images.unsplash.com/photo-1494500764479-0c8f2919a3d8?w=400&q=80&fit=crop',
     },
   },
+  {
+    id: '12',
+    alt_description: 'Milky Way',
+    urls: {
+      raw: 'https://images.unsplash.com/photo-1656464868371-602be27fd4c2',
+      small: 'https://images.unsplash.com/photo-1656464868371-602be27fd4c2?w=400&q=80&fit=crop',
+    },
+  },
 ];
 
 interface MediaThumbnailProps {

--- a/src/components/quick-shortcuts-modal.tsx
+++ b/src/components/quick-shortcuts-modal.tsx
@@ -24,8 +24,8 @@ import {
   useRef,
   useState,
 } from 'react';
-import { useTranslation } from '@/lib/i18n';
 import { useDebounceValue, useEventListener } from 'usehooks-ts';
+import { useTranslation } from '@/lib/i18n';
 import { cn } from '@/lib/utils';
 import {
   normalize,
@@ -693,7 +693,7 @@ function AppView({ app }: { app: ActiveApp }) {
 }
 
 export function QuickShortcutsModal() {
-  const { isOpen, toggle, close, activeApp } = useCommandStore();
+  const { isOpen, toggle, close, activeApp, popApp } = useCommandStore();
 
   useEventListener('keydown', (event) => {
     if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'k') {
@@ -703,7 +703,19 @@ export function QuickShortcutsModal() {
   });
 
   return (
-    <Dialog open={isOpen} onOpenChange={(open) => !open && close()}>
+    <Dialog
+      open={isOpen}
+      onOpenChange={(open, eventDetails) => {
+        if (!open) {
+          if (eventDetails?.reason === 'escape-key' && activeApp) {
+            popApp();
+            eventDetails.cancel();
+          } else {
+            close();
+          }
+        }
+      }}
+    >
       <DialogContent showCloseButton={false} className="overflow-hidden p-0 sm:max-w-[760px]">
         {activeApp ? <AppView app={activeApp} /> : <RootView />}
       </DialogContent>

--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -226,7 +226,7 @@ function ComboboxChips({
     <ComboboxPrimitive.Chips
       data-slot="combobox-chips"
       className={cn(
-        "flex min-h-8 flex-wrap items-center gap-1 rounded-lg border border-input bg-transparent bg-clip-padding px-2.5 py-1 text-sm transition-colors focus-within:border-ring focus-within:ring-3 focus-within:ring-ring/50 has-aria-invalid:border-destructive has-aria-invalid:ring-3 has-aria-invalid:ring-destructive/20 has-data-[slot=combobox-chip]:px-1 dark:bg-input/30 dark:has-aria-invalid:border-destructive/50 dark:has-aria-invalid:ring-destructive/40",
+        "flex min-h-8 flex-wrap items-center gap-1 rounded-lg border border-input bg-clip-padding px-2.5 py-1 text-sm transition-colors focus-within:border-ring focus-within:ring-3 focus-within:ring-ring/50 has-aria-invalid:ring-3 has-data-[slot=combobox-chip]:px-1 bg-input/30 has-aria-invalid:border-destructive/50 has-aria-invalid:ring-destructive/30",
         className
       )}
       {...props}

--- a/src/components/ui/input-group.tsx
+++ b/src/components/ui/input-group.tsx
@@ -14,15 +14,7 @@ function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
       data-slot="input-group"
       role="group"
       className={cn(
-        "group/input-group border-input dark:bg-input/30 shadow-xs relative flex w-full items-center rounded-md border outline-none transition-[color,box-shadow]",
-        "h-9 has-[>textarea]:h-auto",
-        "has-[>[data-align=inline-start]]:[&>input]:pl-2",
-        "has-[>[data-align=inline-end]]:[&>input]:pr-2",
-        "has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>[data-align=block-start]]:[&>input]:pb-3",
-        "has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-3",
-        "has-[[data-slot=input-group-control]:focus-visible]:ring-ring has-[[data-slot=input-group-control]:focus-visible]:ring-1",
-        "has-[[data-slot][aria-invalid=true]]:ring-destructive/20 has-[[data-slot][aria-invalid=true]]:border-destructive dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40",
-
+        "group/input-group relative flex h-8 w-full min-w-0 items-center rounded-lg border border-input transition-colors outline-none in-data-[slot=combobox-content]:focus-within:border-inherit in-data-[slot=combobox-content]:focus-within:ring-0 has-disabled:bg-input/50 has-disabled:opacity-50 has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-3 has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50 has-[[data-slot][aria-invalid=true]]:border-destructive has-[[data-slot][aria-invalid=true]]:ring-3 has-[[data-slot][aria-invalid=true]]:ring-destructive/20 has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>textarea]:h-auto dark:bg-input/30 dark:has-disabled:bg-input/80 dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40 has-[>[data-align=block-end]]:[&>input]:pt-3 has-[>[data-align=block-start]]:[&>input]:pb-3 has-[>[data-align=inline-end]]:[&>input]:pr-1.5 has-[>[data-align=inline-start]]:[&>input]:pl-1.5",
         className
       )}
       {...props}
@@ -31,18 +23,18 @@ function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
 }
 
 const inputGroupAddonVariants = cva(
-  "text-muted-foreground flex h-auto cursor-text select-none items-center justify-center gap-2 py-1.5 text-sm font-medium group-data-[disabled=true]/input-group:opacity-50 [&>kbd]:rounded-[calc(var(--radius)-5px)] [&>svg:not([class*='size-'])]:size-4",
+  "flex h-auto cursor-text items-center justify-center gap-2 py-1.5 text-sm font-medium text-muted-foreground select-none group-data-[disabled=true]/input-group:opacity-50 [&>kbd]:rounded-[calc(var(--radius)-5px)] [&>svg:not([class*='size-'])]:size-4",
   {
     variants: {
       align: {
         "inline-start":
-          "order-first pl-3 has-[>button]:ml-[-0.45rem] has-[>kbd]:ml-[-0.35rem]",
+          "order-first pl-2 has-[>button]:ml-[-0.3rem] has-[>kbd]:ml-[-0.15rem]",
         "inline-end":
-          "order-last pr-3 has-[>button]:mr-[-0.4rem] has-[>kbd]:mr-[-0.35rem]",
+          "order-last pr-2 has-[>button]:mr-[-0.3rem] has-[>kbd]:mr-[-0.15rem]",
         "block-start":
-          "[.border-b]:pb-3 order-first w-full justify-start px-3 pt-3 group-has-[>input]/input-group:pt-2.5",
+          "order-first w-full justify-start px-2.5 pt-2 group-has-[>input]/input-group:pt-2 [.border-b]:pb-2",
         "block-end":
-          "[.border-t]:pt-3 order-last w-full justify-start px-3 pb-3 group-has-[>input]/input-group:pb-2.5",
+          "order-last w-full justify-start px-2.5 pb-2 group-has-[>input]/input-group:pb-2 [.border-t]:pt-2",
       },
     },
     defaultVariants: {
@@ -78,10 +70,10 @@ const inputGroupButtonVariants = cva(
   {
     variants: {
       size: {
-        xs: "h-6 gap-1 rounded-[calc(var(--radius)-5px)] px-2 has-[>svg]:px-2 [&>svg:not([class*='size-'])]:size-3.5",
-        sm: "h-8 gap-1.5 rounded-md px-2.5 has-[>svg]:px-2.5",
+        xs: "h-6 gap-1 rounded-[calc(var(--radius)-3px)] px-1.5 [&>svg:not([class*='size-'])]:size-3.5",
+        sm: "",
         "icon-xs":
-          "size-6 rounded-[calc(var(--radius)-5px)] p-0 has-[>svg]:p-0",
+          "size-6 rounded-[calc(var(--radius)-3px)] p-0 has-[>svg]:p-0",
         "icon-sm": "size-8 p-0 has-[>svg]:p-0",
       },
     },
@@ -97,8 +89,10 @@ function InputGroupButton({
   variant = "ghost",
   size = "xs",
   ...props
-}: Omit<React.ComponentProps<typeof Button>, "size"> &
-  VariantProps<typeof inputGroupButtonVariants>) {
+}: Omit<React.ComponentProps<typeof Button>, "size" | "type"> &
+  VariantProps<typeof inputGroupButtonVariants> & {
+    type?: "button" | "submit" | "reset"
+  }) {
   return (
     <Button
       type={type}
@@ -114,7 +108,7 @@ function InputGroupText({ className, ...props }: React.ComponentProps<"span">) {
   return (
     <span
       className={cn(
-        "text-muted-foreground flex items-center gap-2 text-sm [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none",
+        "flex items-center gap-2 text-sm text-muted-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
         className
       )}
       {...props}
@@ -130,7 +124,7 @@ function InputGroupInput({
     <Input
       data-slot="input-group-control"
       className={cn(
-        "flex-1 rounded-none border-0 bg-transparent shadow-none focus-visible:ring-0 dark:bg-transparent",
+        "flex-1 rounded-none border-0 bg-transparent shadow-none ring-0 focus-visible:ring-0 disabled:bg-transparent aria-invalid:ring-0 dark:bg-transparent dark:disabled:bg-transparent",
         className
       )}
       {...props}
@@ -146,7 +140,7 @@ function InputGroupTextarea({
     <Textarea
       data-slot="input-group-control"
       className={cn(
-        "flex-1 resize-none rounded-none border-0 bg-transparent py-3 shadow-none focus-visible:ring-0 dark:bg-transparent",
+        "flex-1 resize-none rounded-none border-0 bg-transparent py-2 shadow-none ring-0 focus-visible:ring-0 disabled:bg-transparent aria-invalid:ring-0 dark:bg-transparent dark:disabled:bg-transparent",
         className
       )}
       {...props}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,21 +1,20 @@
-import * as React from "react";
+import * as React from "react"
+import { Input as InputPrimitive } from "@base-ui/react/input"
 
-import { cn } from "@/lib/utils";
+import { cn } from "@/lib/utils"
 
 function Input({ className, type, ...props }: React.ComponentProps<"input">) {
-	return (
-		<input
-			type={type}
-			data-slot="input"
-			className={cn(
-				"border-input file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground flex h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-				"focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
-				"aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
-				className,
-			)}
-			{...props}
-		/>
-	);
+  return (
+    <InputPrimitive
+      type={type}
+      data-slot="input"
+      className={cn(
+        "h-8 w-full min-w-0 rounded-lg border border-input bg-transparent px-2.5 py-1 text-base transition-colors outline-none file:inline-flex file:h-6 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
 }
 
-export { Input };
+export { Input }

--- a/src/hooks/use-modules.ts
+++ b/src/hooks/use-modules.ts
@@ -2,13 +2,15 @@ import { useEffect } from 'react';
 import { bootModules, setOpenCommandPalette } from '@/modules/injector';
 import { useCommandStore } from '@/stores/command-store';
 
-export function useModules() {
+export function useModules(enabled = true) {
   const openCommandPalette = useCommandStore((s) => s.open);
 
   useEffect(() => {
+    if (!enabled) return;
+
     setOpenCommandPalette(openCommandPalette);
     bootModules().catch((err) => {
       console.error('[modules] boot failed:', err);
     });
-  }, [openCommandPalette]);
+  }, [enabled, openCommandPalette]);
 }

--- a/src/hooks/use-single-instance.ts
+++ b/src/hooks/use-single-instance.ts
@@ -6,22 +6,24 @@ interface SingleInstanceEvent {
   payload: string[];
 }
 
-export function useSingleInstance() {
+export function useSingleInstance(enabled = true) {
   useEffect(() => {
+    if (!enabled) return;
+
     let unlisten: (() => void) | undefined;
 
     const setupListener = async () => {
       try {
         unlisten = await listen("single-instance", (event: SingleInstanceEvent) => {
           console.log("Single instance event received:", event.payload);
-          
+
           if (event.payload && event.payload.length > 0) {
             console.log("Arguments from second instance:", event.payload);
-            
+
             const filePaths = event.payload.filter(arg => 
               arg.includes('/') || arg.includes('\\') || arg.includes('.')
             );
-            
+
             if (filePaths.length > 0) {
               toast.info(`Files passed from another instance: ${filePaths.length} file(s)`, {
                 description: "The app is already running. Use the upload button to add these files.",
@@ -41,5 +43,5 @@ export function useSingleInstance() {
         unlisten();
       }
     };
-  }, []);
+  }, [enabled]);
 }

--- a/src/modules/apis/domain.ts
+++ b/src/modules/apis/domain.ts
@@ -240,6 +240,10 @@ async function ensureOverlayWindow(): Promise<{ created: boolean }> {
       label: 'module-overlay-window',
       title: 'Module Overlay',
       route: '/module-overlay-window',
+      fullscreen: false,
+      decorations: true,
+      width: 960,
+      height: 540,
     }).catch(() => {});
 
     await new Promise<void>((resolve) => {
@@ -311,6 +315,7 @@ export function createOverlayHostAPI(): OverlayHostAPI {
     },
     project(viewId, props) {
       overlayViewId = viewId;
+      overlayProps = props;
       globalBus.emit('overlay:project', { viewId, props });
       ensureOverlayWindow()
         .then(() => emit('module:overlay-project', { viewId, props }))
@@ -318,6 +323,7 @@ export function createOverlayHostAPI(): OverlayHostAPI {
     },
     clear() {
       overlayViewId = null;
+      overlayProps = undefined;
       globalBus.emit('overlay:clear');
       emit('module:overlay-clear').catch(() => {});
       WebviewWindow.getByLabel('module-overlay-window')

--- a/src/modules/apis/domain.ts
+++ b/src/modules/apis/domain.ts
@@ -1,5 +1,6 @@
 import { invoke } from '@tauri-apps/api/core';
 import { readFile } from '@tauri-apps/plugin-fs';
+import { thumbnailService } from '@/services/thumbnail-service';
 import { emit, listen } from '@tauri-apps/api/event';
 import { WebviewWindow } from '@tauri-apps/api/webviewWindow';
 import { lyricService } from '@/services/lyric-service';
@@ -255,9 +256,11 @@ export function createThemesHostAPI(): ThemesHostAPI {
           handler(bg);
           return;
         }
-        readFile(src)
-          .then((bytes) => URL.createObjectURL(new Blob([bytes])))
-          .then((blobUrl) => handler({ ...bg!, src: blobUrl }))
+        Promise.all([
+          readFile(src).then((bytes) => URL.createObjectURL(new Blob([bytes]))),
+          thumbnailService.getThumbnail(src, 200).catch(() => null),
+        ])
+          .then(([blobUrl, thumb]) => handler({ ...bg!, src: blobUrl, ...(thumb ? { thumb } : {}) }))
           .catch(() => handler(bg));
       };
 

--- a/src/modules/apis/domain.ts
+++ b/src/modules/apis/domain.ts
@@ -1,4 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
+import { readFile } from '@tauri-apps/plugin-fs';
 import { emit, listen } from '@tauri-apps/api/event';
 import { WebviewWindow } from '@tauri-apps/api/webviewWindow';
 import { lyricService } from '@/services/lyric-service';
@@ -16,6 +17,7 @@ import type {
   ThemesHostAPI,
 } from '../types';
 import { globalBus } from './bus';
+import { useProfileStore } from '@/stores/profile-store';
 
 function stripExt(name: string): string {
   return name.replace(/\.[^/.]+$/, '');
@@ -238,6 +240,45 @@ export function createThemesHostAPI(): ThemesHostAPI {
     },
     apply(id) {
       globalBus.emit('themes:apply', { id });
+    },
+    defaultBackground() {
+      const { profiles, activeProfileId } = useProfileStore.getState();
+      const profile = profiles.find((p) => p.id === activeProfileId);
+      return profile?.defaultBackground ?? null;
+    },
+    onDefaultBackgroundChange(handler) {
+      let lastSrc: string | null | undefined = undefined;
+
+      const fire = (bg: { src: string; type: 'theme' | 'image' | 'video'; name: string } | null) => {
+        const src = bg?.src ?? null;
+        if (!src || src.startsWith('blob:') || src.startsWith('http') || src.startsWith('data:')) {
+          handler(bg);
+          return;
+        }
+        readFile(src)
+          .then((bytes) => URL.createObjectURL(new Blob([bytes])))
+          .then((blobUrl) => handler({ ...bg!, src: blobUrl }))
+          .catch(() => handler(bg));
+      };
+
+      const unsub = useProfileStore.subscribe((state) => {
+        const profile = state.profiles.find((p) => p.id === state.activeProfileId);
+        const bg = profile?.defaultBackground ?? null;
+        const src = bg?.src ?? null;
+        if (src === lastSrc) return;
+        lastSrc = src;
+        fire(bg);
+      });
+
+      const { profiles, activeProfileId } = useProfileStore.getState();
+      const profile = profiles.find((p) => p.id === activeProfileId);
+      const current = profile?.defaultBackground ?? null;
+      if (current?.src) {
+        lastSrc = current.src;
+        fire(current);
+      }
+
+      return { dispose: unsub };
     },
   };
 }

--- a/src/modules/apis/domain.ts
+++ b/src/modules/apis/domain.ts
@@ -6,6 +6,8 @@ import { WebviewWindow } from '@tauri-apps/api/webviewWindow';
 import { lyricService } from '@/services/lyric-service';
 import { mediaDbService } from '@/services/media-db-service';
 import { useModuleStore } from '../store';
+import { usePlayerStore } from '@/stores/player-store';
+import { useQueueEntriesStore } from '@/stores/queue-entries-store';
 import type {
   LibraryHostAPI,
   LyricsHostAPI,
@@ -95,7 +97,12 @@ export function createQueueHostAPI(): QueueHostAPI {
       return globalBus.on('queue:changed', handler);
     },
     next() {
-      globalBus.emit('queue:next');
+      const result = useQueueEntriesStore.getState().advanceQueue(
+        usePlayerStore.getState().currentFilePath
+      );
+      if (result.type === 'play') {
+        void usePlayerStore.getState().loadFile(result.path);
+      }
     },
     previous() {
       globalBus.emit('queue:previous');

--- a/src/modules/apis/domain.ts
+++ b/src/modules/apis/domain.ts
@@ -201,13 +201,19 @@ listen('module:overlay-window-closed', () => {
   globalBus.emit('overlay:clear');
 }).catch(() => {});
 
-listen('module:overlay-ready', () => {
-  if (!overlayViewId) return;
-  emit('module:overlay-project', { viewId: overlayViewId, props: overlayProps }).catch(() => {});
-}).catch(() => {});
-
 let overlayViewId: string | null = null;
 let overlayProps: unknown;
+
+function syncOverlayProjection() {
+  if (!overlayViewId) return;
+  emit('module:overlay-project', { viewId: overlayViewId, props: overlayProps }).catch(() => {});
+}
+
+listen('module:overlay-ready', () => {
+  syncOverlayProjection();
+  setTimeout(syncOverlayProjection, 100);
+  setTimeout(syncOverlayProjection, 400);
+}).catch(() => {});
 
 async function ensureMediaWindow(): Promise<{ created: boolean }> {
   let win = await WebviewWindow.getByLabel('media-window').catch(() => null);
@@ -236,14 +242,10 @@ async function ensureOverlayWindow(): Promise<{ created: boolean }> {
   let win = await WebviewWindow.getByLabel('module-overlay-window').catch(() => null);
 
   if (!win) {
-    await invoke('create_window', {
+    await invoke('create_overlay_window', {
       label: 'module-overlay-window',
       title: 'Module Overlay',
       route: '/module-overlay-window',
-      fullscreen: false,
-      decorations: true,
-      width: 960,
-      height: 540,
     }).catch(() => {});
 
     await new Promise<void>((resolve) => {
@@ -255,12 +257,16 @@ async function ensureOverlayWindow(): Promise<{ created: boolean }> {
     });
 
     win = await WebviewWindow.getByLabel('module-overlay-window').catch(() => null);
-    if (win) await win.show().catch(() => {});
+    if (win) {
+      await win.show().catch(() => {});
+      syncOverlayProjection();
+    }
     return { created: true };
   }
 
   const visible = await win.isVisible().catch(() => false);
   if (!visible) await win.show().catch(() => {});
+  syncOverlayProjection();
   return { created: false };
 }
 export function createPresentationHostAPI(): PresentationHostAPI {
@@ -317,9 +323,7 @@ export function createOverlayHostAPI(): OverlayHostAPI {
       overlayViewId = viewId;
       overlayProps = props;
       globalBus.emit('overlay:project', { viewId, props });
-      ensureOverlayWindow()
-        .then(() => emit('module:overlay-project', { viewId, props }))
-        .catch(() => {});
+      ensureOverlayWindow().catch(() => {});
     },
     clear() {
       overlayViewId = null;

--- a/src/modules/apis/domain.ts
+++ b/src/modules/apis/domain.ts
@@ -1,10 +1,10 @@
 import { invoke } from '@tauri-apps/api/core';
 import { readFile } from '@tauri-apps/plugin-fs';
-import { thumbnailService } from '@/services/thumbnail-service';
 import { emit, listen } from '@tauri-apps/api/event';
 import { WebviewWindow } from '@tauri-apps/api/webviewWindow';
 import { lyricService } from '@/services/lyric-service';
 import { mediaDbService } from '@/services/media-db-service';
+import { thumbnailService } from '@/services/thumbnail-service';
 import { useModuleStore } from '../store';
 import { usePlayerStore } from '@/stores/player-store';
 import { useQueueEntriesStore } from '@/stores/queue-entries-store';
@@ -23,7 +23,7 @@ import type {
 import { globalBus } from './bus';
 import { useProfileStore } from '@/stores/profile-store';
 
-function stripExt(name: string): string {
+function stripExt(name: string) {
   return name.replace(/\.[^/.]+$/, '');
 }
 
@@ -57,7 +57,13 @@ export function createLyricsHostAPI(): LyricsHostAPI {
       };
     },
     currentSlide() {
-      return null;
+      const store = usePlayerStore.getState();
+      if (!store.currentLyricPath || store.currentLyricTotalSlides <= 0) return null;
+
+      return {
+        index: store.currentLyricSlideIndex,
+        text: '',
+      };
     },
     advance() {
       globalBus.emit('lyrics:advance');
@@ -121,12 +127,18 @@ export function createQueueHostAPI(): QueueHostAPI {
 export function createLibraryHostAPI(): LibraryHostAPI {
   return {
     async list(type, query) {
-      const term = query?.trim();
-      const hits = term
-        ? await mediaDbService.search(term, { mediaType: type, fullContent: false, limit: 100 })
-        : type
-          ? await mediaDbService.listByType(type, 200)
-          : [];
+      const mediaType = type as 'audio' | 'video' | 'image' | undefined;
+      const hits = query?.trim()
+        ? await mediaDbService.search(query.trim(), { mediaType, limit: 200 })
+        : mediaType
+          ? await mediaDbService.listByType(mediaType, 500)
+          : (
+              await Promise.all([
+                mediaDbService.listByType('audio', 200),
+                mediaDbService.listByType('video', 200),
+                mediaDbService.listByType('image', 200),
+              ])
+            ).flat();
       return hits.map<MediaRef>((h) => ({
         id: String(h.id),
         path: h.path,
@@ -140,7 +152,7 @@ export function createLibraryHostAPI(): LibraryHostAPI {
       const hit = await mediaDbService.getById(numId);
       if (!hit) return null;
       return {
-        id,
+        id: String(hit.id),
         path: hit.path,
         name: hit.name,
         type: hit.media_type as PublicMediaType,
@@ -161,9 +173,21 @@ export function createLibraryHostAPI(): LibraryHostAPI {
 export function createPlayerHostAPI(): PlayerHostAPI {
   return {
     current() {
-      return null;
+      const store = usePlayerStore.getState();
+      const path = store.currentFilePath ?? store.currentImagePath;
+      if (!path) return null;
+
+      return {
+        id: path,
+        path,
+        title: store.localTitle || stripExt(path.split(/[\\/]/).pop() ?? path),
+        artist: store.localArtist || undefined,
+      };
     },
     state() {
+      const store = usePlayerStore.getState();
+      if (store.currentImagePath) return 'paused';
+      if (store.currentFilePath) return store.isPlaying ? 'playing' : 'paused';
       return 'idle';
     },
     play(track) {
@@ -215,32 +239,21 @@ listen('module:overlay-ready', () => {
   setTimeout(syncOverlayProjection, 400);
 }).catch(() => {});
 
-async function ensureMediaWindow(): Promise<{ created: boolean }> {
-  let win = await WebviewWindow.getByLabel('media-window').catch(() => null);
+listen('module:presenter-ready', () => {
+  const { presenterViewId, presenterProps } = useModuleStore.getState();
+  if (!presenterViewId) return;
 
-  if (!win) {
-    await invoke('create_window', { label: 'media-window', title: 'Media Player' }).catch(() => {});
+  emit('module:presenter-project', { viewId: presenterViewId, props: presenterProps }).catch(() => {});
+  setTimeout(() => {
+    emit('module:presenter-project', { viewId: presenterViewId, props: presenterProps }).catch(() => {});
+  }, 100);
+  setTimeout(() => {
+    emit('module:presenter-project', { viewId: presenterViewId, props: presenterProps }).catch(() => {});
+  }, 400);
+}).catch(() => {});
 
-    await new Promise<void>((resolve) => {
-      const fallback = setTimeout(resolve, 6000);
-      listen('module:presenter-ready', () => {
-        clearTimeout(fallback);
-        resolve();
-      }).catch(() => {});
-    });
-
-    win = await WebviewWindow.getByLabel('media-window').catch(() => null);
-    return { created: true };
-  }
-
-  const visible = await win.isVisible().catch(() => false);
-  if (!visible) await win.show().catch(() => {});
-  return { created: false };
-}
-
-async function ensureOverlayWindow(): Promise<{ created: boolean }> {
+async function ensureOverlayWindow() {
   let win = await WebviewWindow.getByLabel('module-overlay-window').catch(() => null);
-
   if (!win) {
     await invoke('create_overlay_window', {
       label: 'module-overlay-window',
@@ -249,11 +262,20 @@ async function ensureOverlayWindow(): Promise<{ created: boolean }> {
     }).catch(() => {});
 
     await new Promise<void>((resolve) => {
-      const fallback = setTimeout(resolve, 6000);
-      listen('module:overlay-ready', () => {
-        clearTimeout(fallback);
+      let settled = false;
+      const finish = () => {
+        if (settled) return;
+        settled = true;
         resolve();
-      }).catch(() => {});
+      };
+      listen('module:overlay-ready', () => {
+        finish();
+      }).then((unlisten) => {
+        setTimeout(() => {
+          unlisten();
+          finish();
+        }, 500);
+      }).catch(() => finish());
     });
 
     win = await WebviewWindow.getByLabel('module-overlay-window').catch(() => null);
@@ -331,7 +353,7 @@ export function createOverlayHostAPI(): OverlayHostAPI {
       globalBus.emit('overlay:clear');
       emit('module:overlay-clear').catch(() => {});
       WebviewWindow.getByLabel('module-overlay-window')
-        .then((window) => window?.close())
+        .then((w) => w?.close())
         .catch(() => {});
     },
     isWindowOpen() {
@@ -339,21 +361,73 @@ export function createOverlayHostAPI(): OverlayHostAPI {
     },
   };
 }
+
+async function ensureMediaWindow() {
+  let win = await WebviewWindow.getByLabel('media-window').catch(() => null);
+  if (!win) {
+    await invoke('create_window', { label: 'media-window', title: 'Media Player' }).catch(
+      () => {}
+    );
+
+    await new Promise<void>((resolve) => {
+      let settled = false;
+      const finish = () => {
+        if (settled) return;
+        settled = true;
+        resolve();
+      };
+      listen('module:presenter-ready', () => {
+        finish();
+      }).then((unlisten) => {
+        setTimeout(() => {
+          unlisten();
+          finish();
+        }, 500);
+      }).catch(() => finish());
+    });
+
+    win = await WebviewWindow.getByLabel('media-window').catch(() => null);
+    if (win) {
+      await win.show().catch(() => {});
+    }
+    return { created: true };
+  }
+
+  const visible = await win.isVisible().catch(() => false);
+  if (!visible) await win.show().catch(() => {});
+  return { created: false };
+}
+
 export function createThemesHostAPI(): ThemesHostAPI {
   return {
     current() {
-      return { id: 'default', name: 'Default', colorMode: 'dark', accentId: 'cyan' };
+      const { profiles, activeProfileId } = useProfileStore.getState();
+      const profile = profiles.find((item) => item.id === activeProfileId);
+
+      return {
+        id: profile?.id ?? 'default',
+        name: profile?.name ?? 'Default',
+        colorMode: profile?.colorMode ?? 'dark',
+        accentId: profile?.accentId ?? 'cyan',
+      };
     },
     list() {
-      return [{ id: 'default', name: 'Default', colorMode: 'dark', accentId: 'cyan' }];
+      return useProfileStore.getState().profiles.map((profile) => ({
+        id: profile.id,
+        name: profile.name,
+        colorMode: profile.colorMode ?? 'dark',
+        accentId: profile.accentId ?? 'cyan',
+      }));
     },
     apply(id) {
-      globalBus.emit('themes:apply', { id });
+      useProfileStore.getState().setActiveProfile(id);
     },
     defaultBackground() {
       const { profiles, activeProfileId } = useProfileStore.getState();
-      const profile = profiles.find((p) => p.id === activeProfileId);
-      return profile?.defaultBackground ?? null;
+      const profileBg = profiles.find((p) => p.id === activeProfileId)?.defaultBackground;
+      return profileBg
+        ? { src: profileBg.src, type: profileBg.type, name: profileBg.name }
+        : null;
     },
     onDefaultBackgroundChange(handler) {
       let lastSrc: string | null | undefined = undefined;
@@ -364,11 +438,19 @@ export function createThemesHostAPI(): ThemesHostAPI {
           handler(bg);
           return;
         }
+
         Promise.all([
           readFile(src).then((bytes) => URL.createObjectURL(new Blob([bytes]))),
           thumbnailService.getThumbnail(src, 200).catch(() => null),
         ])
-          .then(([blobUrl, thumb]) => handler({ ...bg!, src: blobUrl, ...(thumb ? { thumb } : {}) }))
+          .then(([blobUrl, thumb]) => {
+            if (!bg) {
+              handler(null);
+              return;
+            }
+
+            handler({ ...bg, src: blobUrl, ...(thumb ? { thumb } : {}) });
+          })
           .catch(() => handler(bg));
       };
 
@@ -389,7 +471,16 @@ export function createThemesHostAPI(): ThemesHostAPI {
         fire(current);
       }
 
-      return { dispose: unsub };
+      return {
+        dispose() {
+          unsub();
+        },
+      };
     },
   };
 }
+
+
+
+
+

--- a/src/modules/apis/domain.ts
+++ b/src/modules/apis/domain.ts
@@ -16,6 +16,7 @@ import type {
   MediaType as PublicMediaType,
   PlayerHostAPI,
   PresentationHostAPI,
+  OverlayHostAPI,
   QueueHostAPI,
   ThemesHostAPI,
 } from '../types';
@@ -194,6 +195,13 @@ listen('module:presenter-window-closed', () => {
   globalBus.emit('presentation:clear');
 }).catch(() => {});
 
+listen('module:overlay-window-closed', () => {
+  overlayViewId = null;
+  globalBus.emit('overlay:clear');
+}).catch(() => {});
+
+let overlayViewId: string | null = null;
+
 async function ensureMediaWindow(): Promise<{ created: boolean }> {
   let win = await WebviewWindow.getByLabel('media-window').catch(() => null);
 
@@ -217,6 +225,33 @@ async function ensureMediaWindow(): Promise<{ created: boolean }> {
   return { created: false };
 }
 
+async function ensureOverlayWindow(): Promise<{ created: boolean }> {
+  let win = await WebviewWindow.getByLabel('module-overlay-window').catch(() => null);
+
+  if (!win) {
+    await invoke('create_window', {
+      label: 'module-overlay-window',
+      title: 'Module Overlay',
+      route: '/module-overlay-window',
+    }).catch(() => {});
+
+    await new Promise<void>((resolve) => {
+      const fallback = setTimeout(resolve, 6000);
+      listen('module:overlay-ready', () => {
+        clearTimeout(fallback);
+        resolve();
+      }).catch(() => {});
+    });
+
+    win = await WebviewWindow.getByLabel('module-overlay-window').catch(() => null);
+    if (win) await win.show().catch(() => {});
+    return { created: true };
+  }
+
+  const visible = await win.isVisible().catch(() => false);
+  if (!visible) await win.show().catch(() => {});
+  return { created: false };
+}
 export function createPresentationHostAPI(): PresentationHostAPI {
   let openedByModule = false;
 
@@ -257,6 +292,36 @@ export function createPresentationHostAPI(): PresentationHostAPI {
   };
 }
 
+export function createOverlayHostAPI(): OverlayHostAPI {
+  return {
+    state() {
+      return overlayViewId ? 'live' : 'idle';
+    },
+    onStateChange(handler) {
+      const onProject = globalBus.on('overlay:project', () => handler('live'));
+      const onClear = globalBus.on('overlay:clear', () => handler('idle'));
+      return { dispose() { onProject.dispose(); onClear.dispose(); } };
+    },
+    project(viewId, props) {
+      overlayViewId = viewId;
+      globalBus.emit('overlay:project', { viewId, props });
+      ensureOverlayWindow()
+        .then(() => emit('module:overlay-project', { viewId, props }))
+        .catch(() => {});
+    },
+    clear() {
+      overlayViewId = null;
+      globalBus.emit('overlay:clear');
+      emit('module:overlay-clear').catch(() => {});
+      WebviewWindow.getByLabel('module-overlay-window')
+        .then((window) => window?.close())
+        .catch(() => {});
+    },
+    isWindowOpen() {
+      return overlayViewId !== null;
+    },
+  };
+}
 export function createThemesHostAPI(): ThemesHostAPI {
   return {
     current() {

--- a/src/modules/apis/domain.ts
+++ b/src/modules/apis/domain.ts
@@ -197,10 +197,17 @@ listen('module:presenter-window-closed', () => {
 
 listen('module:overlay-window-closed', () => {
   overlayViewId = null;
+  overlayProps = undefined;
   globalBus.emit('overlay:clear');
 }).catch(() => {});
 
+listen('module:overlay-ready', () => {
+  if (!overlayViewId) return;
+  emit('module:overlay-project', { viewId: overlayViewId, props: overlayProps }).catch(() => {});
+}).catch(() => {});
+
 let overlayViewId: string | null = null;
+let overlayProps: unknown;
 
 async function ensureMediaWindow(): Promise<{ created: boolean }> {
   let win = await WebviewWindow.getByLabel('media-window').catch(() => null);

--- a/src/modules/apis/domain.ts
+++ b/src/modules/apis/domain.ts
@@ -88,6 +88,25 @@ export function createQueueHostAPI(): QueueHostAPI {
     markPlayed(id) {
       globalBus.emit('queue:markPlayed', { id });
     },
+    state() {
+      return { items: [], currentIndex: null };
+    },
+    onChange(handler) {
+      return globalBus.on('queue:changed', handler);
+    },
+    next() {
+      globalBus.emit('queue:next');
+    },
+    previous() {
+      globalBus.emit('queue:previous');
+    },
+    goTo(index) {
+      globalBus.emit('queue:goTo', { index });
+    },
+    registerTrigger(spec) {
+      const dispose = useModuleStore.getState().registerQueueTrigger(spec);
+      return { dispose };
+    },
   };
 }
 

--- a/src/modules/apis/ui.ts
+++ b/src/modules/apis/ui.ts
@@ -1,3 +1,4 @@
+import { readFile } from '@tauri-apps/plugin-fs';
 import { toast } from 'sonner';
 import { useModuleStore } from '../store';
 import type { SelectedBackground, UIAPI } from '../types';
@@ -46,7 +47,16 @@ export function createUIAPI(openCommandPaletteFn: (prefilter?: string) => void):
     },
 
     openBackgroundPicker(onSelect) {
-      _bgPickerOpener?.(onSelect);
+      if (!_bgPickerOpener) return;
+      _bgPickerOpener((bg) => {
+        const src = bg.src ?? '';
+        const isFilePath = src && !src.startsWith('blob:') && !src.startsWith('http') && !src.startsWith('data:');
+        if (!isFilePath) { onSelect(bg); return; }
+        readFile(src)
+          .then((bytes) => URL.createObjectURL(new Blob([bytes])))
+          .then((blobUrl) => onSelect({ ...bg, src: blobUrl }))
+          .catch(() => onSelect(bg));
+      });
     },
   };
 }

--- a/src/modules/components/DialogSlot.tsx
+++ b/src/modules/components/DialogSlot.tsx
@@ -5,6 +5,7 @@ import { ModuleErrorBoundary } from './ModuleErrorBoundary';
 
 export function DialogSlot() {
   const closeDialog = useModuleStore((s) => s.closeDialog);
+
   const spec = useModuleStore<PanelSpec | null>((s) => {
     if (!s.openDialogId) return null;
     for (const specs of s.panels.values()) {
@@ -14,9 +15,18 @@ export function DialogSlot() {
     return null;
   });
 
+  const moduleId = useModuleStore<string | null>((s) => {
+    if (!s.openDialogId) return null;
+    for (const [modId, specs] of s.panels.entries()) {
+      if (specs.some((p) => p.id === s.openDialogId && p.slot === 'dialog')) {
+        return modId;
+      }
+    }
+    return null;
+  });
+
   const isOpen = spec !== null;
   const Component = spec?.component;
-  const moduleId = spec?.id.split('.').slice(0, -1).join('.');
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => { if (!open) closeDialog(); }}>
@@ -27,7 +37,9 @@ export function DialogSlot() {
       >
         {isOpen && Component && moduleId && (
           <ModuleErrorBoundary moduleId={moduleId} panelId={spec!.id}>
-            <Component close={closeDialog} />
+            <div data-module-scope={moduleId}>
+              <Component close={closeDialog} />
+            </div>
           </ModuleErrorBoundary>
         )}
       </DialogContent>

--- a/src/modules/components/HeaderTrailingSlot.tsx
+++ b/src/modules/components/HeaderTrailingSlot.tsx
@@ -8,15 +8,20 @@ interface HeaderTrailingSlotProps {
   panelProps?: PanelProps;
 }
 
+type SlotPanel = {
+  moduleId: string;
+  spec: PanelSpec;
+};
+
 export function HeaderTrailingSlot({ panelProps = {} }: HeaderTrailingSlotProps) {
   const panelMap = useModuleStore((s) => s.panels);
   const panels = useMemo(() => {
-    const result: PanelSpec[] = [];
+    const result: SlotPanel[] = [];
 
-    for (const specs of panelMap.values()) {
+    for (const [moduleId, specs] of panelMap.entries()) {
       for (const spec of specs) {
         if (spec.slot === 'app.header.trailing') {
-          result.push(spec);
+          result.push({ moduleId, spec });
         }
       }
     }
@@ -28,14 +33,14 @@ export function HeaderTrailingSlot({ panelProps = {} }: HeaderTrailingSlotProps)
 
   return (
     <div className="flex min-w-0 items-center gap-2">
-      {panels.map((spec) => {
+      {panels.map(({ moduleId, spec }, index) => {
         if (spec.when && !spec.when()) return null;
 
-        const moduleId = spec.id.split('.').slice(0, -1).join('.');
         const Component = spec.component as React.ComponentType<PanelProps>;
+        const panelKey = `${moduleId}:${spec.id}:${index}`;
 
         return (
-          <ModuleErrorBoundary key={spec.id} moduleId={moduleId} panelId={spec.id}>
+          <ModuleErrorBoundary key={panelKey} moduleId={moduleId} panelId={spec.id}>
             <div className="min-w-0 max-w-36 shrink-0 overflow-hidden rounded-md border border-border/60 bg-background/60 px-2 py-1 text-xs empty:hidden">
               <Component {...panelProps} />
             </div>

--- a/src/modules/components/HeaderTrailingSlot.tsx
+++ b/src/modules/components/HeaderTrailingSlot.tsx
@@ -1,45 +1,47 @@
 import { useMemo } from 'react';
+import type React from 'react';
 import { useModuleStore } from '../store';
-import type { PanelProps, PanelSpec, SlotName } from '../types';
+import type { PanelProps, PanelSpec } from '../types';
 import { ModuleErrorBoundary } from './ModuleErrorBoundary';
 
-interface PanelSlotProps {
-  slot: SlotName;
+interface HeaderTrailingSlotProps {
   panelProps?: PanelProps;
 }
 
-export function PanelSlot({ slot, panelProps = {} }: PanelSlotProps) {
+export function HeaderTrailingSlot({ panelProps = {} }: HeaderTrailingSlotProps) {
   const panelMap = useModuleStore((s) => s.panels);
   const panels = useMemo(() => {
     const result: PanelSpec[] = [];
 
     for (const specs of panelMap.values()) {
       for (const spec of specs) {
-        if (spec.slot === slot) {
+        if (spec.slot === 'app.header.trailing') {
           result.push(spec);
         }
       }
     }
 
     return result;
-  }, [panelMap, slot]);
+  }, [panelMap]);
 
   if (panels.length === 0) return null;
 
   return (
-    <>
+    <div className="flex min-w-0 items-center gap-2">
       {panels.map((spec) => {
         if (spec.when && !spec.when()) return null;
 
         const moduleId = spec.id.split('.').slice(0, -1).join('.');
-        const Component = spec.component;
+        const Component = spec.component as React.ComponentType<PanelProps>;
 
         return (
           <ModuleErrorBoundary key={spec.id} moduleId={moduleId} panelId={spec.id}>
-            <Component {...panelProps} />
+            <div className="min-w-0 max-w-36 shrink-0 overflow-hidden rounded-md border border-border/60 bg-background/60 px-2 py-1 text-xs empty:hidden">
+              <Component {...panelProps} />
+            </div>
           </ModuleErrorBoundary>
         );
       })}
-    </>
+    </div>
   );
 }

--- a/src/modules/components/PanelSlot.tsx
+++ b/src/modules/components/PanelSlot.tsx
@@ -8,15 +8,20 @@ interface PanelSlotProps {
   panelProps?: PanelProps;
 }
 
+type SlotPanel = {
+  moduleId: string;
+  spec: PanelSpec;
+};
+
 export function PanelSlot({ slot, panelProps = {} }: PanelSlotProps) {
   const panelMap = useModuleStore((s) => s.panels);
   const panels = useMemo(() => {
-    const result: PanelSpec[] = [];
+    const result: SlotPanel[] = [];
 
-    for (const specs of panelMap.values()) {
+    for (const [moduleId, specs] of panelMap.entries()) {
       for (const spec of specs) {
         if (spec.slot === slot) {
-          result.push(spec);
+          result.push({ moduleId, spec });
         }
       }
     }
@@ -28,14 +33,14 @@ export function PanelSlot({ slot, panelProps = {} }: PanelSlotProps) {
 
   return (
     <>
-      {panels.map((spec) => {
+      {panels.map(({ moduleId, spec }, index) => {
         if (spec.when && !spec.when()) return null;
 
-        const moduleId = spec.id.split('.').slice(0, -1).join('.');
         const Component = spec.component;
+        const panelKey = `${moduleId}:${spec.id}:${index}`;
 
         return (
-          <ModuleErrorBoundary key={spec.id} moduleId={moduleId} panelId={spec.id}>
+          <ModuleErrorBoundary key={panelKey} moduleId={moduleId} panelId={spec.id}>
             <Component {...panelProps} />
           </ModuleErrorBoundary>
         );

--- a/src/modules/components/PresenterSlot.tsx
+++ b/src/modules/components/PresenterSlot.tsx
@@ -115,10 +115,10 @@ export function PresenterSlot({ renderBackdrop = true }: { renderBackdrop?: bool
   const Component = spec.component;
 
   return (
-    <div className="fixed inset-0 z-50">
+    <div className="fixed inset-0 z-50 h-dvh w-dvw overflow-hidden bg-transparent isolate">
       {renderBackdrop && <PresenterBackdropLayer props={props} />}
       <ModuleErrorBoundary moduleId={moduleId} panelId={spec.id}>
-        <div data-module-scope={moduleId}>
+        <div data-module-scope={moduleId} className="absolute inset-0 h-full w-full overflow-hidden">
           <Component {...props} onClose={clearPresenter} />
         </div>
       </ModuleErrorBoundary>

--- a/src/modules/components/PresenterSlot.tsx
+++ b/src/modules/components/PresenterSlot.tsx
@@ -63,12 +63,21 @@ export function PresenterSlot() {
     }
     return null;
   });
+
+  const moduleId = useModuleStore<string | null>((s) => {
+    if (!s.presenterViewId) return null;
+    for (const [modId, specs] of s.panels.entries()) {
+      if (specs.some((p) => p.id === s.presenterViewId && p.slot === 'presenter.content')) {
+        return modId;
+      }
+    }
+    return null;
+  });
   const props = useModuleStore((s) => s.presenterProps) as Record<string, unknown>;
 
-  if (!spec) return null;
+  if (!spec || !moduleId) return null;
 
   const Component = spec.component;
-  const moduleId = spec.id.split('.').slice(0, -1).join('.');
   const background = props?.background as string | undefined;
   const bg = background === 'media' ? (props?.backgroundMedia as BackgroundMedia | undefined) : undefined;
 
@@ -77,7 +86,9 @@ export function PresenterSlot() {
       {background === 'default' && <PresenterDefaultBackground />}
       {bg && <PresenterBackground media={bg} />}
       <ModuleErrorBoundary moduleId={moduleId} panelId={spec.id}>
-        <Component {...props} onClose={clearPresenter} />
+        <div data-module-scope={moduleId}>
+          <Component {...props} onClose={clearPresenter} />
+        </div>
       </ModuleErrorBoundary>
     </div>
   );

--- a/src/modules/components/PresenterSlot.tsx
+++ b/src/modules/components/PresenterSlot.tsx
@@ -11,12 +11,25 @@ interface BackgroundMedia {
   name: string;
 }
 
+type PresenterProps = Record<string, unknown>;
+
 function useBackgroundBlobSrc(path?: string): string | undefined {
   const [src, setSrc] = useState<string | undefined>();
 
   useEffect(() => {
-    if (!path) { setSrc(undefined); return; }
-    if (path.startsWith('http') || path.startsWith('#')) { setSrc(path); return; }
+    if (!path) {
+      setSrc(undefined);
+      return;
+    }
+    if (
+      path.startsWith('http') ||
+      path.startsWith('blob:') ||
+      path.startsWith('data:') ||
+      path.startsWith('#')
+    ) {
+      setSrc(path);
+      return;
+    }
 
     let url: string;
     readFile(path)
@@ -26,7 +39,9 @@ function useBackgroundBlobSrc(path?: string): string | undefined {
       })
       .catch(() => setSrc(undefined));
 
-    return () => { if (url) URL.revokeObjectURL(url); };
+    return () => {
+      if (url) URL.revokeObjectURL(url);
+    };
   }, [path]);
 
   return src;
@@ -39,7 +54,9 @@ function PresenterBackground({ media }: { media: BackgroundMedia }) {
   if (!src) return null;
 
   if (media.type === 'video') {
-    return <video src={src} autoPlay loop muted className="absolute inset-0 w-full h-full object-cover" />;
+    return (
+      <video src={src} autoPlay loop muted className="absolute inset-0 h-full w-full object-cover" />
+    );
   }
   return <img src={src} alt="" className="absolute inset-0 w-full h-full object-cover" />;
 }
@@ -53,7 +70,25 @@ function PresenterDefaultBackground() {
   return <img src={src} alt="" className="absolute inset-0 w-full h-full object-cover" />;
 }
 
-export function PresenterSlot() {
+function PresenterBackdropLayer({ props }: { props: PresenterProps }) {
+  const background = props?.background as string | undefined;
+  const bg =
+    background === 'media' ? (props?.backgroundMedia as BackgroundMedia | undefined) : undefined;
+
+  if (background === 'default') return <PresenterDefaultBackground />;
+  if (bg) return <PresenterBackground media={bg} />;
+  return null;
+}
+
+export function PresenterBackdrop() {
+  const presenterViewId = useModuleStore((s) => s.presenterViewId);
+  const props = useModuleStore((s) => s.presenterProps) as PresenterProps | undefined;
+
+  if (!presenterViewId || !props) return null;
+  return <PresenterBackdropLayer props={props} />;
+}
+
+export function PresenterSlot({ renderBackdrop = true }: { renderBackdrop?: boolean }) {
   const clearPresenter = useModuleStore((s) => s.clearPresenter);
   const spec = useModuleStore<PanelSpec | null>((s) => {
     if (!s.presenterViewId) return null;
@@ -73,18 +108,15 @@ export function PresenterSlot() {
     }
     return null;
   });
-  const props = useModuleStore((s) => s.presenterProps) as Record<string, unknown>;
+  const props = useModuleStore((s) => s.presenterProps) as PresenterProps;
 
   if (!spec || !moduleId) return null;
 
   const Component = spec.component;
-  const background = props?.background as string | undefined;
-  const bg = background === 'media' ? (props?.backgroundMedia as BackgroundMedia | undefined) : undefined;
 
   return (
     <div className="fixed inset-0 z-50">
-      {background === 'default' && <PresenterDefaultBackground />}
-      {bg && <PresenterBackground media={bg} />}
+      {renderBackdrop && <PresenterBackdropLayer props={props} />}
       <ModuleErrorBoundary moduleId={moduleId} panelId={spec.id}>
         <div data-module-scope={moduleId}>
           <Component {...props} onClose={clearPresenter} />

--- a/src/modules/host.ts
+++ b/src/modules/host.ts
@@ -7,6 +7,7 @@ import {
   createLibraryHostAPI,
   createLyricsHostAPI,
   createPlayerHostAPI,
+  createOverlayHostAPI,
   createPresentationHostAPI,
   createQueueHostAPI,
   createThemesHostAPI,
@@ -50,6 +51,7 @@ export async function createHost(
     library: createLibraryHostAPI(),
     player: createPlayerHostAPI(),
     presentation: createPresentationHostAPI(),
+    overlay: createOverlayHostAPI(),
     themes: createThemesHostAPI(),
     fonts: createFontsAPI(),
 

--- a/src/modules/injector.ts
+++ b/src/modules/injector.ts
@@ -47,6 +47,15 @@ function installGlobalErrorHandlers() {
   });
 }
 
+function scopeModuleStyles(moduleId: string) {
+  const styleEl = document.head.querySelector<HTMLStyleElement>(
+    `style[data-module="${CSS.escape(moduleId)}"]`,
+  );
+  if (styleEl?.textContent) {
+    styleEl.textContent = `@scope ([data-module-scope="${moduleId}"]) {\n${styleEl.textContent}\n}`;
+  }
+}
+
 export async function bootModules() {
   if (!globalHandlersInstalled) {
     installGlobalErrorHandlers();
@@ -105,6 +114,8 @@ export async function loadModule(manifest: ModuleManifest) {
     const trackedHost = wrapHostForTracking(host, disposables);
 
     await plugin.onload(trackedHost);
+
+    scopeModuleStyles(manifest.id);
 
     loaded.set(manifest.id, { plugin, disposables, errorTimestamps: [] });
     store.setStatus(manifest.id, 'active');

--- a/src/modules/presenter-host.ts
+++ b/src/modules/presenter-host.ts
@@ -60,6 +60,12 @@ export async function createPresenterHost(manifest: ModuleManifest): Promise<Lum
       items: stub([]),
       currentIndex: stub(-1),
       add: noop, remove: noop, reorder: noop, shuffle: noop, markPlayed: noop,
+      state: stub({ items: [], currentIndex: null }),
+      onChange: () => noopDisposable,
+      next: noop,
+      previous: noop,
+      goTo: noop,
+      registerTrigger: () => noopDisposable,
     },
     library: {
       list: stub(Promise.resolve([])),
@@ -81,6 +87,13 @@ export async function createPresenterHost(manifest: ModuleManifest): Promise<Lum
       clear: noop,
       isWindowOpen: stub(true),
     },
+    overlay: {
+      state: stub('idle' as const),
+      onStateChange: () => noopDisposable,
+      project: noop,
+      clear: noop,
+      isWindowOpen: stub(false),
+    },
     fonts: {
       list: stub(Promise.resolve([] as string[])),
     },
@@ -88,6 +101,8 @@ export async function createPresenterHost(manifest: ModuleManifest): Promise<Lum
       current: stub({ id: 'default', name: 'Default', colorMode: 'dark' as const, accentId: 'cyan' }),
       list: stub([]),
       apply: noop,
+      defaultBackground: stub(null),
+      onDefaultBackgroundChange: () => noopDisposable,
     },
 
     fs: createFsAPI(id),

--- a/src/modules/store.ts
+++ b/src/modules/store.ts
@@ -1,9 +1,10 @@
 import { create } from 'zustand';
-import type { ModuleRecord, ModuleStatus, PanelSpec } from './types';
+import type { ModuleRecord, ModuleStatus, PanelSpec, QueueTriggerSpec } from './types';
 
 interface ModuleStore {
   modules: Map<string, ModuleRecord>;
   panels: Map<string, PanelSpec[]>;
+  queueTriggerSpecs: Map<string, QueueTriggerSpec>;
   openDialogId: string | null;
   presenterViewId: string | null;
   presenterProps: unknown;
@@ -18,6 +19,9 @@ interface ModuleStore {
   removePanelsForModule(moduleId: string): void;
   getPanelsForSlot(slot: string): PanelSpec[];
 
+  registerQueueTrigger(spec: QueueTriggerSpec): () => void;
+  getQueueTriggerSpecs(): QueueTriggerSpec[];
+
   openDialog(id: string): void;
   closeDialog(): void;
   projectPanel(viewId: string, props?: unknown): void;
@@ -27,6 +31,7 @@ interface ModuleStore {
 export const useModuleStore = create<ModuleStore>((set, get) => ({
   modules: new Map(),
   panels: new Map(),
+  queueTriggerSpecs: new Map(),
   openDialogId: null,
   presenterViewId: null,
   presenterProps: undefined,
@@ -98,6 +103,25 @@ export const useModuleStore = create<ModuleStore>((set, get) => ({
       next.delete(moduleId);
       return { panels: next };
     });
+  },
+
+  registerQueueTrigger(spec) {
+    set((s) => {
+      const next = new Map(s.queueTriggerSpecs);
+      next.set(spec.id, spec);
+      return { queueTriggerSpecs: next };
+    });
+    return () => {
+      set((s) => {
+        const next = new Map(s.queueTriggerSpecs);
+        next.delete(spec.id);
+        return { queueTriggerSpecs: next };
+      });
+    };
+  },
+
+  getQueueTriggerSpecs() {
+    return Array.from(get().queueTriggerSpecs.values());
   },
 
   openDialog(id) {

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -7,7 +7,8 @@ export interface Disposable {
 export type SlotName =
   | 'dialog'
   | 'presenter.content'
-  | 'sidebar.right.tabs';
+  | 'sidebar.right.tabs'
+  | 'app.header.trailing';
 
 export interface PanelProps {
   close?: () => void;
@@ -405,3 +406,4 @@ export interface ModuleRecord {
   errorCount: number;
   source: 'bundled' | 'store' | 'sideload' | 'dev';
 }
+

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -284,6 +284,8 @@ export interface ThemesHostAPI {
   current(): ThemeRef;
   list(): ThemeRef[];
   apply(id: string): void;
+  defaultBackground(): { src: string; type: 'theme' | 'image' | 'video'; name: string } | null;
+  onDefaultBackgroundChange(handler: (bg: { src: string; type: 'theme' | 'image' | 'video'; name: string } | null) => void): Disposable;
 }
 
 export interface FsAPI {

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -293,6 +293,13 @@ export interface PresentationHostAPI {
   isWindowOpen(): boolean;
 }
 
+export interface OverlayHostAPI {
+  state(): 'idle' | 'live';
+  onStateChange(handler: (state: 'idle' | 'live') => void): Disposable;
+  project(viewId: string, props?: unknown): void;
+  clear(): void;
+  isWindowOpen(): boolean;
+}
 
 export interface ThemeRef {
   id: string;
@@ -355,6 +362,7 @@ export interface LumenHost {
   library: LibraryHostAPI;
   player: PlayerHostAPI;
   presentation: PresentationHostAPI;
+  overlay: OverlayHostAPI;
   themes: ThemesHostAPI;
   fonts: FontsAPI;
 

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -201,6 +201,20 @@ export interface QueueItem {
   played: boolean;
 }
 
+export interface QueueState {
+  items: { id: string; title: string }[];
+  currentIndex: number | null;
+}
+
+export interface QueueTriggerSpec {
+  id: string;
+  label: string;
+  icon?: React.ComponentType<{ size?: number; className?: string }>;
+  ConfigComponent: React.ComponentType<{ value: unknown; onChange: (value: unknown) => void }>;
+  defaultConfig: unknown;
+  onFire(config: unknown): void;
+}
+
 export interface QueueHostAPI {
   items(): QueueItem[];
   currentIndex(): number;
@@ -209,6 +223,12 @@ export interface QueueHostAPI {
   reorder(fromIndex: number, toIndex: number): void;
   shuffle(): void;
   markPlayed(id: string): void;
+  state(): QueueState;
+  onChange(handler: (state: QueueState) => void): Disposable;
+  next(): void;
+  previous(): void;
+  goTo(index: number): void;
+  registerTrigger(spec: QueueTriggerSpec): Disposable;
 }
 
 export type MediaType = 'audio' | 'video' | 'image';

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -285,7 +285,7 @@ export interface ThemesHostAPI {
   list(): ThemeRef[];
   apply(id: string): void;
   defaultBackground(): { src: string; type: 'theme' | 'image' | 'video'; name: string } | null;
-  onDefaultBackgroundChange(handler: (bg: { src: string; type: 'theme' | 'image' | 'video'; name: string } | null) => void): Disposable;
+  onDefaultBackgroundChange(handler: (bg: { src: string; thumb?: string; type: 'theme' | 'image' | 'video'; name: string } | null) => void): Disposable;
 }
 
 export interface FsAPI {

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -211,6 +211,7 @@ export interface QueueTriggerSpec {
   label: string;
   icon?: React.ComponentType<{ size?: number; className?: string }>;
   ConfigComponent: React.ComponentType<{ value: unknown; onChange: (value: unknown) => void }>;
+  SummaryComponent?: React.ComponentType<{ value: unknown; onEdit: () => void }>;
   defaultConfig: unknown;
   onFire(config: unknown): void;
 }

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './app/__root'
+import { Route as ModuleOverlayWindowRouteImport } from './app/module-overlay-window'
 import { Route as MediaWindowRouteImport } from './app/media-window'
 import { Route as LayoutRouteImport } from './app/_layout'
 import { Route as LayoutIndexRouteImport } from './app/_layout/index'
@@ -17,6 +18,11 @@ import { Route as LayoutPresentationRouteImport } from './app/_layout/presentati
 import { Route as LayoutLiveRouteImport } from './app/_layout/live'
 import { Route as LayoutEditRouteImport } from './app/_layout/edit'
 
+const ModuleOverlayWindowRoute = ModuleOverlayWindowRouteImport.update({
+  id: '/module-overlay-window',
+  path: '/module-overlay-window',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const MediaWindowRoute = MediaWindowRouteImport.update({
   id: '/media-window',
   path: '/media-window',
@@ -54,6 +60,7 @@ const LayoutEditRoute = LayoutEditRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/media-window': typeof MediaWindowRoute
+  '/module-overlay-window': typeof ModuleOverlayWindowRoute
   '/edit': typeof LayoutEditRoute
   '/live': typeof LayoutLiveRoute
   '/presentation': typeof LayoutPresentationRoute
@@ -62,6 +69,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/media-window': typeof MediaWindowRoute
+  '/module-overlay-window': typeof ModuleOverlayWindowRoute
   '/edit': typeof LayoutEditRoute
   '/live': typeof LayoutLiveRoute
   '/presentation': typeof LayoutPresentationRoute
@@ -72,6 +80,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/_layout': typeof LayoutRouteWithChildren
   '/media-window': typeof MediaWindowRoute
+  '/module-overlay-window': typeof ModuleOverlayWindowRoute
   '/_layout/edit': typeof LayoutEditRoute
   '/_layout/live': typeof LayoutLiveRoute
   '/_layout/presentation': typeof LayoutPresentationRoute
@@ -82,17 +91,26 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/media-window'
+    | '/module-overlay-window'
     | '/edit'
     | '/live'
     | '/presentation'
     | '/settings'
     | '/'
   fileRoutesByTo: FileRoutesByTo
-  to: '/media-window' | '/edit' | '/live' | '/presentation' | '/settings' | '/'
+  to:
+    | '/media-window'
+    | '/module-overlay-window'
+    | '/edit'
+    | '/live'
+    | '/presentation'
+    | '/settings'
+    | '/'
   id:
     | '__root__'
     | '/_layout'
     | '/media-window'
+    | '/module-overlay-window'
     | '/_layout/edit'
     | '/_layout/live'
     | '/_layout/presentation'
@@ -103,10 +121,18 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   LayoutRoute: typeof LayoutRouteWithChildren
   MediaWindowRoute: typeof MediaWindowRoute
+  ModuleOverlayWindowRoute: typeof ModuleOverlayWindowRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/module-overlay-window': {
+      id: '/module-overlay-window'
+      path: '/module-overlay-window'
+      fullPath: '/module-overlay-window'
+      preLoaderRoute: typeof ModuleOverlayWindowRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/media-window': {
       id: '/media-window'
       path: '/media-window'
@@ -181,6 +207,7 @@ const LayoutRouteWithChildren =
 const rootRouteChildren: RootRouteChildren = {
   LayoutRoute: LayoutRouteWithChildren,
   MediaWindowRoute: MediaWindowRoute,
+  ModuleOverlayWindowRoute: ModuleOverlayWindowRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/services/queue-db-service.ts
+++ b/src/services/queue-db-service.ts
@@ -155,6 +155,13 @@ class QueueDbService {
     await db.execute('DELETE FROM queue');
   }
 
+  async reorderQueue(orderedIds: number[]): Promise<void> {
+    const db = await this.ready();
+    for (let i = 0; i < orderedIds.length; i++) {
+      await db.execute('UPDATE queue SET position = $1 WHERE id = $2', [i, orderedIds[i]]);
+    }
+  }
+
   async shuffleQueue(): Promise<void> {
     const db = await this.ready();
     const rows = await db.select<QueueRow[]>('SELECT * FROM queue ORDER BY position ASC');

--- a/src/stores/command-store.ts
+++ b/src/stores/command-store.ts
@@ -32,12 +32,12 @@ export const useCommandStore = create<CommandStore>((set) => ({
   commands: [],
   prefixes: [],
 
-  open: (prefilter = '') => set({ isOpen: true, prefilter, activeApp: null }),
-  close: () => set({ isOpen: false, prefilter: '', activeApp: null }),
+  open: (prefilter = '') => set({ isOpen: true, prefilter }),
+  close: () => set({ isOpen: false, prefilter: '' }),
   toggle: () =>
     set((s) =>
       s.isOpen
-        ? { isOpen: false, prefilter: '', activeApp: null }
+        ? { isOpen: false, prefilter: '' }
         : { isOpen: true },
     ),
 

--- a/src/stores/player-store.ts
+++ b/src/stores/player-store.ts
@@ -5,6 +5,7 @@ import { create } from 'zustand';
 import { getSetting, saveSetting } from '@/services/db';
 import { remoteSyncService } from '@/services/remote-sync-service';
 import { useQueueStore } from '@/stores/queue-store';
+import { useQueueEntriesStore } from '@/stores/queue-entries-store';
 
 interface PlayerStore {
   localTime: number;
@@ -186,12 +187,10 @@ export const usePlayerStore = create<PlayerStore>((set, get) => ({
       void broadcastPlayerSync(get, 'stop');
       invoke('push_stream_blank').catch(() => {});
 
-      useQueueStore
-        .getState()
-        .shiftQueue(get().currentFilePath ?? undefined)
-        .then((next) => {
-          if (next) get().loadFile(next.path);
-        });
+      const result = useQueueEntriesStore.getState().advanceQueue(get().currentFilePath);
+      if (result.type === 'play') {
+        void get().loadFile(result.path);
+      }
     });
 
     const unlistenSetVolume = listen<number>('set-volume', (event) => {

--- a/src/stores/queue-entries-store.ts
+++ b/src/stores/queue-entries-store.ts
@@ -1,0 +1,89 @@
+import { create } from 'zustand';
+import { useModuleStore } from '@/modules/store';
+import { useQueueStore, type QueueItem } from './queue-store';
+
+export type TriggerInstance = { id: string; triggerId: string; config: unknown; showLabel: boolean };
+
+export type ListEntry =
+  | { kind: 'item'; id: string; item: QueueItem }
+  | { kind: 'trigger'; id: string; inst: TriggerInstance };
+
+type AdvanceResult =
+  | { type: 'play'; path: string }
+  | { type: 'triggered' }
+  | { type: 'end' };
+
+interface QueueEntriesStore {
+  entries: ListEntry[];
+  pendingIndex: number;
+  syncQueue: (queue: QueueItem[]) => void;
+  setEntries: (entries: ListEntry[]) => void;
+  advanceQueue: (currentFilePath: string | null) => AdvanceResult;
+}
+
+export const useQueueEntriesStore = create<QueueEntriesStore>((set, get) => ({
+  entries: [],
+  pendingIndex: -1,
+
+  syncQueue: (queue) => {
+    set((state) => {
+      const prevItemIds = new Set(
+        state.entries
+          .filter((e): e is Extract<ListEntry, { kind: 'item' }> => e.kind === 'item')
+          .map((e) => e.id)
+      );
+      const currIds = new Set(queue.map((i) => String(i.id)));
+
+      const filtered = state.entries
+        .filter((e) => e.kind === 'trigger' || currIds.has(e.id))
+        .map((e): ListEntry => {
+          if (e.kind === 'item') {
+            const updated = queue.find((i) => String(i.id) === e.id);
+            return updated ? { ...e, item: updated } : e;
+          }
+          return e;
+        });
+
+      const newItems = queue
+        .filter((i) => !prevItemIds.has(String(i.id)))
+        .map((i): ListEntry => ({ kind: 'item', id: String(i.id), item: i }));
+
+      return { entries: [...filtered, ...newItems] };
+    });
+  },
+
+  setEntries: (entries) => set({ entries }),
+
+  advanceQueue: (currentFilePath) => {
+    const { entries, pendingIndex } = get();
+
+    let startIdx: number;
+    if (pendingIndex >= 0) {
+      startIdx = pendingIndex;
+      set({ pendingIndex: -1 });
+    } else {
+      startIdx = currentFilePath
+        ? entries.findIndex((e) => e.kind === 'item' && e.item.file.path === currentFilePath)
+        : -1;
+    }
+
+    for (let i = startIdx + 1; i < entries.length; i++) {
+      const entry = entries[i];
+      if (entry.kind === 'item') {
+        useQueueStore.getState().markPlayed(entry.item.id);
+        return { type: 'play', path: entry.item.file.path };
+      }
+      if (entry.kind === 'trigger') {
+        const specs = useModuleStore.getState().getQueueTriggerSpecs();
+        const spec = specs.find((s) => s.id === entry.inst.triggerId);
+        if (spec) {
+          set({ pendingIndex: i });
+          spec.onFire(entry.inst.config);
+          return { type: 'triggered' };
+        }
+      }
+    }
+
+    return { type: 'end' };
+  },
+}));

--- a/src/stores/queue-store.ts
+++ b/src/stores/queue-store.ts
@@ -20,6 +20,7 @@ interface QueueStore {
   shiftQueue: (excludePath?: string) => Promise<FileInfo | null>;
   clearQueue: () => Promise<void>;
   shuffleQueue: () => Promise<void>;
+  reorderQueue: (orderedIds: number[]) => Promise<void>;
   updateMetadata: (filePath: string, metadata: { duration?: number; title?: string; artist?: string }) => Promise<void>;
 }
 
@@ -91,6 +92,14 @@ export const useQueueStore = create<QueueStore>((set) => ({
     await queueDbService.loadQueue().then((items) => {
       set({ queue: items.map((item) => ({ id: item.id, file: item, played: item.played })) });
     });
+  },
+
+  reorderQueue: async (orderedIds) => {
+    set((s) => {
+      const map = new Map(s.queue.map((item) => [item.id, item]));
+      return { queue: orderedIds.map((id) => map.get(id)!).filter(Boolean) };
+    });
+    await queueDbService.reorderQueue(orderedIds);
   },
 
   updateMetadata: async (filePath, metadata) => {


### PR DESCRIPTION
## 📋 Description

Adds a dedicated module overlay window flow for presenter-style module output, while keeping the media window behavior unchanged.

### What was changed?
- Added support for opening module output in a separate `module-overlay-window` route instead of reusing the media window.
- Added a dedicated Tauri command to create the overlay window as a normal movable window near the main app window.
- Kept the media window fullscreen behavior intact for existing presentation flows.
- Replayed overlay projection when the overlay window becomes ready so presenter content loads reliably.
- Isolated auxiliary window bootstrapping to avoid loading the full main-app module shell inside overlay/media windows.
- Synced overlay state when the native window is closed via toolbar, `Esc`, or `Alt+F4`.
- Added the required Tauri capability permissions for the overlay window, including native destroy handling.

### Why?
- Modules needed an overlay-specific output path that does not hijack the media screen.
- The previous implementation could open a blank overlay, interfere with media window sizing behavior, or leave the overlay button state stale after native window close.

## 🔗 Related Issues

- No linked issue provided

## 🧪 How to Test

1. Open a module that supports overlay output, such as the countdown module.
2. Click the overlay action and confirm a separate overlay window opens near the main app window.
3. Verify the module presenter content renders inside the overlay window.
4. Start, pause, and reset the module flow and confirm the overlay stays in sync.
5. Confirm preview/media flows still use the media window in fullscreen as before.
6. Close the overlay using the toolbar close button, `Esc`, and `Alt+F4`.
7. Verify the overlay closes and the module UI leaves the overlay state correctly.

## 📸 Screenshots/Evidence

- User-validated manually during development

## ✅ Checklist

- [x] UX/API/contract impact covered
- [ ] Docs or release notes updated
- [ ] Migrations/Seeds applied (if any)
- [ ] Rollout/rollback flags defined
- [ ] Tests added or updated
- [ ] All tests passing
- [x] Self-reviewed
- [ ] QA/Stakeholders notified

## 📝 Additional Notes

- This PR focuses on the `lumen` app side of overlay window support.
- Related SDK and module changes were handled in their respective repositories.
- Tauri capability changes require restarting the desktop app to validate native close behavior.
