### PR TITLE
feat/add-external-url-suport

### DIFF
--- a/docs/architecture/youtube-url-media-support-plan.md
+++ b/docs/architecture/youtube-url-media-support-plan.md
@@ -1,0 +1,195 @@
+# YouTube URL Media Support Plan
+
+## Goal
+
+Allow Lumen to treat a YouTube URL as a video media item in the library and queue, with the smallest useful model for now:
+
+- Support only YouTube URLs initially.
+- Store URL entries under `video` media.
+- Do not add an in-app UI to add YouTube videos yet; modules will use host APIs later.
+- Reuse the current player path because `ReactPlayer` already handles YouTube.
+- Fetch title, channel/author, and thumbnail through YouTube oEmbed when possible.
+- Cache the thumbnail locally so the list/queue can still show it offline.
+- Persist a download status so the UI/player can distinguish URL-only media from media that has a local downloaded file later.
+
+## Current Decision
+
+Keep the persisted model intentionally small. We do not need provider/source fields while the only accepted URL source is YouTube and the player already supports the URL.
+
+`FileInfo` keeps only these new URL-related fields:
+
+```ts
+export type DownloadStatus = 'not_downloaded' | 'downloaded' | 'missing';
+
+export interface FileInfo {
+  name: string;
+  path: string;
+  size: number;
+  modifiedAt: Date;
+  extension: string;
+  duration?: number;
+  title?: string;
+  artist?: string;
+  originalUrl?: string;
+  thumbnailPath?: string;
+  remoteThumbnailUrl?: string;
+  downloadStatus?: DownloadStatus;
+}
+```
+
+Compatibility rules:
+
+- Local files keep working exactly as before.
+- URL media is identified by `extension === 'url'` or `originalUrl` being present.
+- For now, `path` remains required by the existing schema and queue/player flow.
+- For URL-only media, `path` stores the normalized YouTube watch URL as a compatibility fallback.
+- If a future downloader adds a local video file, the downloaded file path can be represented through the existing `path` semantics after a dedicated migration, or by adding a single explicit local-path column later when the downloader exists.
+
+## SQLite Changes
+
+Add only the fields that are needed by the current behavior.
+
+`media_files`:
+
+```sql
+ALTER TABLE media_files ADD COLUMN original_url TEXT;
+ALTER TABLE media_files ADD COLUMN thumbnail_path TEXT;
+ALTER TABLE media_files ADD COLUMN remote_thumbnail_url TEXT;
+ALTER TABLE media_files ADD COLUMN download_status TEXT NOT NULL DEFAULT 'downloaded';
+CREATE INDEX IF NOT EXISTS idx_mf_original_url ON media_files (original_url);
+```
+
+`queue`:
+
+```sql
+ALTER TABLE queue ADD COLUMN original_url TEXT;
+ALTER TABLE queue ADD COLUMN thumbnail_path TEXT;
+ALTER TABLE queue ADD COLUMN remote_thumbnail_url TEXT;
+ALTER TABLE queue ADD COLUMN download_status TEXT NOT NULL DEFAULT 'downloaded';
+CREATE INDEX IF NOT EXISTS idx_queue_original_url ON queue (original_url);
+```
+
+Fields intentionally not persisted now:
+
+- `source_kind`
+- `provider`
+- `provider_id`
+- `canonical_url`
+- `downloaded_path`
+- `local_path`
+
+If these columns exist from an earlier local test migration, they can be dropped manually. The app no longer writes or reads them.
+
+## URL Service
+
+Use `src/services/url-media-service.ts` as the narrow provider-aware boundary.
+
+Responsibilities:
+
+1. Accept YouTube URL shapes:
+   - `youtube.com/watch?v=...`
+   - `youtu.be/...`
+   - `youtube.com/shorts/...`
+   - `youtube.com/embed/...`
+2. Normalize internally to `https://www.youtube.com/watch?v=<videoId>`.
+3. Fetch oEmbed:
+   - `title` -> `name` and `title`
+   - `author_name` -> `artist`
+   - `thumbnail_url` -> `remoteThumbnailUrl`
+4. Cache the thumbnail under app cache, for example `cache/remote-thumbs/youtube_<videoId>.jpg`.
+5. Return a `FileInfo` with:
+   - `extension = 'url'`
+   - `path = normalized YouTube URL`
+   - `originalUrl = input URL`
+   - `downloadStatus = 'not_downloaded'`
+   - cached thumbnail fields when available
+
+Failure behavior:
+
+- If oEmbed or thumbnail download fails, still create the item.
+- Use a fallback title such as `YouTube video <id>`.
+- Leave thumbnail fields empty and let the UI fall back to the video icon.
+
+## Library And Queue
+
+Library:
+
+- Add `mediaDbService.insertUrlMedia(url)`.
+- Validate that the URL is YouTube.
+- Reuse an existing row when `original_url` or normalized `path` already matches.
+- Insert the row as `media_type = 'video'`.
+- Keep filesystem sync from deleting URL entries by excluding `extension = 'url'` from local-file cleanup.
+
+Queue:
+
+- Persist the same minimal URL fields into `queue` rows.
+- Add `queueDbService.addUrlToQueue(url)`.
+- Keep duplicate detection based on normalized `file_path` or `original_url`.
+- Queue rows should render offline from persisted title/artist/thumb fields.
+
+## Playback
+
+Player-store behavior:
+
+- Treat supported YouTube URLs as `video`.
+- Save/restore YouTube URLs as video media.
+- Queue auto-advance can keep returning `path`; URL entries already use the normalized YouTube URL there.
+
+Video player behavior:
+
+- If the load payload is HTTP(S), skip local `readFile()`.
+- Set `activeUrl` directly to the normalized URL.
+- Keep local files on the old blob URL path.
+
+## Thumbnail And UI
+
+Thumbnail service:
+
+- For local media, keep using generated local thumbnails.
+- For URL media with `thumbnailPath`, read the cached thumbnail file.
+- For URL media with only `remoteThumbnailUrl`, fetch it as a fallback if online.
+- If no thumbnail exists, reject and let the UI render the icon.
+
+List/queue badges:
+
+- URL media shows `YouTube`.
+- URL-only media shows `Not downloaded`.
+- Future local/downloaded media can show `Downloaded`.
+- Missing local download can show `Missing download`.
+
+## Module-Facing API
+
+Modules can later call:
+
+```ts
+host.library.addUrl({
+  type: 'video',
+  url: 'https://youtu.be/...',
+  addToQueue?: boolean,
+  playNext?: boolean,
+});
+
+host.queue.addUrl({
+  url: 'https://youtu.be/...',
+  position?: 'end' | 'next',
+});
+```
+
+Contract:
+
+- Only YouTube is accepted initially.
+- Lumen owns oEmbed lookup and thumbnail caching.
+- Modules do not need to know provider IDs or YouTube metadata details.
+
+## Implemented Shape
+
+The first cut should land with this scope:
+
+1. Minimal `FileInfo` URL fields.
+2. Dynamic column migration for `media_files` and `queue` using only the four needed columns.
+3. YouTube URL parsing, normalization, oEmbed metadata, and cached thumbnail support.
+4. URL-safe playback in the video player.
+5. Library/queue URL helper methods for future module use.
+6. URL badges and download status in library and queue rows.
+
+This keeps the data model small now and leaves room to add one explicit downloaded-file field later only when the downloader behavior is real.

--- a/docs/module-api-reference.md
+++ b/docs/module-api-reference.md
@@ -564,6 +564,10 @@ unsub.dispose()
 host.queue.next()
 host.queue.previous()
 host.queue.goTo(2)   // 0-based index
+
+// Add a supported URL to the queue — currently YouTube video URLs only
+await host.queue.addUrl?.({ url: 'https://youtu.be/VIDEO_ID', position: 'end' })
+await host.queue.addUrl?.({ url: 'https://youtu.be/VIDEO_ID', position: 'next' })
 ```
 
 ### `QueueItem`
@@ -582,6 +586,7 @@ host.queue.goTo(2)   // 0-based index
 | `next()` | `void` | Advance to next item |
 | `previous()` | `void` | Go to previous item |
 | `goTo(index)` | `void` | Jump to specific index |
+| `addUrl(input)` | `Promise<void>` | Adds a supported URL to the queue. Currently YouTube video URLs only. Optional until the SDK types catch up. |
 
 > ⚠️ `state()` read and `onChange` work. Write navigation methods (`next`, `previous`, `goTo`) emit via the app event bus.
 
@@ -609,6 +614,20 @@ host.player.play('media-item-id')
 > ⚠️ Methods emit via bus — full read state (`current()`, `state()`, `volume()`) not yet wired.
 
 ---
+
+### URL media
+
+Modules can ask Lumen to own YouTube metadata and thumbnail caching instead of calling YouTube directly:
+
+```ts
+const item = await host.library.addUrl?.({
+  type: 'video',
+  url: 'https://youtu.be/VIDEO_ID',
+  addToQueue: true,
+})
+```
+
+Initial support is intentionally provider-limited: only YouTube URLs are accepted, and they are stored as `video` media with cached thumbnail metadata when available.
 
 ## Domain APIs 🚧
 

--- a/src/components/aside-panel.tsx
+++ b/src/components/aside-panel.tsx
@@ -19,6 +19,7 @@ import { CSS } from '@dnd-kit/utilities';
 import { CheckCircle2, ListX, Tag, X, Zap } from 'lucide-react';
 import type React from 'react';
 import { useEffect, useRef, useState } from 'react';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import {
@@ -59,6 +60,18 @@ type TriggerDialog = {
 } | null;
 
 type TabValue = 'queue' | 'notes' | 'themes';
+
+function getDownloadStatusLabel(item: QueueItem): string | null {
+  if (item.file.extension !== 'url' && !item.file.originalUrl) return null;
+  switch (item.file.downloadStatus) {
+    case 'downloaded':
+      return 'Downloaded';
+    case 'missing':
+      return 'Missing download';
+    default:
+      return 'Not downloaded';
+  }
+}
 
 const TABS: { value: TabValue; label: string }[] = [
   { value: 'queue', label: 'Queue' },
@@ -445,6 +458,7 @@ function SortableQueueItem({
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: sortableId,
   });
+  const downloadStatus = getDownloadStatusLabel(item);
 
   return (
     <div
@@ -486,8 +500,20 @@ function SortableQueueItem({
               >
                 {item.file.title || item.file.name}
               </div>
-              <div className="text-xs text-muted-foreground mt-0.5">
-                {item.file.artist || item.file.name.split('.').pop()?.toUpperCase()}
+              <div className="mt-0.5 flex items-center gap-1.5 text-xs text-muted-foreground">
+                {item.file.originalUrl && (
+                  <Badge variant="secondary" className="h-4 rounded px-1.5 text-[10px]">
+                    YouTube
+                  </Badge>
+                )}
+                {downloadStatus && (
+                  <Badge variant="outline" className="h-4 rounded px-1.5 text-[10px]">
+                    {downloadStatus}
+                  </Badge>
+                )}
+                <span className="truncate">
+                  {item.file.artist || item.file.name.split('.').pop()?.toUpperCase()}
+                </span>
               </div>
             </div>
           </div>

--- a/src/components/delete-file-alert.tsx
+++ b/src/components/delete-file-alert.tsx
@@ -1,62 +1,70 @@
-import { useState } from 'react';
 import { remove } from '@tauri-apps/plugin-fs';
+import { useState } from 'react';
 import { toast } from 'sonner';
 import {
-	AlertDialog,
-	AlertDialogAction,
-	AlertDialogCancel,
-	AlertDialogContent,
-	AlertDialogDescription,
-	AlertDialogTitle,
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
+import { mediaDbService } from '@/services/media-db-service';
 import { useDeleteFileStore } from '@/stores/delete-file-store';
 
 interface DeleteFileAlertProps {
-	onDelete?: (filePath: string) => void;
+  onDelete?: (filePath: string) => void;
 }
 
 export function DeleteFileAlert({ onDelete }: DeleteFileAlertProps) {
-	const { isOpen, file, closeDeleteDialog } = useDeleteFileStore();
-	const [isDeleting, setIsDeleting] = useState(false);
+  const { isOpen, file, closeDeleteDialog } = useDeleteFileStore();
+  const [isDeleting, setIsDeleting] = useState(false);
+  const isUrlMedia = file?.extension === 'url' || Boolean(file?.originalUrl);
 
-	const handleConfirmDelete = async () => {
-		if (!file) return;
+  const handleConfirmDelete = async () => {
+    if (!file) return;
 
-		setIsDeleting(true);
-		try {
-			await remove(file.path);
-			closeDeleteDialog();
-			toast.success(`${file.name} removed`);
+    setIsDeleting(true);
+    try {
+      if (file.extension === 'url' || Boolean(file.originalUrl)) {
+        await mediaDbService.deleteFile(file.path);
+      } else {
+        await remove(file.path);
+      }
+      closeDeleteDialog();
+      toast.success(`${file.name} removed`);
 
-			if (onDelete) {
-				onDelete(file.path);
-			}
-		} catch (error) {
-			console.error('Failed to delete file:', error);
-			toast.error('Failed to delete file');
-		} finally {
-			setIsDeleting(false);
-		}
-	};
+      if (onDelete) {
+        onDelete(file.path);
+      }
+    } catch (error) {
+      console.error('Failed to delete file:', error);
+      toast.error('Failed to delete file');
+    } finally {
+      setIsDeleting(false);
+    }
+  };
 
-	return (
-		<AlertDialog open={isOpen} onOpenChange={closeDeleteDialog}>
-			<AlertDialogContent>
-				<AlertDialogTitle>Delete file?</AlertDialogTitle>
-				<AlertDialogDescription>
-					Are you sure you want to delete "{file?.name}"? This action cannot be undone.
-				</AlertDialogDescription>
-				<div className="flex gap-3 justify-end">
-					<AlertDialogCancel>Cancel</AlertDialogCancel>
-					<AlertDialogAction
-						onClick={handleConfirmDelete}
-						disabled={isDeleting}
-						className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-					>
-						{isDeleting ? 'Deleting...' : 'Delete'}
-					</AlertDialogAction>
-				</div>
-			</AlertDialogContent>
-		</AlertDialog>
-	);
+  return (
+    <AlertDialog open={isOpen} onOpenChange={closeDeleteDialog}>
+      <AlertDialogContent>
+        <AlertDialogTitle>{isUrlMedia ? 'Remove media?' : 'Delete file?'}</AlertDialogTitle>
+        <AlertDialogDescription>
+          {isUrlMedia
+            ? `Remove "${file?.name}" from the library? The YouTube video itself will not be deleted.`
+            : `Are you sure you want to delete "${file?.name}"? This action cannot be undone.`}
+        </AlertDialogDescription>
+        <div className="flex gap-3 justify-end">
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleConfirmDelete}
+            disabled={isDeleting}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          >
+            {isDeleting ? 'Deleting...' : isUrlMedia ? 'Remove' : 'Delete'}
+          </AlertDialogAction>
+        </div>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
 }

--- a/src/components/file-list-item.tsx
+++ b/src/components/file-list-item.tsx
@@ -14,6 +14,7 @@ import {
 } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
   ContextMenu,
@@ -39,6 +40,22 @@ interface FileListItemProps {
 
 const THUMBNAIL_TYPES = new Set<MediaType>(['video', 'image']);
 
+function isUrlMedia(file: FileInfo): boolean {
+  return file.extension === 'url' || Boolean(file.originalUrl);
+}
+
+function downloadStatusLabel(file: FileInfo): string | null {
+  if (!isUrlMedia(file)) return null;
+  switch (file.downloadStatus) {
+    case 'downloaded':
+      return 'Downloaded';
+    case 'missing':
+      return 'Missing download';
+    default:
+      return 'Not downloaded';
+  }
+}
+
 function FileThumbnail({ file, mediaType }: { file: FileInfo; mediaType: MediaType }) {
   const Icon = getMediaIcon(mediaType);
   const [thumbSrc, setThumbSrc] = useState<string | null>(null);
@@ -48,11 +65,17 @@ function FileThumbnail({ file, mediaType }: { file: FileInfo; mediaType: MediaTy
     if (!THUMBNAIL_TYPES.has(mediaType)) return;
     let cancelled = false;
     thumbnailService
-      .getThumbnail(file.path)
-      .then((url) => { if (!cancelled) setThumbSrc(url); })
-      .catch(() => { if (!cancelled) setFailed(true); });
-    return () => { cancelled = true; };
-  }, [file.path, mediaType]);
+      .getMediaThumbnail(file)
+      .then((url) => {
+        if (!cancelled) setThumbSrc(url);
+      })
+      .catch(() => {
+        if (!cancelled) setFailed(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [file, mediaType]);
 
   if (!THUMBNAIL_TYPES.has(mediaType) || failed) {
     return <Icon className="size-5 text-muted-foreground mt-0.5 shrink-0" aria-hidden="true" />;
@@ -119,6 +142,9 @@ export function FileListItem({
   isFocused,
 }: FileListItemProps) {
   const { openDeleteDialog } = useDeleteFileStore();
+  const urlMedia = isUrlMedia(file);
+  const statusLabel = downloadStatusLabel(file);
+  const fileSizeLabel = urlMedia ? 'URL' : formatFileSize(file.size);
 
   const handleClick = () => {
     if (onClick) {
@@ -134,6 +160,7 @@ export function FileListItem({
 
   const handleOpenFolder = async (e: React.MouseEvent) => {
     e.stopPropagation();
+    if (urlMedia) return;
     try {
       const folderPath = file.path.substring(0, file.path.lastIndexOf('\\'));
       await invoke('open_folder', { path: folderPath });
@@ -148,7 +175,7 @@ export function FileListItem({
     openDeleteDialog(file);
   };
 
-  const fileDescription = `${file.name}, ${formatFileSize(file.size)}, modified ${formatDate(file.modifiedAt)}`;
+  const fileDescription = `${file.name}, ${fileSizeLabel}, modified ${formatDate(file.modifiedAt)}`;
 
   return (
     <ContextMenu>
@@ -163,13 +190,23 @@ export function FileListItem({
           <div className="flex items-start gap-3 w-full min-w-0">
             <FileThumbnail file={file} mediaType={mediaType} />
             <div className="flex-1 min-w-0">
-              <p className="font-medium truncate">{file.name}</p>
+              <p className="font-medium truncate">{file.title || file.name}</p>
               <div
-                className="flex items-center gap-3 mt-1 text-sm text-muted-foreground"
+                className="flex items-center gap-2 mt-1 text-sm text-muted-foreground"
                 aria-hidden="true"
               >
-                <span>{formatFileSize(file.size)}</span>
-                <span>•</span>
+                {file.originalUrl && (
+                  <Badge variant="secondary" className="h-4 rounded px-1.5 text-[10px]">
+                    YouTube
+                  </Badge>
+                )}
+                {statusLabel && (
+                  <Badge variant="outline" className="h-4 rounded px-1.5 text-[10px]">
+                    {statusLabel}
+                  </Badge>
+                )}
+                {!statusLabel && <span>{fileSizeLabel}</span>}
+                <span>-</span>
                 <span className="truncate">{formatDate(file.modifiedAt)}</span>
               </div>
             </div>
@@ -203,10 +240,12 @@ export function FileListItem({
             <ContextMenuSeparator />
           </>
         )}
-        <ContextMenuItem onClick={handleOpenFolder}>
-          <FolderOpen className="h-4 w-4" aria-hidden="true" />
-          Open folder
-        </ContextMenuItem>
+        {!urlMedia && (
+          <ContextMenuItem onClick={handleOpenFolder}>
+            <FolderOpen className="h-4 w-4" aria-hidden="true" />
+            Open folder
+          </ContextMenuItem>
+        )}
         <ContextMenuItem onClick={handleDeleteClick} variant="destructive">
           <Trash2 className="h-4 w-4" aria-hidden="true" />
           Delete

--- a/src/components/miniplayer.tsx
+++ b/src/components/miniplayer.tsx
@@ -49,11 +49,19 @@ export function MiniPlayer({ className }: MiniPlayerProps) {
 
   useEffect(() => {
     const handler = async (e: Event) => {
-      const { source, path, action } = (e as CustomEvent<{ source: string; path: string; action: 'play' | 'queue' }>).detail;
+      const { source, path, action } = (
+        e as CustomEvent<{ source: string; path: string; action: 'play' | 'queue' }>
+      ).detail;
 
       if (action === 'play') {
-        if (source === 'lyric') { await player.presentLyric(path); return; }
-        if (source === 'image') { await player.presentImage(path); return; }
+        if (source === 'lyric') {
+          await player.presentLyric(path);
+          return;
+        }
+        if (source === 'image') {
+          await player.presentImage(path);
+          return;
+        }
         await player.loadFile(path);
         return;
       }
@@ -66,9 +74,20 @@ export function MiniPlayer({ className }: MiniPlayerProps) {
           path: hit.path,
           size: 0,
           modifiedAt: new Date(hit.modified_at),
-          extension: hit.path.split('.').pop() ?? '',
+          extension: hit.original_url ? 'url' : (hit.path.split('.').pop() ?? ''),
           duration: hit.duration ?? undefined,
           artist: hit.artist ?? undefined,
+          originalUrl: hit.original_url ?? undefined,
+          thumbnailPath: hit.thumbnail_path ?? undefined,
+          remoteThumbnailUrl: hit.remote_thumbnail_url ?? undefined,
+          downloadStatus:
+            hit.download_status === 'not_downloaded' ||
+            hit.download_status === 'downloaded' ||
+            hit.download_status === 'missing'
+              ? hit.download_status
+              : hit.original_url
+                ? 'not_downloaded'
+                : 'downloaded',
         });
       }
     };

--- a/src/components/settings/theme-section.tsx
+++ b/src/components/settings/theme-section.tsx
@@ -229,9 +229,10 @@ export function ThemeSection() {
             <div className="space-y-1.5">
               <p className="text-sm font-medium">{t('Language')}</p>
               <Select
-                value={activeProfile?.language ?? locale}
+                value={activeProfile?.language ?? locale ?? 'en'}
                 onValueChange={(lang) => {
-                  if (activeProfile) updateProfile(activeProfile.id, { language: lang });
+                  if (activeProfile)
+                    updateProfile(activeProfile.id, { language: lang ?? undefined });
                 }}
               >
                 <SelectTrigger className="w-32">

--- a/src/components/ui/videoplayer.tsx
+++ b/src/components/ui/videoplayer.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import ReactPlayer from 'react-player';
 import { cn } from '@/lib/utils';
 import { thumbnailService } from '@/services/thumbnail-service';
+import { urlMediaService } from '@/services/url-media-service';
 import { Slider } from './slider';
 import { Tooltip, TooltipContent, TooltipTrigger } from './tooltip';
 
@@ -40,25 +41,19 @@ export const Videoplayer = ({
   async function fetchMetadata(
     videoUrl: string
   ): Promise<{ title: string; thumbnail?: string; artist?: string }> {
-    if (videoUrl.startsWith('http://') || videoUrl.startsWith('https://')) {
+    if (urlMediaService.parseYouTubeUrl(videoUrl)) {
       try {
-        const u = new URL(videoUrl);
-        if (u.hostname.includes('youtube.com') || u.hostname.includes('youtu.be')) {
-          const res = await fetch(
-            `https://www.youtube.com/oembed?url=${encodeURIComponent(videoUrl)}&format=json`
-          );
-          if (res.ok) {
-            const data = await res.json();
-            return {
-              title: data.title,
-              thumbnail: data.thumbnail_url,
-              artist: data.author_name ?? undefined,
-            };
-          }
-          return { title: 'YouTube Video' };
-        }
-      } catch {}
+        const data = await urlMediaService.resolveYouTube(videoUrl);
+        return {
+          title: data.title,
+          thumbnail: data.remoteThumbnailUrl,
+          artist: data.artist,
+        };
+      } catch {
+        return { title: 'YouTube Video' };
+      }
     }
+
     const raw = videoUrl.split(/[\\/]/).pop() ?? videoUrl;
     const decoded = decodeURIComponent(raw);
     return { title: decoded.replace(/\.[^.]+$/, '') };
@@ -195,6 +190,19 @@ export const Videoplayer = ({
           URL.revokeObjectURL(currentBlobUrl.current);
           currentBlobUrl.current = null;
         }
+        const parsedUrl = urlMediaService.parseYouTubeUrl(filePath);
+        if (parsedUrl) {
+          if (loadSeqRef.current !== seq) return;
+          currentFilePath.current = parsedUrl.canonicalUrl;
+          pendingSeekTime.current = seekTime > 0 ? seekTime : null;
+          pendingThumbnail.current = null;
+          switchingUrlRef.current = true;
+          setPlayed(0);
+          setActiveUrl(parsedUrl.canonicalUrl);
+          setPlaying(true);
+          return;
+        }
+
         const mimeTypes: Record<string, string> = {
           mp4: 'video/mp4',
           webm: 'video/webm',

--- a/src/modules/apis/domain.ts
+++ b/src/modules/apis/domain.ts
@@ -8,6 +8,7 @@ import { thumbnailService } from '@/services/thumbnail-service';
 import { useModuleStore } from '../store';
 import { usePlayerStore } from '@/stores/player-store';
 import { useQueueEntriesStore } from '@/stores/queue-entries-store';
+import { useQueueStore } from '@/stores/queue-store';
 import type {
   LibraryHostAPI,
   LyricsHostAPI,
@@ -104,9 +105,9 @@ export function createQueueHostAPI(): QueueHostAPI {
       return globalBus.on('queue:changed', handler);
     },
     next() {
-      const result = useQueueEntriesStore.getState().advanceQueue(
-        usePlayerStore.getState().currentFilePath
-      );
+      const result = useQueueEntriesStore
+        .getState()
+        .advanceQueue(usePlayerStore.getState().currentFilePath);
       if (result.type === 'play') {
         void usePlayerStore.getState().loadFile(result.path);
       }
@@ -120,6 +121,13 @@ export function createQueueHostAPI(): QueueHostAPI {
     registerTrigger(spec) {
       const dispose = useModuleStore.getState().registerQueueTrigger(spec);
       return { dispose };
+    },
+    async addUrl(input) {
+      if (input.position === 'next') {
+        await useQueueStore.getState().playUrlNext(input.url);
+        return;
+      }
+      await useQueueStore.getState().addUrlToQueue(input.url);
     },
   };
 }
@@ -166,6 +174,20 @@ export function createLibraryHostAPI(): LibraryHostAPI {
     },
     async thumbnail(_path, _size) {
       return '';
+    },
+    async addUrl(input) {
+      const file = await mediaDbService.insertUrlMedia(input.url);
+      if (input.playNext) {
+        await useQueueStore.getState().playNext(file);
+      } else if (input.addToQueue) {
+        await useQueueStore.getState().addToQueue(file);
+      }
+      return {
+        id: file.path,
+        path: file.path,
+        name: file.name,
+        type: input.type,
+      };
     },
   };
 }
@@ -243,12 +265,18 @@ listen('module:presenter-ready', () => {
   const { presenterViewId, presenterProps } = useModuleStore.getState();
   if (!presenterViewId) return;
 
-  emit('module:presenter-project', { viewId: presenterViewId, props: presenterProps }).catch(() => {});
+  emit('module:presenter-project', { viewId: presenterViewId, props: presenterProps }).catch(
+    () => {}
+  );
   setTimeout(() => {
-    emit('module:presenter-project', { viewId: presenterViewId, props: presenterProps }).catch(() => {});
+    emit('module:presenter-project', { viewId: presenterViewId, props: presenterProps }).catch(
+      () => {}
+    );
   }, 100);
   setTimeout(() => {
-    emit('module:presenter-project', { viewId: presenterViewId, props: presenterProps }).catch(() => {});
+    emit('module:presenter-project', { viewId: presenterViewId, props: presenterProps }).catch(
+      () => {}
+    );
   }, 400);
 }).catch(() => {});
 
@@ -270,12 +298,14 @@ async function ensureOverlayWindow() {
       };
       listen('module:overlay-ready', () => {
         finish();
-      }).then((unlisten) => {
-        setTimeout(() => {
-          unlisten();
-          finish();
-        }, 500);
-      }).catch(() => finish());
+      })
+        .then((unlisten) => {
+          setTimeout(() => {
+            unlisten();
+            finish();
+          }, 500);
+        })
+        .catch(() => finish());
     });
 
     win = await WebviewWindow.getByLabel('module-overlay-window').catch(() => null);
@@ -301,7 +331,12 @@ export function createPresentationHostAPI(): PresentationHostAPI {
     onStateChange(handler) {
       const onProject = globalBus.on('presentation:project', () => handler('live'));
       const onClear = globalBus.on('presentation:clear', () => handler('idle'));
-      return { dispose() { onProject.dispose(); onClear.dispose(); } };
+      return {
+        dispose() {
+          onProject.dispose();
+          onClear.dispose();
+        },
+      };
     },
     project(viewId, props) {
       const isFirstProject = useModuleStore.getState().presenterViewId === null;
@@ -339,7 +374,12 @@ export function createOverlayHostAPI(): OverlayHostAPI {
     onStateChange(handler) {
       const onProject = globalBus.on('overlay:project', () => handler('live'));
       const onClear = globalBus.on('overlay:clear', () => handler('idle'));
-      return { dispose() { onProject.dispose(); onClear.dispose(); } };
+      return {
+        dispose() {
+          onProject.dispose();
+          onClear.dispose();
+        },
+      };
     },
     project(viewId, props) {
       overlayViewId = viewId;
@@ -365,9 +405,7 @@ export function createOverlayHostAPI(): OverlayHostAPI {
 async function ensureMediaWindow() {
   let win = await WebviewWindow.getByLabel('media-window').catch(() => null);
   if (!win) {
-    await invoke('create_window', { label: 'media-window', title: 'Media Player' }).catch(
-      () => {}
-    );
+    await invoke('create_window', { label: 'media-window', title: 'Media Player' }).catch(() => {});
 
     await new Promise<void>((resolve) => {
       let settled = false;
@@ -378,12 +416,14 @@ async function ensureMediaWindow() {
       };
       listen('module:presenter-ready', () => {
         finish();
-      }).then((unlisten) => {
-        setTimeout(() => {
-          unlisten();
-          finish();
-        }, 500);
-      }).catch(() => finish());
+      })
+        .then((unlisten) => {
+          setTimeout(() => {
+            unlisten();
+            finish();
+          }, 500);
+        })
+        .catch(() => finish());
     });
 
     win = await WebviewWindow.getByLabel('media-window').catch(() => null);
@@ -425,14 +465,14 @@ export function createThemesHostAPI(): ThemesHostAPI {
     defaultBackground() {
       const { profiles, activeProfileId } = useProfileStore.getState();
       const profileBg = profiles.find((p) => p.id === activeProfileId)?.defaultBackground;
-      return profileBg
-        ? { src: profileBg.src, type: profileBg.type, name: profileBg.name }
-        : null;
+      return profileBg ? { src: profileBg.src, type: profileBg.type, name: profileBg.name } : null;
     },
     onDefaultBackgroundChange(handler) {
       let lastSrc: string | null | undefined = undefined;
 
-      const fire = (bg: { src: string; type: 'theme' | 'image' | 'video'; name: string } | null) => {
+      const fire = (
+        bg: { src: string; type: 'theme' | 'image' | 'video'; name: string } | null
+      ) => {
         const src = bg?.src ?? null;
         if (!src || src.startsWith('blob:') || src.startsWith('http') || src.startsWith('data:')) {
           handler(bg);
@@ -479,8 +519,3 @@ export function createThemesHostAPI(): ThemesHostAPI {
     },
   };
 }
-
-
-
-
-

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -231,6 +231,7 @@ export interface QueueHostAPI {
   previous(): void;
   goTo(index: number): void;
   registerTrigger(spec: QueueTriggerSpec): Disposable;
+  addUrl?(input: { url: string; position?: 'end' | 'next' }): Promise<void>;
 }
 
 export type MediaType = 'audio' | 'video' | 'image';
@@ -262,6 +263,12 @@ export interface LibraryHostAPI {
   get(id: string): Promise<MediaItem | null>;
   metadata(path: string): Promise<MediaMetadata>;
   thumbnail(path: string, size?: number): Promise<string>;
+  addUrl?(input: {
+    type: 'video';
+    url: string;
+    addToQueue?: boolean;
+    playNext?: boolean;
+  }): Promise<MediaRef>;
 }
 
 export interface TrackRef {
@@ -314,7 +321,11 @@ export interface ThemesHostAPI {
   list(): ThemeRef[];
   apply(id: string): void;
   defaultBackground(): { src: string; type: 'theme' | 'image' | 'video'; name: string } | null;
-  onDefaultBackgroundChange(handler: (bg: { src: string; thumb?: string; type: 'theme' | 'image' | 'video'; name: string } | null) => void): Disposable;
+  onDefaultBackgroundChange(
+    handler: (
+      bg: { src: string; thumb?: string; type: 'theme' | 'image' | 'video'; name: string } | null
+    ) => void
+  ): Disposable;
 }
 
 export interface FsAPI {
@@ -406,4 +417,3 @@ export interface ModuleRecord {
   errorCount: number;
   source: 'bundled' | 'store' | 'sideload' | 'dev';
 }
-

--- a/src/services/file-management-service.ts
+++ b/src/services/file-management-service.ts
@@ -3,6 +3,7 @@ import { copyFile, exists, readDir, remove, stat } from '@tauri-apps/plugin-fs';
 import { fileInitService } from './file-init-service';
 import { mediaDbService } from './media-db-service';
 import type { FileInfo, MediaType } from './types';
+import { urlMediaService } from './url-media-service';
 
 export interface FileManagementService {
   /**
@@ -47,6 +48,12 @@ export interface FileManagementService {
    * @param mediaType - The media type folder to refresh
    */
   refreshFiles(mediaType: MediaType): Promise<FileInfo[]>;
+
+  /**
+   * Add a supported URL as media without copying a local file.
+   * Currently only YouTube URLs are accepted and they are always video media.
+   */
+  addUrl(mediaType: 'video', url: string): Promise<FileInfo>;
 }
 
 const EXTENSION_MAP: Record<MediaType, string[]> = {
@@ -56,16 +63,26 @@ const EXTENSION_MAP: Record<MediaType, string[]> = {
   text: ['.txt', '.md', '.doc', '.docx', '.pdf'],
   lyrics: ['.txt', '.lrc', '.srt', '.md'],
   themes: ['.jpg', '.jpeg', '.png', '.gif', '.webp', '.svg', '.mp4', '.webm'],
-  files: []
+  files: [],
 };
 
 class FileManagementServiceImpl implements FileManagementService {
+  async addUrl(mediaType: 'video', url: string): Promise<FileInfo> {
+    if (mediaType !== 'video' || !urlMediaService.isSupportedUrl(url)) {
+      throw new Error('Only YouTube video URLs are supported');
+    }
+
+    return mediaDbService.insertUrlMedia(url);
+  }
+
   async listFiles(mediaType: MediaType): Promise<FileInfo[]> {
     try {
       return await mediaDbService.listFiles(mediaType);
     } catch (error) {
       console.error(`Failed to list files for media type ${mediaType}:`, error);
-      throw new Error(`Failed to list files: ${error instanceof Error ? error.message : String(error)}`);
+      throw new Error(
+        `Failed to list files: ${error instanceof Error ? error.message : String(error)}`
+      );
     }
   }
 
@@ -100,7 +117,7 @@ class FileManagementServiceImpl implements FileManagementService {
           path: destPath,
           size: fileMetadata.size,
           modifiedAt: fileMetadata.mtime || new Date(),
-          extension: fileExtension
+          extension: fileExtension,
         };
 
         uploadedFiles.push(fileInfo);
@@ -111,13 +128,13 @@ class FileManagementServiceImpl implements FileManagementService {
         console.error(`Failed to upload file "${fileName}":`, error);
         errors.push({
           path: filePath,
-          error: `Failed to copy "${fileName}": ${errorMessage}`
+          error: `Failed to copy "${fileName}": ${errorMessage}`,
         });
       }
     }
 
     if (uploadedFiles.length === 0 && errors.length > 0) {
-      const errorMessages = errors.map(e => e.error).join('; ');
+      const errorMessages = errors.map((e) => e.error).join('; ');
       throw new Error(`Failed to upload files: ${errorMessages}`);
     }
 
@@ -166,7 +183,7 @@ class FileManagementServiceImpl implements FileManagementService {
       const newName = `${baseName} (${counter})${extension}`;
       const newPath = await join(folder, newName);
 
-      if (!await exists(newPath)) {
+      if (!(await exists(newPath))) {
         return newPath;
       }
 
@@ -180,16 +197,19 @@ class FileManagementServiceImpl implements FileManagementService {
 
       const extensions = EXTENSION_MAP[mediaType];
 
-      const filters = mediaType === 'files'
-        ? []
-        : [{
-            name: mediaType,
-            extensions: extensions.map(ext => ext.slice(1))
-          }];
+      const filters =
+        mediaType === 'files'
+          ? []
+          : [
+              {
+                name: mediaType,
+                extensions: extensions.map((ext) => ext.slice(1)),
+              },
+            ];
 
       const selected = await open({
         multiple: true,
-        filters: filters
+        filters: filters,
       });
 
       if (!selected) {
@@ -199,7 +219,9 @@ class FileManagementServiceImpl implements FileManagementService {
       return Array.isArray(selected) ? selected : [selected];
     } catch (error) {
       console.error(`Failed to open file picker for media type ${mediaType}:`, error);
-      throw new Error(`Failed to open file picker: ${error instanceof Error ? error.message : String(error)}`);
+      throw new Error(
+        `Failed to open file picker: ${error instanceof Error ? error.message : String(error)}`
+      );
     }
   }
 

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -14,9 +14,11 @@ export type {
 } from './devices-service';
 export { devicesService } from './devices-service';
 
-export type { FileInfo, MediaType } from './types';
+export type { DownloadStatus, FileInfo, MediaType } from './types';
 export { remoteSyncService } from './remote-sync-service';
 export type { PlayerSyncPayload } from './remote-sync-service';
 export type { StreamingConfig, StreamingStatus } from './streaming-service';
 export { streamingService } from './streaming-service';
 export { thumbnailService } from './thumbnail-service';
+export { urlMediaService } from './url-media-service';
+export type { UrlMediaMetadata } from './url-media-service';

--- a/src/services/media-db-service.ts
+++ b/src/services/media-db-service.ts
@@ -3,6 +3,7 @@ import Database from '@tauri-apps/plugin-sql';
 import { getAppBasePath, getDbPath } from './app-paths';
 import { extractMetadata } from './metadata-extractor';
 import type { FileInfo, MediaType } from './types';
+import { urlMediaService } from './url-media-service';
 
 interface DbRow {
   id: number;
@@ -15,6 +16,10 @@ interface DbRow {
   duration: number | null;
   artist: string | null;
   content: string | null;
+  original_url: string | null;
+  thumbnail_path: string | null;
+  remote_thumbnail_url: string | null;
+  download_status: string | null;
 }
 
 export interface SearchHit {
@@ -26,7 +31,30 @@ export interface SearchHit {
   duration: number | null;
   modified_at: number;
   rank: number;
+  title?: string | null;
+  original_url?: string | null;
+  thumbnail_path?: string | null;
+  remote_thumbnail_url?: string | null;
+  download_status?: string | null;
 }
+
+type ColumnSpec = {
+  name: string;
+  sql: string;
+};
+
+const MEDIA_FILE_URL_COLUMNS: ColumnSpec[] = [
+  { name: 'original_url', sql: 'ALTER TABLE media_files ADD COLUMN original_url TEXT' },
+  { name: 'thumbnail_path', sql: 'ALTER TABLE media_files ADD COLUMN thumbnail_path TEXT' },
+  {
+    name: 'remote_thumbnail_url',
+    sql: 'ALTER TABLE media_files ADD COLUMN remote_thumbnail_url TEXT',
+  },
+  {
+    name: 'download_status',
+    sql: "ALTER TABLE media_files ADD COLUMN download_status TEXT NOT NULL DEFAULT 'downloaded'",
+  },
+];
 
 class MediaDbService {
   private readyPromise: Promise<Database> | null = null;
@@ -67,10 +95,13 @@ class MediaDbService {
     await db.execute(`CREATE INDEX IF NOT EXISTS idx_mf_type ON media_files (media_type)`);
     await db.execute(`CREATE INDEX IF NOT EXISTS idx_mf_name ON media_files (name COLLATE NOCASE)`);
 
-    const cols = await db.select<{ name: string }[]>('PRAGMA table_info(media_files)');
-    if (!cols.some((c) => c.name === 'content')) {
-      await db.execute(`ALTER TABLE media_files ADD COLUMN content TEXT`);
-    }
+    await this.ensureColumns(db, 'media_files', [
+      { name: 'content', sql: 'ALTER TABLE media_files ADD COLUMN content TEXT' },
+      ...MEDIA_FILE_URL_COLUMNS,
+    ]);
+    await db.execute(
+      `CREATE INDEX IF NOT EXISTS idx_mf_original_url ON media_files (original_url)`
+    );
 
     await db.execute(`
       CREATE TABLE IF NOT EXISTS theme_files (
@@ -88,6 +119,20 @@ class MediaDbService {
     return db;
   }
 
+  private async ensureColumns(
+    db: Database,
+    tableName: string,
+    columns: ColumnSpec[]
+  ): Promise<void> {
+    const existing = await db.select<{ name: string }[]>(`PRAGMA table_info(${tableName})`);
+    const names = new Set(existing.map((column) => column.name));
+    for (const column of columns) {
+      if (!names.has(column.name)) {
+        await db.execute(column.sql);
+      }
+    }
+  }
+
   async initialize(): Promise<void> {
     await this.ready();
   }
@@ -96,7 +141,7 @@ class MediaDbService {
     const db = await this.ready();
 
     const existing = await db.select<{ path: string }[]>(
-      'SELECT path FROM media_files WHERE media_type = $1',
+      `SELECT path FROM media_files WHERE media_type = $1 AND extension != 'url'`,
       [mediaType]
     );
     const existingPaths = new Set(existing.map((r) => r.path));
@@ -110,8 +155,8 @@ class MediaDbService {
         } catch {}
 
         await db.execute(
-          `INSERT OR IGNORE INTO media_files (name, path, size, modified_at, extension, media_type, duration, artist, content)
-           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+          `INSERT OR IGNORE INTO media_files (name, path, size, modified_at, extension, media_type, duration, artist, content, download_status)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'downloaded')`,
           [
             file.name,
             file.path,
@@ -129,7 +174,7 @@ class MediaDbService {
 
     for (const { path } of existing) {
       if (!fsPaths.has(path)) {
-        await db.execute('DELETE FROM media_files WHERE path = $1', [path]);
+        await db.execute(`DELETE FROM media_files WHERE path = $1 AND extension != 'url'`, [path]);
       }
     }
   }
@@ -157,21 +202,30 @@ class MediaDbService {
     const db = await this.ready();
 
     let metadata: { duration?: number; artist?: string } = {};
-    try {
-      metadata = await extractMetadata(file.path);
-    } catch {}
+    if (file.extension !== 'url') {
+      try {
+        metadata = await extractMetadata(file.path);
+      } catch {}
+    }
 
     await db.execute(
-      `INSERT INTO media_files (name, path, size, modified_at, extension, media_type, duration, artist, content)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+      `INSERT INTO media_files (
+         name, path, size, modified_at, extension, media_type, duration, artist, content,
+         original_url, thumbnail_path, remote_thumbnail_url, download_status
+       )
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
        ON CONFLICT(path) DO UPDATE SET
-         name        = excluded.name,
-         size        = excluded.size,
-         modified_at = excluded.modified_at,
-         extension   = excluded.extension,
-         duration    = excluded.duration,
-         artist      = excluded.artist,
-         content     = COALESCE(excluded.content, media_files.content)`,
+         name                 = excluded.name,
+         size                 = excluded.size,
+         modified_at          = excluded.modified_at,
+         extension            = excluded.extension,
+         duration             = excluded.duration,
+         artist               = excluded.artist,
+         content              = COALESCE(excluded.content, media_files.content),
+         original_url         = excluded.original_url,
+         thumbnail_path       = COALESCE(excluded.thumbnail_path, media_files.thumbnail_path),
+         remote_thumbnail_url = COALESCE(excluded.remote_thumbnail_url, media_files.remote_thumbnail_url),
+         download_status      = excluded.download_status`,
       [
         file.name,
         file.path,
@@ -179,11 +233,31 @@ class MediaDbService {
         file.modifiedAt instanceof Date ? file.modifiedAt.getTime() : Number(file.modifiedAt),
         file.extension,
         mediaType,
-        metadata.duration ?? null,
-        metadata.artist ?? null,
+        metadata.duration ?? file.duration ?? null,
+        file.artist ?? metadata.artist ?? null,
         content ?? null,
+        file.originalUrl ?? null,
+        file.thumbnailPath ?? null,
+        file.remoteThumbnailUrl ?? null,
+        file.downloadStatus ?? (file.extension === 'url' ? 'not_downloaded' : 'downloaded'),
       ]
     );
+  }
+
+  async insertUrlMedia(url: string, opts: { refreshMetadata?: boolean } = {}): Promise<FileInfo> {
+    const parsed = urlMediaService.parseYouTubeUrl(url);
+    if (!parsed) {
+      throw new Error('Only YouTube URLs are supported');
+    }
+
+    if (!opts.refreshMetadata) {
+      const existing = await this.getFileInfoByOriginalUrl(url, parsed.canonicalUrl);
+      if (existing) return existing;
+    }
+
+    const file = await urlMediaService.createYouTubeFileInfo(url);
+    await this.insertFile(file, 'video');
+    return file;
   }
 
   async search(
@@ -230,51 +304,68 @@ class MediaDbService {
        ORDER BY name COLLATE NOCASE LIMIT $${paramIdx}`,
       params
     );
-    return rows.map((r) => ({
-      id: r.id,
-      name: r.name,
-      path: r.path,
-      media_type: r.media_type as MediaType,
-      artist: r.artist,
-      duration: r.duration,
-      modified_at: r.modified_at,
-      rank: 0,
-    }));
+    return rows.map(rowToSearchHit);
   }
 
   async listByType(mediaType: MediaType, limit = 50): Promise<SearchHit[]> {
     const db = await this.ready();
-    const rows = await db.select<SearchHit[]>(
-      `SELECT id, name, path, media_type, artist, duration, modified_at, 0 AS rank
+    const rows = await db.select<DbRow[]>(
+      `SELECT *
          FROM media_files
         WHERE media_type = $1
         ORDER BY name COLLATE NOCASE
         LIMIT $2`,
       [mediaType, limit]
     );
-    return rows;
+    return rows.map(rowToSearchHit);
   }
 
   async getById(id: number): Promise<SearchHit | null> {
     const db = await this.ready();
-    const rows = await db.select<SearchHit[]>(
-      `SELECT id, name, path, media_type, artist, duration, modified_at, 0 AS rank
+    const rows = await db.select<DbRow[]>(
+      `SELECT *
          FROM media_files
         WHERE id = $1`,
       [id]
     );
-    return rows[0] ?? null;
+    return rows[0] ? rowToSearchHit(rows[0]) : null;
   }
 
   async getByPath(path: string): Promise<SearchHit | null> {
     const db = await this.ready();
-    const rows = await db.select<SearchHit[]>(
-      `SELECT id, name, path, media_type, artist, duration, modified_at, 0 AS rank
+    const rows = await db.select<DbRow[]>(
+      `SELECT *
          FROM media_files
         WHERE path = $1`,
       [path]
     );
-    return rows[0] ?? null;
+    return rows[0] ? rowToSearchHit(rows[0]) : null;
+  }
+
+  async getFileInfoByPath(path: string): Promise<FileInfo | null> {
+    const db = await this.ready();
+    const rows = await db.select<DbRow[]>(
+      `SELECT *
+         FROM media_files
+        WHERE path = $1`,
+      [path]
+    );
+    return rows[0] ? rowToFileInfo(rows[0]) : null;
+  }
+
+  async getFileInfoByOriginalUrl(
+    originalUrl: string,
+    canonicalUrl?: string
+  ): Promise<FileInfo | null> {
+    const db = await this.ready();
+    const rows = await db.select<DbRow[]>(
+      `SELECT *
+         FROM media_files
+        WHERE original_url = $1 OR original_url = $2 OR path = $2
+        LIMIT 1`,
+      [originalUrl, canonicalUrl ?? originalUrl]
+    );
+    return rows[0] ? rowToFileInfo(rows[0]) : null;
   }
 
   async deleteFile(path: string): Promise<void> {
@@ -345,6 +436,10 @@ class MediaDbService {
   }
 }
 
+function isDownloadStatus(value: string | null): value is NonNullable<FileInfo['downloadStatus']> {
+  return value === 'not_downloaded' || value === 'downloaded' || value === 'missing';
+}
+
 function rowToFileInfo(row: DbRow): FileInfo {
   return {
     name: row.name,
@@ -353,13 +448,39 @@ function rowToFileInfo(row: DbRow): FileInfo {
     modifiedAt: new Date(row.modified_at),
     extension: row.extension,
     duration: row.duration ?? undefined,
+    title: row.name,
     artist: row.artist ?? undefined,
+    originalUrl: row.original_url ?? undefined,
+    thumbnailPath: row.thumbnail_path ?? undefined,
+    remoteThumbnailUrl: row.remote_thumbnail_url ?? undefined,
+    downloadStatus: isDownloadStatus(row.download_status)
+      ? row.download_status
+      : row.extension === 'url'
+        ? 'not_downloaded'
+        : 'downloaded',
+  };
+}
+
+function rowToSearchHit(row: DbRow): SearchHit {
+  return {
+    id: row.id,
+    name: row.name,
+    path: row.path,
+    media_type: row.media_type as MediaType,
+    artist: row.artist,
+    duration: row.duration,
+    modified_at: row.modified_at,
+    rank: 0,
+    title: row.name,
+    original_url: row.original_url,
+    thumbnail_path: row.thumbnail_path,
+    remote_thumbnail_url: row.remote_thumbnail_url,
+    download_status: row.download_status,
   };
 }
 
 function escapeLike(s: string): string {
   return s.replace(/#/g, '##').replace(/%/g, '#%').replace(/_/g, '#_');
 }
-
 
 export const mediaDbService = new MediaDbService();

--- a/src/services/queue-db-service.ts
+++ b/src/services/queue-db-service.ts
@@ -1,6 +1,7 @@
 import Database from '@tauri-apps/plugin-sql';
 import { getDbPath } from './app-paths';
 import type { FileInfo } from './types';
+import { urlMediaService } from './url-media-service';
 
 interface QueueRow {
   id: number;
@@ -14,12 +15,31 @@ interface QueueRow {
   duration: number | null;
   title: string | null;
   artist: string | null;
+  original_url: string | null;
+  thumbnail_path: string | null;
+  remote_thumbnail_url: string | null;
+  download_status: string | null;
 }
 
 export interface QueueDbItem extends FileInfo {
   id: number;
   played: boolean;
 }
+
+type ColumnSpec = {
+  name: string;
+  sql: string;
+};
+
+const QUEUE_URL_COLUMNS: ColumnSpec[] = [
+  { name: 'original_url', sql: 'ALTER TABLE queue ADD COLUMN original_url TEXT' },
+  { name: 'thumbnail_path', sql: 'ALTER TABLE queue ADD COLUMN thumbnail_path TEXT' },
+  { name: 'remote_thumbnail_url', sql: 'ALTER TABLE queue ADD COLUMN remote_thumbnail_url TEXT' },
+  {
+    name: 'download_status',
+    sql: "ALTER TABLE queue ADD COLUMN download_status TEXT NOT NULL DEFAULT 'downloaded'",
+  },
+];
 
 class QueueDbService {
   private readyPromise: Promise<Database> | null = null;
@@ -48,7 +68,23 @@ class QueueDbService {
         artist           TEXT
       )
     `);
+    await this.ensureColumns(db, 'queue', QUEUE_URL_COLUMNS);
+    await db.execute(`CREATE INDEX IF NOT EXISTS idx_queue_original_url ON queue (original_url)`);
     return db;
+  }
+
+  private async ensureColumns(
+    db: Database,
+    tableName: string,
+    columns: ColumnSpec[]
+  ): Promise<void> {
+    const existing = await db.select<{ name: string }[]>(`PRAGMA table_info(${tableName})`);
+    const names = new Set(existing.map((column) => column.name));
+    for (const column of columns) {
+      if (!names.has(column.name)) {
+        await db.execute(column.sql);
+      }
+    }
   }
 
   async loadQueue(): Promise<QueueDbItem[]> {
@@ -59,9 +95,11 @@ class QueueDbService {
 
   async exists(filePath: string): Promise<boolean> {
     const db = await this.ready();
+    const parsed = urlMediaService.parseYouTubeUrl(filePath);
+    const sourceUrl = parsed?.canonicalUrl ?? filePath;
     const [{ count }] = await db.select<[{ count: number }]>(
-      'SELECT COUNT(*) as count FROM queue WHERE file_path = $1',
-      [filePath]
+      'SELECT COUNT(*) as count FROM queue WHERE file_path = $1 OR original_url = $2',
+      [sourceUrl, sourceUrl]
     );
     return count > 0;
   }
@@ -71,22 +109,7 @@ class QueueDbService {
     const [{ max_pos }] = await db.select<[{ max_pos: number | null }]>(
       'SELECT MAX(position) as max_pos FROM queue'
     );
-    const result = await db.execute(
-      `INSERT INTO queue (position, file_path, file_name, file_size, file_modified_at, file_extension, duration, title, artist)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
-      [
-        (max_pos ?? -1) + 1,
-        file.path,
-        file.name,
-        file.size,
-        file.modifiedAt instanceof Date ? file.modifiedAt.getTime() : Number(file.modifiedAt),
-        file.extension,
-        file.duration ?? null,
-        file.title ?? null,
-        file.artist ?? null,
-      ]
-    );
-    return result.lastInsertId!;
+    return this.insertAtPosition(db, file, (max_pos ?? -1) + 1);
   }
 
   async playNext(file: FileInfo): Promise<number> {
@@ -94,19 +117,35 @@ class QueueDbService {
     const [{ min_pos }] = await db.select<[{ min_pos: number | null }]>(
       'SELECT MIN(position) as min_pos FROM queue'
     );
+    return this.insertAtPosition(db, file, (min_pos ?? 1) - 1);
+  }
+
+  async addUrlToQueue(url: string): Promise<number> {
+    const file = await urlMediaService.createYouTubeFileInfo(url);
+    return this.addToQueue(file);
+  }
+
+  private async insertAtPosition(db: Database, file: FileInfo, position: number): Promise<number> {
     const result = await db.execute(
-      `INSERT INTO queue (position, file_path, file_name, file_size, file_modified_at, file_extension, duration, title, artist)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+      `INSERT INTO queue (
+         position, file_path, file_name, file_size, file_modified_at, file_extension,
+         duration, title, artist, original_url, thumbnail_path, remote_thumbnail_url, download_status
+       )
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`,
       [
-        (min_pos ?? 1) - 1,
+        position,
         file.path,
-        file.name,
+        file.title ?? file.name,
         file.size,
         file.modifiedAt instanceof Date ? file.modifiedAt.getTime() : Number(file.modifiedAt),
         file.extension,
         file.duration ?? null,
         file.title ?? null,
         file.artist ?? null,
+        file.originalUrl ?? null,
+        file.thumbnailPath ?? null,
+        file.remoteThumbnailUrl ?? null,
+        file.downloadStatus ?? (file.extension === 'url' ? 'not_downloaded' : 'downloaded'),
       ]
     );
     return result.lastInsertId!;
@@ -136,10 +175,12 @@ class QueueDbService {
    */
   async shiftQueue(excludePath?: string): Promise<QueueDbItem | null> {
     const db = await this.ready();
-    const rows = excludePath
+    const parsed = excludePath ? urlMediaService.parseYouTubeUrl(excludePath) : null;
+    const normalizedExcludePath = parsed?.canonicalUrl ?? excludePath;
+    const rows = normalizedExcludePath
       ? await db.select<QueueRow[]>(
           'SELECT * FROM queue WHERE played = 0 AND file_path != $1 ORDER BY position ASC LIMIT 1',
-          [excludePath]
+          [normalizedExcludePath]
         )
       : await db.select<QueueRow[]>(
           'SELECT * FROM queue WHERE played = 0 ORDER BY position ASC LIMIT 1'
@@ -173,7 +214,13 @@ class QueueDbService {
 
   async updateMetadata(
     filePath: string,
-    metadata: { duration?: number; title?: string; artist?: string }
+    metadata: {
+      duration?: number;
+      title?: string;
+      artist?: string;
+      thumbnailPath?: string;
+      remoteThumbnailUrl?: string;
+    }
   ): Promise<void> {
     const db = await this.ready();
     const updates: string[] = [];
@@ -191,27 +238,49 @@ class QueueDbService {
       updates.push(`artist = $${updates.length + 1}`);
       values.push(metadata.artist);
     }
+    if (metadata.thumbnailPath !== undefined) {
+      updates.push(`thumbnail_path = $${updates.length + 1}`);
+      values.push(metadata.thumbnailPath);
+    }
+    if (metadata.remoteThumbnailUrl !== undefined) {
+      updates.push(`remote_thumbnail_url = $${updates.length + 1}`);
+      values.push(metadata.remoteThumbnailUrl);
+    }
 
     if (updates.length === 0) return;
 
-    values.push(filePath);
-    const query = `UPDATE queue SET ${updates.join(', ')} WHERE file_path = $${values.length}`;
+    const parsed = urlMediaService.parseYouTubeUrl(filePath);
+    const sourceUrl = parsed?.canonicalUrl ?? filePath;
+    values.push(sourceUrl);
+    const query = `UPDATE queue SET ${updates.join(', ')} WHERE file_path = $${values.length} OR original_url = $${values.length}`;
     await db.execute(query, values);
   }
+}
+
+function isDownloadStatus(value: string | null): value is NonNullable<FileInfo['downloadStatus']> {
+  return value === 'not_downloaded' || value === 'downloaded' || value === 'missing';
 }
 
 function rowToItem(row: QueueRow): QueueDbItem {
   return {
     id: row.id,
-    name: row.file_name,
+    name: row.title ?? row.file_name,
     path: row.file_path,
     size: row.file_size,
     modifiedAt: new Date(row.file_modified_at),
     extension: row.file_extension,
     played: row.played === 1,
     duration: row.duration ?? undefined,
-    title: row.title ?? undefined,
+    title: row.title ?? row.file_name,
     artist: row.artist ?? undefined,
+    originalUrl: row.original_url ?? undefined,
+    thumbnailPath: row.thumbnail_path ?? undefined,
+    remoteThumbnailUrl: row.remote_thumbnail_url ?? undefined,
+    downloadStatus: isDownloadStatus(row.download_status)
+      ? row.download_status
+      : row.file_extension === 'url'
+        ? 'not_downloaded'
+        : 'downloaded',
   };
 }
 

--- a/src/services/thumbnail-service.ts
+++ b/src/services/thumbnail-service.ts
@@ -1,5 +1,6 @@
 import { invoke } from '@tauri-apps/api/core';
 import { readFile } from '@tauri-apps/plugin-fs';
+import type { FileInfo } from './types';
 
 const MAX_CONCURRENT = 2;
 
@@ -46,6 +47,33 @@ class ThumbnailService {
     } finally {
       this.releaseSlot();
     }
+  }
+
+  async getMediaThumbnail(file: FileInfo, size = 200): Promise<string> {
+    if (file.extension !== 'url' && !file.originalUrl) {
+      return this.getThumbnail(file.path, size);
+    }
+
+    const key = `${file.path}:${file.thumbnailPath ?? file.remoteThumbnailUrl ?? ''}:${size}`;
+    const cached = this.cache.get(key);
+    if (cached) return cached;
+
+    if (file.thumbnailPath) {
+      const bytes = await readFile(file.thumbnailPath);
+      const blobUrl = URL.createObjectURL(new Blob([bytes], { type: 'image/jpeg' }));
+      this.cache.set(key, blobUrl);
+      return blobUrl;
+    }
+
+    if (file.remoteThumbnailUrl) {
+      const response = await fetch(file.remoteThumbnailUrl);
+      if (!response.ok) throw new Error(`Failed to load remote thumbnail: ${response.status}`);
+      const blobUrl = URL.createObjectURL(await response.blob());
+      this.cache.set(key, blobUrl);
+      return blobUrl;
+    }
+
+    throw new Error('No thumbnail available');
   }
 }
 

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -1,4 +1,5 @@
 export type MediaType = 'lyrics' | 'video' | 'image' | 'text' | 'audio' | 'files' | 'themes';
+export type DownloadStatus = 'not_downloaded' | 'downloaded' | 'missing';
 
 export interface FileInfo {
   name: string;
@@ -9,6 +10,10 @@ export interface FileInfo {
   duration?: number;
   title?: string;
   artist?: string;
+  originalUrl?: string;
+  thumbnailPath?: string;
+  remoteThumbnailUrl?: string;
+  downloadStatus?: DownloadStatus;
 }
 
 export interface FileUploadResult {

--- a/src/services/url-media-service.ts
+++ b/src/services/url-media-service.ts
@@ -1,0 +1,138 @@
+import { join } from '@tauri-apps/api/path';
+import { exists, mkdir, writeFile } from '@tauri-apps/plugin-fs';
+import { getAppBasePath } from './app-paths';
+import type { FileInfo } from './types';
+
+type YouTubeOEmbedResponse = {
+  title?: string;
+  author_name?: string;
+  thumbnail_url?: string;
+};
+
+export type UrlMediaMetadata = {
+  originalUrl: string;
+  canonicalUrl: string;
+  title: string;
+  artist?: string;
+  remoteThumbnailUrl?: string;
+  thumbnailPath?: string;
+};
+
+class UrlMediaService {
+  isSupportedUrl(value: string): boolean {
+    return this.parseYouTubeUrl(value) !== null;
+  }
+
+  isRemoteUrl(value: string): boolean {
+    return /^https?:\/\//i.test(value);
+  }
+
+  parseYouTubeUrl(value: string): { videoId: string; canonicalUrl: string } | null {
+    let url: URL;
+    try {
+      url = new URL(value);
+    } catch {
+      return null;
+    }
+
+    const host = url.hostname.replace(/^www\./i, '').toLowerCase();
+    let videoId: string | null = null;
+
+    if (host === 'youtu.be') {
+      videoId = url.pathname.split('/').filter(Boolean)[0] ?? null;
+    } else if (host === 'youtube.com' || host === 'm.youtube.com' || host === 'music.youtube.com') {
+      if (url.pathname === '/watch') {
+        videoId = url.searchParams.get('v');
+      } else if (url.pathname.startsWith('/shorts/')) {
+        videoId = url.pathname.split('/').filter(Boolean)[1] ?? null;
+      } else if (url.pathname.startsWith('/embed/')) {
+        videoId = url.pathname.split('/').filter(Boolean)[1] ?? null;
+      }
+    }
+
+    if (!videoId || !/^[a-zA-Z0-9_-]{6,}$/.test(videoId)) return null;
+
+    return {
+      videoId,
+      canonicalUrl: `https://www.youtube.com/watch?v=${videoId}`,
+    };
+  }
+
+  async resolveYouTube(url: string): Promise<UrlMediaMetadata> {
+    const parsed = this.parseYouTubeUrl(url);
+    if (!parsed) {
+      throw new Error('Only YouTube URLs are supported');
+    }
+
+    const fallbackTitle = `YouTube video ${parsed.videoId}`;
+    let metadata: YouTubeOEmbedResponse | null = null;
+
+    try {
+      const res = await fetch(
+        `https://www.youtube.com/oembed?url=${encodeURIComponent(parsed.canonicalUrl)}&format=json`
+      );
+      if (res.ok) {
+        metadata = (await res.json()) as YouTubeOEmbedResponse;
+      }
+    } catch {
+      metadata = null;
+    }
+
+    const remoteThumbnailUrl = metadata?.thumbnail_url;
+    const thumbnailPath = remoteThumbnailUrl
+      ? await this.cacheRemoteThumbnail(parsed.videoId, remoteThumbnailUrl).catch(() => undefined)
+      : undefined;
+
+    return {
+      originalUrl: url,
+      canonicalUrl: parsed.canonicalUrl,
+      title: metadata?.title?.trim() || fallbackTitle,
+      artist: metadata?.author_name?.trim() || undefined,
+      remoteThumbnailUrl,
+      thumbnailPath,
+    };
+  }
+
+  async createYouTubeFileInfo(url: string): Promise<FileInfo> {
+    const metadata = await this.resolveYouTube(url);
+    return {
+      name: metadata.title,
+      path: metadata.canonicalUrl,
+      size: 0,
+      modifiedAt: new Date(),
+      extension: 'url',
+      title: metadata.title,
+      artist: metadata.artist,
+      originalUrl: metadata.originalUrl,
+      thumbnailPath: metadata.thumbnailPath,
+      remoteThumbnailUrl: metadata.remoteThumbnailUrl,
+      downloadStatus: 'not_downloaded',
+    };
+  }
+
+  private async getRemoteThumbsPath(): Promise<string> {
+    const basePath = await getAppBasePath();
+    const cachePath = await join(basePath, 'cache', 'remote-thumbs');
+    if (!(await exists(cachePath))) {
+      await mkdir(cachePath, { recursive: true });
+    }
+    return cachePath;
+  }
+
+  private async cacheRemoteThumbnail(videoId: string, thumbnailUrl: string): Promise<string> {
+    const cacheDir = await this.getRemoteThumbsPath();
+    const filePath = await join(cacheDir, `youtube_${videoId}.jpg`);
+    if (await exists(filePath)) return filePath;
+
+    const response = await fetch(thumbnailUrl);
+    if (!response.ok) {
+      throw new Error(`Failed to download thumbnail: ${response.status}`);
+    }
+
+    const bytes = new Uint8Array(await response.arrayBuffer());
+    await writeFile(filePath, bytes);
+    return filePath;
+  }
+}
+
+export const urlMediaService = new UrlMediaService();

--- a/src/stores/player-store.ts
+++ b/src/stores/player-store.ts
@@ -4,6 +4,7 @@ import { WebviewWindow } from '@tauri-apps/api/webviewWindow';
 import { create } from 'zustand';
 import { getSetting, saveSetting } from '@/services/db';
 import { remoteSyncService } from '@/services/remote-sync-service';
+import { urlMediaService } from '@/services/url-media-service';
 import { useQueueStore } from '@/stores/queue-store';
 import { useQueueEntriesStore } from '@/stores/queue-entries-store';
 
@@ -85,8 +86,13 @@ async function waitForMediaWindowReady(timeoutMs = 3000): Promise<void> {
   });
 }
 
+function normalizeMediaSource(source: string): string {
+  return urlMediaService.parseYouTubeUrl(source)?.canonicalUrl ?? source;
+}
+
 function getMediaTypeFromPath(filePath: string | null | undefined): PlayerStore['localMediaType'] {
   if (!filePath) return undefined;
+  if (urlMediaService.parseYouTubeUrl(filePath)) return 'video';
   const ext = filePath.split('.').pop()?.toLowerCase() ?? '';
   const videoExtensions = ['mp4', 'webm', 'mkv', 'avi', 'mov'];
   if (videoExtensions.includes(ext)) {
@@ -220,7 +226,7 @@ export const usePlayerStore = create<PlayerStore>((set, get) => ({
     });
 
     const unlistenLoadUrl = listen<{ url: string; time: number }>('load-url', (event) => {
-      const filePath = event.payload.url;
+      const filePath = normalizeMediaSource(event.payload.url);
       const seekTime = Number(event.payload.time) || 0;
       set({
         isPlaying: true,
@@ -412,9 +418,8 @@ export const usePlayerStore = create<PlayerStore>((set, get) => ({
   setIsDragging: (dragging) => set({ isDragging: dragging }),
 
   loadFile: async (filePath: string, seekTime = 0) => {
-    const videoExtensions = ['mp4', 'webm', 'mkv', 'avi', 'mov'];
-    const ext = filePath.split('.').pop()?.toLowerCase() ?? '';
-    const isVideo = videoExtensions.includes(ext);
+    const source = normalizeMediaSource(filePath);
+    const isVideo = getMediaTypeFromPath(source) === 'video';
 
     let win = await getMediaWindow();
     if (!win) {
@@ -434,12 +439,12 @@ export const usePlayerStore = create<PlayerStore>((set, get) => ({
       await new Promise((r) => setTimeout(r, 50));
     }
 
-    get().sendWs({ event: 'load_url', url: filePath, value: seekTime });
+    get().sendWs({ event: 'load_url', url: source, value: seekTime });
     set({
       isPlaying: true,
       localMediaType: isVideo ? 'video' : 'audio',
       restoredFilePath: null,
-      currentFilePath: filePath,
+      currentFilePath: source,
       currentLyricPath: null,
       currentLyricSlideIndex: 0,
       currentLyricTotalSlides: 0,
@@ -447,7 +452,7 @@ export const usePlayerStore = create<PlayerStore>((set, get) => ({
       localDuration: seekTime > 0 ? get().localDuration : 0,
     });
 
-    saveSetting('last_media_path', filePath).catch(() => {});
+    saveSetting('last_media_path', source).catch(() => {});
     saveSetting('last_media_type', isVideo ? 'video' : 'audio').catch(() => {});
     saveSetting('last_time', '0').catch(() => {});
     void broadcastPlayerSync(get, 'load_url');
@@ -546,10 +551,7 @@ function nowUnixSeconds() {
   return Math.floor(Date.now() / 1000);
 }
 
-async function broadcastPlayerSync(
-  get: () => PlayerStore,
-  action?: string
-): Promise<void> {
+async function broadcastPlayerSync(get: () => PlayerStore, action?: string): Promise<void> {
   const state = get();
   await remoteSyncService.broadcast(
     {
@@ -575,7 +577,9 @@ async function broadcastPlayerSync(
         active: Boolean(state.currentLyricPath),
         url: state.currentLyricPath ?? undefined,
         slide_index: state.currentLyricPath ? state.currentLyricSlideIndex : undefined,
-        total_slides: state.currentLyricPath ? state.currentLyricTotalSlides || undefined : undefined,
+        total_slides: state.currentLyricPath
+          ? state.currentLyricTotalSlides || undefined
+          : undefined,
       },
       action,
     },

--- a/src/stores/queue-store.ts
+++ b/src/stores/queue-store.ts
@@ -1,6 +1,7 @@
 import { toast } from 'sonner';
 import { create } from 'zustand';
 import { queueDbService } from '@/services/queue-db-service';
+import { urlMediaService } from '@/services/url-media-service';
 import type { FileInfo } from '@/services/types';
 
 export interface QueueItem {
@@ -14,6 +15,8 @@ interface QueueStore {
   loadFromDb: () => Promise<void>;
   addToQueue: (file: FileInfo) => Promise<void>;
   playNext: (file: FileInfo) => Promise<void>;
+  addUrlToQueue: (url: string) => Promise<void>;
+  playUrlNext: (url: string) => Promise<void>;
   removeFromQueue: (id: number) => Promise<void>;
   markPlayed: (id: number) => Promise<void>;
   togglePlayed: (id: number) => Promise<void>;
@@ -21,7 +24,16 @@ interface QueueStore {
   clearQueue: () => Promise<void>;
   shuffleQueue: () => Promise<void>;
   reorderQueue: (orderedIds: number[]) => Promise<void>;
-  updateMetadata: (filePath: string, metadata: { duration?: number; title?: string; artist?: string }) => Promise<void>;
+  updateMetadata: (
+    filePath: string,
+    metadata: {
+      duration?: number;
+      title?: string;
+      artist?: string;
+      thumbnailPath?: string;
+      remoteThumbnailUrl?: string;
+    }
+  ) => Promise<void>;
 }
 
 export const useQueueStore = create<QueueStore>((set) => ({
@@ -44,6 +56,30 @@ export const useQueueStore = create<QueueStore>((set) => ({
   },
 
   playNext: async (file) => {
+    const already = await queueDbService.exists(file.path);
+    if (already) {
+      toast.info('Already in queue', { description: file.name });
+      return;
+    }
+
+    const id = await queueDbService.playNext(file);
+    set((s) => ({ queue: [{ id, file, played: false }, ...s.queue] }));
+  },
+
+  addUrlToQueue: async (url) => {
+    const file = await urlMediaService.createYouTubeFileInfo(url);
+    const already = await queueDbService.exists(file.path);
+    if (already) {
+      toast.info('Already in queue', { description: file.name });
+      return;
+    }
+
+    const id = await queueDbService.addToQueue(file);
+    set((s) => ({ queue: [...s.queue, { id, file, played: false }] }));
+  },
+
+  playUrlNext: async (url) => {
+    const file = await urlMediaService.createYouTubeFileInfo(url);
     const already = await queueDbService.exists(file.path);
     if (already) {
       toast.info('Already in queue', { description: file.name });
@@ -114,6 +150,8 @@ export const useQueueStore = create<QueueStore>((set) => ({
                 duration: metadata.duration ?? item.file.duration,
                 title: metadata.title ?? item.file.title,
                 artist: metadata.artist ?? item.file.artist,
+                thumbnailPath: metadata.thumbnailPath ?? item.file.thumbnailPath,
+                remoteThumbnailUrl: metadata.remoteThumbnailUrl ?? item.file.remoteThumbnailUrl,
               },
             }
           : item


### PR DESCRIPTION
## Description

Adds first-class support for YouTube URLs as video media in Lumen, aimed at module/host API usage rather than an in-app add-URL UI.

### What was changed?

- Added a YouTube URL media service for URL parsing, normalization, oEmbed metadata, and remote thumbnail caching.
- Added minimal URL fields to media and queue persistence: `original_url`, `thumbnail_path`, `remote_thumbnail_url`, and `download_status`.
- Keeps URL media as `media_type = 'video'` with `extension = 'url'` and uses the normalized YouTube URL as the current `path` compatibility value.
- Prevents filesystem media sync from deleting URL media rows.
- Adds URL-aware library/queue host APIs for modules.
- Updates playback so HTTP(S)/YouTube URLs bypass local file reads and use the existing ReactPlayer path.
- Adds URL thumbnail/status rendering in library and queue rows.
- Documents the plan and module API behavior.

### Why?

Modules need a way to add playable YouTube video media without Lumen exposing a manual add-URL UI yet. Lumen should own metadata lookup, thumbnail caching, queue persistence, and playback compatibility.

## Related Issues

- Closes #50

## How to Test

1. Start with a clean local Lumen DB or run the dynamic migrations.
2. Add a YouTube URL through `host.library.addUrl` / `host.queue.addUrl`, or insert a test row manually with `extension = 'url'` and `media_type = 'video'`.
3. Confirm the item appears under videos with URL/download status badges.
4. Add it to the queue and restart Lumen; confirm the queue row restores with persisted metadata fields.
5. Play the URL and confirm the video player loads it as a remote URL instead of trying to read it as a local file.
6. Refresh/sync the video folder and confirm URL media rows are not deleted.

Local validation performed:

- `tsc`
- `vite build`

## Screenshots/Evidence

N/A for this backend/API-focused first cut.

## Checklist

- [x] UX/API/contract impact covered
- [x] Docs or release notes updated
- [x] Migrations/Seeds applied (dynamic column migration)
- [x] Rollout/rollback flags defined or not needed
- [x] Tests added or updated where practical
- [x] All tests passing
- [x] Self-reviewed
- [ ] QA/Stakeholders notified

## Additional Notes

Initial support intentionally accepts only YouTube URLs. It does not add generic provider modeling, in-app URL entry UI, or local video downloading yet.
