### PR TITLE
feat/add-new-sdk-apiui

### DIFF
--- a/docs/architecture/module-net-request-api.md
+++ b/docs/architecture/module-net-request-api.md
@@ -1,0 +1,475 @@
+# Module Net Request API
+
+## Goal
+
+Give Lumen modules a generic, host-managed HTTP client that works for external APIs without exposing privileged networking directly to module code.
+
+The API must be broad enough for integrations such as YouTube, GitHub, Bible APIs, planning tools, cloud storage metadata, webhooks, and small file endpoints. It should not be tied to any single provider. The Lumen host owns native request execution, permission checks, timeouts, response limits, redirect validation, and future credential handling.
+
+The immediate pressure is the YouTube module, but the contract should be generic platform infrastructure.
+
+## Current State
+
+There is an important split today:
+
+- The Lumen app repo has an internal `NetAPI` in `src/modules/types.ts` and wires `host.net` in `src/modules/apis/net.ts`.
+- The published/local `@lumen-media/module-sdk` repo does not currently expose `net` on `LumenHost`.
+- The app-side implementation is renderer-backed and currently calls browser `fetch()`.
+- The app docs mention `host.net` in `docs/module-api-reference.md`, but the SDK contract needs to catch up before third-party modules can rely on it.
+
+Current app-side shape, with no known module consumers today:
+
+```ts
+host.net.get(url, opts)
+host.net.post(url, body, opts)
+```
+
+Because no module currently consumes `host.net`, this should be treated as a contract redesign instead of a compatibility migration.
+
+## SDK Coordination
+
+This is a cross-repository change. The Lumen app cannot ship the final `host.net` contract alone because modules compile against `@lumen-media/module-sdk`.
+
+Required SDK work in `Lumen-media/module-sdk`:
+
+- Add `NetAPI`, `NetRequest`, `NetRequestBody`, `NetResponse`, `NetError`, and related helper types.
+- Add `net: NetAPI` to `LumenHost`.
+- Add `permissions.network` to `manifest.schema.json` and manifest TypeScript types.
+- Update SDK docs and examples so module authors use `host.net.request()`.
+- Release a new SDK version, then update the Lumen app dependency/contract to match.
+
+Required Lumen app work:
+
+- Update the app's internal module host types to match the SDK.
+- Implement `host.net.request()` through Rust/Tauri.
+- Validate `permissions.network` from installed module manifests.
+- Keep app docs aligned with the SDK public contract.
+## Decision
+
+Make `host.net.request()` the primary public API. Implement it through a Tauri command backed by Rust HTTP client code.
+
+```txt
+module code
+  -> host.net.request(input)
+  -> Tauri invoke
+  -> Rust validates module permissions and URL
+  -> Rust builds and executes the HTTP request
+  -> Rust normalizes response or error
+  -> SDK returns NetResponse to module
+```
+
+`host.net.get()` and `host.net.post()` may exist as convenience helpers, but they should be thin SDK wrappers over `request()` and should not define the core contract.
+
+## Design Principles
+
+- Provider-neutral: no YouTube, GitHub, or app-specific concepts in `host.net`.
+- Structured: avoid exposing browser `RequestInit` directly because it is not stable across native execution.
+- Serializable: every request/response shape must cross the Tauri boundary cleanly.
+- Explicit body and response modes: JSON, text, bytes, and common form bodies need clear representation.
+- Safe by default: permission checks, denied local networks, size limits, timeouts, and redirect validation are host responsibilities.
+- Small-response oriented: `host.net.request()` is for API calls and modest assets, not unbounded downloads or media mirroring.
+- Evolvable: large downloads, streaming, secrets, and OAuth can become separate host services later.
+
+## SDK Shape
+
+```ts
+export type NetMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'HEAD';
+export type NetResponseType = 'json' | 'text' | 'bytes' | 'none';
+
+export type NetQueryValue = string | number | boolean | null | undefined;
+
+export type NetRequestBody =
+  | { type: 'json'; value: unknown }
+  | { type: 'text'; value: string; contentType?: string }
+  | { type: 'bytes'; valueBase64: string; contentType?: string }
+  | { type: 'form'; value: Record<string, NetQueryValue> }
+  | {
+      type: 'multipart';
+      parts: Array<
+        | { name: string; type: 'text'; value: string; contentType?: string }
+        | {
+            name: string;
+            type: 'bytes';
+            valueBase64: string;
+            filename?: string;
+            contentType?: string;
+          }
+      >;
+    };
+
+export interface NetRequest {
+  url: string;
+  method?: NetMethod;
+  query?: Record<string, NetQueryValue | NetQueryValue[]>;
+  headers?: Record<string, string>;
+  body?: NetRequestBody;
+  responseType?: NetResponseType;
+  timeoutMs?: number;
+  maxBytes?: number;
+  followRedirects?: boolean;
+}
+
+export interface NetResponse<T = unknown> {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  headers: Record<string, string>;
+  url: string;
+  redirected: boolean;
+  data: T;
+}
+
+export interface NetAPI {
+  request<T = unknown>(input: NetRequest): Promise<NetResponse<T>>;
+
+  // Optional convenience helpers. These are SDK sugar, not the core contract.
+  get?<T = unknown>(url: string, opts?: Omit<NetRequest, 'url' | 'method' | 'body'>): Promise<T>;
+  post?<T = unknown>(
+    url: string,
+    body?: NetRequestBody | unknown,
+    opts?: Omit<NetRequest, 'url' | 'method' | 'body'>
+  ): Promise<T>;
+}
+```
+
+### Defaults
+
+- `method`: `GET` when `body` is absent, `POST` when `body` is present.
+- `responseType`: `json` when response `Content-Type` looks JSON, otherwise `text`. Modules can set it explicitly.
+- `timeoutMs`: 15 seconds.
+- `maxBytes`: 10 MB.
+- `followRedirects`: `true`, with each redirect revalidated against module permissions.
+
+### Convenience Helpers
+
+If shipped, `get()` and `post()` should:
+
+- Call `request()` internally.
+- Throw on non-2xx responses.
+- Return `response.data` directly.
+- Use the same structured options as `request()`, not browser `RequestInit`.
+
+Example:
+
+```ts
+const data = await host.net.get?.<SearchResponse>(
+  'https://www.googleapis.com/youtube/v3/search',
+  {
+    query: {
+      part: 'snippet',
+      type: 'video',
+      q: 'oceans hillsong',
+      key: apiKey,
+      maxResults: 10,
+    },
+  }
+);
+```
+
+## Examples
+
+### JSON GET
+
+```ts
+const response = await host.net.request<YoutubeSearchResponse>({
+  method: 'GET',
+  url: 'https://www.googleapis.com/youtube/v3/search',
+  query: {
+    part: 'snippet',
+    type: 'video',
+    q,
+    key: apiKey,
+    maxResults: 10,
+  },
+  responseType: 'json',
+});
+
+if (!response.ok) {
+  throw new Error(`YouTube request failed: ${response.status}`);
+}
+```
+
+### JSON POST
+
+```ts
+await host.net.request({
+  method: 'POST',
+  url: 'https://api.example.com/webhooks/event',
+  headers: { Authorization: `Bearer ${token}` },
+  body: {
+    type: 'json',
+    value: { event: 'started', at: Date.now() },
+  },
+  responseType: 'json',
+});
+```
+
+### Form URL Encoded
+
+```ts
+await host.net.request<TokenResponse>({
+  method: 'POST',
+  url: 'https://api.example.com/oauth/token',
+  body: {
+    type: 'form',
+    value: {
+      grant_type: 'refresh_token',
+      refresh_token: refreshToken,
+    },
+  },
+});
+```
+
+### Text Response
+
+```ts
+const response = await host.net.request<string>({
+  url: 'https://example.com/status.txt',
+  responseType: 'text',
+});
+```
+
+### Bytes Response
+
+```ts
+const response = await host.net.request<string>({
+  url: 'https://example.com/small-image.png',
+  responseType: 'bytes',
+  maxBytes: 2_000_000,
+});
+
+// response.data is base64 in v1.
+const bytesBase64 = response.data;
+```
+
+Bytes are represented as base64 in v1 because it crosses the Tauri/JSON bridge predictably. If this becomes too costly, the SDK can add a binary invoke path later.
+
+## Manifest Permissions
+
+The generic request API needs an allowlist. A module should not be able to call arbitrary URLs just because it is installed.
+
+Proposed manifest extension:
+
+```json
+{
+  "permissions": {
+    "network": [
+      "https://www.googleapis.com/youtube/v3/*",
+      "https://api.github.com/repos/example/*"
+    ]
+  }
+}
+```
+
+The Rust side validates every request against the installed module's manifest before making the network call.
+
+Initial matching rules:
+
+- Only `https` by default.
+- Exact host match unless the manifest explicitly uses a wildcard host.
+- Wildcard hosts should be rare and reviewed carefully, for example `https://*.example.com/*`.
+- Path wildcards are allowed only at segment boundaries or as a trailing `*`.
+- Query strings are not part of the permission pattern.
+- Redirect targets must be revalidated against the same rules.
+- Deny localhost, loopback, private IP ranges, link-local IPs, and custom/file schemes by default.
+- Resolve DNS before request and reject private network targets even when the URL uses a public-looking hostname.
+
+Future permission UI can show a clear install prompt:
+
+```txt
+This module can connect to:
+- www.googleapis.com
+- api.github.com
+```
+
+## Runtime Safeguards
+
+The host should enforce conservative defaults:
+
+- Default timeout: 15 seconds.
+- Maximum timeout: 60 seconds.
+- Default response size limit: 10 MB.
+- Hard maximum response size: 50 MB unless a future permission grants more.
+- Maximum redirect count: 5.
+- Deny request bodies on `GET` and `HEAD`.
+- Deny unsafe request headers controlled by the host/runtime.
+- Strip hop-by-hop response headers.
+- Normalize errors into typed module-facing errors.
+- Log requests by module id without logging secrets or full sensitive query strings.
+
+Headers modules should not set:
+
+- `Host`
+- `Content-Length`
+- `Connection`
+- `Transfer-Encoding`
+- `Upgrade`
+- `Proxy-*`
+- `Sec-*`
+
+The host may reserve or rewrite `User-Agent`.
+
+## Error Model
+
+`request()` should reject only when the request could not be completed or violated host policy. HTTP statuses such as 400, 401, 403, 404, and 500 should resolve as `NetResponse` with `ok: false`.
+
+Proposed error shape:
+
+```ts
+export type NetErrorCode =
+  | 'permission_denied'
+  | 'invalid_url'
+  | 'blocked_url'
+  | 'timeout'
+  | 'network_error'
+  | 'response_too_large'
+  | 'invalid_response'
+  | 'unsupported_body'
+  | 'unsupported_response_type';
+
+export interface NetError extends Error {
+  code: NetErrorCode;
+  status?: number;
+  url?: string;
+}
+```
+
+This keeps provider errors visible to modules while keeping host policy failures explicit.
+
+## Rust Implementation Sketch
+
+Add a Tauri command such as:
+
+```rust
+#[tauri::command]
+async fn module_net_request(
+    module_id: String,
+    input: ModuleNetRequest,
+    runtime: tauri::State<'_, ModuleRuntime>,
+) -> Result<ModuleNetResponse, ModuleNetError> {
+    runtime.assert_network_allowed(&module_id, &input.url)?;
+    runtime.net_client().request(module_id, input).await
+}
+```
+
+Implementation pieces:
+
+- `ModuleNetRequest`, `ModuleNetRequestBody`, and `ModuleNetResponse` serde structs.
+- URL parser and permission matcher.
+- DNS/private-network guard.
+- Shared `reqwest::Client`.
+- Redirect policy that validates each hop.
+- Body encoder for JSON, text, bytes, form, and multipart.
+- Response parser for JSON, text, bytes, and none.
+- Size-limited response body read.
+- Error mapping that does not leak native internals unnecessarily.
+
+## Non-Goals For V1
+
+These should not be forced into generic `host.net.request()` initially:
+
+- Long-running downloads to disk.
+- Streaming request or response bodies.
+- WebSockets or SSE.
+- OAuth browser flows.
+- Secret storage.
+- Cookie jar/session persistence.
+- Automatic provider-specific pagination or retry logic.
+
+Future services can cover these separately:
+
+```ts
+host.downloads.downloadFile(...)
+host.secrets.get(...)
+host.auth.oauth(...)
+host.net.stream?(...)
+```
+
+## Credential Handling
+
+This API does not solve secrets by itself.
+
+For the first YouTube module version, the user can provide their own Google API key inside the module's settings UI. The module stores that preference using `host.data.json`.
+
+Longer term, Lumen should consider:
+
+```ts
+host.secrets.get(key)
+host.secrets.set(key, value)
+host.secrets.delete(key)
+```
+
+That would let modules store API keys in OS-backed secure storage instead of plain module data. `host.net.request()` should be compatible with either approach: the module can pass the key in query params/headers today, and a future host service can inject secrets later.
+
+## YouTube Module Usage
+
+The YouTube module would declare:
+
+```json
+{
+  "permissions": {
+    "network": [
+      "https://www.googleapis.com/youtube/v3/*"
+    ]
+  }
+}
+```
+
+Search request:
+
+```ts
+const search = await host.net.request<YoutubeSearchResponse>({
+  url: 'https://www.googleapis.com/youtube/v3/search',
+  query: {
+    part: 'snippet',
+    type: 'video',
+    q,
+    key: apiKey,
+    maxResults: 10,
+    safeSearch: 'moderate',
+    regionCode: 'BR',
+  },
+  responseType: 'json',
+});
+```
+
+Details request:
+
+```ts
+const details = await host.net.request<YoutubeVideosResponse>({
+  url: 'https://www.googleapis.com/youtube/v3/videos',
+  query: {
+    part: 'snippet,contentDetails,status,statistics',
+    id: videoIds.join(','),
+    key: apiKey,
+  },
+  responseType: 'json',
+});
+```
+
+The module still owns YouTube-specific normalization. Lumen only owns the generic transport.
+
+## Open Questions
+
+- Should `get()` and `post()` exist in v1, or should the public API force every module through `request()` first?
+- Should network permissions be enforced immediately for all modules, or only once third-party install is public?
+- Should dev/sideloaded modules get a temporary "allow all network" escape hatch with a clear warning?
+- Should response caching be generic in `host.net`, or left to each module through `host.data`?
+- Should Lumen expose `host.secrets` before the YouTube module ships, or is `host.data.json` acceptable for the first iteration?
+- Should v1 include multipart uploads, or postpone them until a concrete module needs them?
+
+## Implementation Checklist
+
+- [ ] Promote `NetAPI` into `@lumen-media/module-sdk`.
+- [ ] Add `permissions.network` to the module manifest schema.
+- [ ] Implement Rust `module_net_request` command.
+- [ ] Replace renderer `fetch()` implementation with Tauri invoke.
+- [ ] Implement structured body encoders for JSON, text, bytes, form, and optionally multipart.
+- [ ] Implement response parsers for JSON, text, bytes, and none.
+- [ ] Decide whether to ship `get()` and `post()` wrappers or only `request()` in the first public SDK shape.
+- [ ] Add URL permission matcher tests.
+- [ ] Add blocked localhost/private-network tests.
+- [ ] Add response-size and timeout tests.
+- [ ] Document module author examples in `module-api-reference.md`.
+- [ ] Update the YouTube module manifest to request Google API access.
+

--- a/docs/module-api-reference.md
+++ b/docs/module-api-reference.md
@@ -188,6 +188,7 @@ host.commands.invoke('my-module.search', { query: 'test' });
 | `query` | `string` | Current value of the commander search input, when `commanderSearch` is enabled |
 | `setQuery` | `(query: string) => void` | Updates the commander search input from the app component |
 | `setSearchTrailing` | `(component?: CommanderSearchTrailingComponent) => void` | Registers an optional component rendered to the right of the search input |
+| `setBackHandler` | `(handler?: CommanderBackHandler) => void` | Registers an optional back override used by the commander header and `Escape` before the app is closed |
 
 
 ### Commander app search
@@ -225,6 +226,28 @@ host.commands.add({
 
 `commanderSearch: true` uses the default app title as the placeholder. Passing an object lets you set `placeholder` and `initialQuery`. Prefix results can also set `commanderSearch`, which is useful when the prefix handler opens an app with the typed prefix query already filled.
 
+### Commander app back handling
+
+Apps can optionally override the commander back action without leaving the app. Register a `setBackHandler` callback that returns `true` when it handled the back action internally. If it returns `false`, `undefined`, or no handler is registered, the commander falls back to the default app exit behavior.
+
+```tsx
+function SearchApp({ setBackHandler }: CommanderAppProps) {
+  const [view, setView] = React.useState<'search' | 'settings'>('search');
+
+  React.useEffect(() => {
+    if (!setBackHandler) return;
+
+    setBackHandler(() => {
+      if (view === 'settings') {
+        setView('search');
+        return true;
+      }
+    });
+
+    return () => setBackHandler(undefined);
+  }, [setBackHandler, view]);
+}
+```
 ### Prefix search
 
 Registers a keyword prefix that intercepts typed queries in the palette. When the user types `bible foo`, the query `foo` is routed to your handler instead of running the normal search.
@@ -1024,4 +1047,6 @@ export default class ExamplePlugin extends LumenPlugin {
   }
 }
 ```
+
+
 

--- a/docs/module-api-reference.md
+++ b/docs/module-api-reference.md
@@ -492,13 +492,14 @@ await host.fs.remove('temp/file.tmp');
 
 ---
 
-## `host.net` 🚧
+## `host.net` ✅
 
-Generic host-managed HTTP requests for modules. The intended public contract is `request()`, implemented by Lumen through Rust/Tauri. See [module-net-request-api.md](./architecture/module-net-request-api.md).
+Generic host-managed HTTP requests for modules. Implemented through Rust/Tauri with `reqwest` — permission checks, timeouts, response size limits, and redirect validation are all enforced by the Lumen host. See [module-net-request-api.md](./architecture/module-net-request-api.md).
 
-This requires a matching `@lumen-media/module-sdk` update: `NetAPI` must be added to the SDK `LumenHost`, and `permissions.network` must be added to the SDK manifest schema before modules can depend on it.
+The primary API is `request()`. Convenience helpers `get()` and `post()` are thin wrappers that throw on non-2xx and return `response.data` directly.
 
 ```ts
+// Primary API — full control
 const response = await host.net.request<{ items: unknown[] }>({
   method: 'GET',
   url: 'https://api.example.com/items',
@@ -509,8 +510,14 @@ const response = await host.net.request<{ items: unknown[] }>({
 });
 
 if (!response.ok) {
-  throw new Error(Request failed: );
+  throw new Error(`Request failed: ${response.status}`);
 }
+
+// Convenience — throws on non-2xx, returns data directly
+const items = await host.net.get!<{ items: unknown[] }>(
+  'https://api.example.com/items',
+  { query: { search: 'test', limit: 10 } },
+);
 
 await host.net.request({
   method: 'POST',
@@ -520,9 +527,73 @@ await host.net.request({
 });
 ```
 
-Supported request body modes are planned as `json`, `text`, `bytes`, `form`, and optionally `multipart`. Supported response modes are `json`, `text`, `bytes`, and `none`.
+### Request body modes
 
-Modules should only request hosts declared in their manifest network permissions once permission enforcement lands.
+| Mode | Type discriminant | Value |
+|---|---|---|
+| JSON | `{ type: 'json', value: unknown }` | Any JSON-serializable value |
+| Text | `{ type: 'text', value: string, contentType?: string }` | Plain text, defaults to `text/plain` |
+| Bytes | `{ type: 'bytes', valueBase64: string, contentType?: string }` | Base64-encoded binary |
+| Form | `{ type: 'form', value: Record<string, string> }` | URL-encoded form |
+| Multipart | `{ type: 'multipart', parts: [...] }` | Not yet supported in v1 |
+
+### Response modes
+
+| Mode | Description |
+|---|---|
+| `json` (default) | Parses body as JSON. Falls back to raw string if parsing fails. |
+| `text` | Returns body as a plain string. |
+| `bytes` | Returns body as a base64-encoded string. |
+| `none` | Returns `null`. Use for fire-and-forget requests. |
+
+### Defaults
+
+- Method: `GET` when body is absent, `POST` when body is present.
+- Response type: `json`.
+- Timeout: 15 seconds (max 60 s).
+- Max response size: 10 MB (hard limit 50 MB).
+- Follow redirects: yes (max 5 hops).
+- Only `https://` URLs allowed. Localhost, private IPs, and link-local addresses are blocked.
+- Forbidden headers: `Host`, `Content-Length`, `Connection`, `Transfer-Encoding`, `Upgrade`, `Proxy-*`, `Sec-*`.
+
+### Manifest permissions
+
+Modules must declare which URLs they can access in their `manifest.json`:
+
+```json
+{
+  "permissions": {
+    "network": [
+      "https://www.googleapis.com/youtube/v3/*",
+      "https://api.github.com/repos/example/*"
+    ]
+  }
+}
+```
+
+Matching rules:
+- Only `https` scheme.
+- Exact host match, or wildcard subdomain (`*.example.com`).
+- Path wildcards at segment boundaries (`/api/*`).
+- Redirect targets are revalidated against the same rules.
+- Queries are not part of the permission pattern.
+- If a module declares no permissions, all `https` URLs are allowed (behaviour may change in the future).
+
+### Error model
+
+`request()` rejects only on host policy violations or network failures. HTTP 4xx/5xx resolve as `response.ok === false`.
+
+```ts
+try {
+  await host.net.request({ url: 'https://api.example.com/data' });
+} catch (err) {
+  // err.code: 'permission_denied' | 'invalid_url' | 'blocked_url'
+  //           | 'timeout' | 'network_error' | 'response_too_large'
+  //           | 'invalid_response' | 'unsupported_body'
+  // err.status?: number
+  // err.url?: string
+}
+```
 
 ---
 

--- a/docs/module-api-reference.md
+++ b/docs/module-api-reference.md
@@ -177,6 +177,7 @@ host.commands.invoke('my-module.search', { query: 'test' });
 | `type` | `'action' \| 'app'` | | Defaults to `'action'` |
 | `run` | `(args?: unknown) => unknown` | ✓ for `'action'` | Executed on select |
 | `component` | `React.ComponentType<CommanderAppProps>` | ✓ for `'app'` | Sub-UI rendered in palette |
+| `commanderSearch` | `boolean \| CommanderSearchOptions` | | Shows the commander search input inside the app view and passes its query to `component` |
 
 ### `CommanderAppProps`
 
@@ -184,6 +185,45 @@ host.commands.invoke('my-module.search', { query: 'test' });
 |---|---|---|
 | `onClose` | `() => void` | Closes the palette entirely |
 | `onBack` | `() => void` | Returns to the palette root list |
+| `query` | `string` | Current value of the commander search input, when `commanderSearch` is enabled |
+| `setQuery` | `(query: string) => void` | Updates the commander search input from the app component |
+| `setSearchTrailing` | `(component?: CommanderSearchTrailingComponent) => void` | Registers an optional component rendered to the right of the search input |
+
+
+### Commander app search
+
+App commands do not show a search input by default. Enable it with `commanderSearch` when the app should use the commander's own input instead of rendering a second search field.
+
+```tsx
+import { type CommanderAppProps } from '@lumen/module-sdk';
+
+function SearchApp({ query = '', setSearchTrailing }: CommanderAppProps) {
+  React.useEffect(() => {
+    if (!setSearchTrailing) return;
+
+    setSearchTrailing(() => function SearchActions() {
+      return <button aria-label="Settings">⚙</button>;
+    });
+
+    return () => setSearchTrailing(undefined);
+  }, [setSearchTrailing]);
+
+  return <Results query={query} />;
+}
+
+host.commands.add({
+  id: 'my-module.search',
+  title: 'Search External Service',
+  type: 'app',
+  commanderSearch: {
+    placeholder: 'Search external service...',
+    initialQuery: '',
+  },
+  component: SearchApp,
+});
+```
+
+`commanderSearch: true` uses the default app title as the placeholder. Passing an object lets you set `placeholder` and `initialQuery`. Prefix results can also set `commanderSearch`, which is useful when the prefix handler opens an app with the typed prefix query already filled.
 
 ### Prefix search
 
@@ -245,6 +285,7 @@ While a module prefix is active the filter tabs are hidden and results appear un
 | `badge` | `string` | | Override the badge label (defaults to prefix `title`) |
 | `run` | `() => void` | | Called on Enter — closes palette |
 | `component` | `React.ComponentType<CommanderAppProps>` | | Opens as an app screen inside the palette |
+| `commanderSearch` | `boolean \| CommanderSearchOptions` | | Shows the commander search input in the opened app screen |
 
 ### Built-in scope prefixes
 

--- a/docs/module-api-reference.md
+++ b/docs/module-api-reference.md
@@ -492,27 +492,37 @@ await host.fs.remove('temp/file.tmp');
 
 ---
 
-## `host.net` ✅
+## `host.net` 🚧
 
-Fetch wrapper with error handling. Throws on non-OK responses.
+Generic host-managed HTTP requests for modules. The intended public contract is `request()`, implemented by Lumen through Rust/Tauri. See [module-net-request-api.md](./architecture/module-net-request-api.md).
+
+This requires a matching `@lumen-media/module-sdk` update: `NetAPI` must be added to the SDK `LumenHost`, and `permissions.network` must be added to the SDK manifest schema before modules can depend on it.
 
 ```ts
-// GET — returns parsed JSON
-const data = await host.net.get<{ id: number; title: string }>(
-  'https://api.example.com/items/1'
-);
+const response = await host.net.request<{ items: unknown[] }>({
+  method: 'GET',
+  url: 'https://api.example.com/items',
+  query: { search: 'test', limit: 10 },
+  headers: { Authorization: `Bearer ${token}` },
+  responseType: 'json',
+  timeoutMs: 15_000,
+});
 
-// POST — body automatically serialized as JSON
-const result = await host.net.post<{ ok: boolean }>(
-  'https://api.example.com/items',
-  { title: 'New item', priority: 1 }
-);
+if (!response.ok) {
+  throw new Error(Request failed: );
+}
 
-// Extra fetch options (headers, etc.)
-const protected = await host.net.get('https://api.example.com/private', {
-  headers: { Authorization: 'Bearer token' },
+await host.net.request({
+  method: 'POST',
+  url: 'https://api.example.com/events',
+  body: { type: 'json', value: { kind: 'started' } },
+  responseType: 'none',
 });
 ```
+
+Supported request body modes are planned as `json`, `text`, `bytes`, `form`, and optionally `multipart`. Supported response modes are `json`, `text`, `bytes`, and `none`.
+
+Modules should only request hosts declared in their manifest network permissions once permission enforcement lands.
 
 ---
 
@@ -902,5 +912,4 @@ export default class ExamplePlugin extends LumenPlugin {
   }
 }
 ```
-
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2620,6 +2620,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2795,6 +2814,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -2804,6 +2824,37 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -2824,9 +2875,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.3",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -3489,6 +3542,7 @@ name = "lumen"
 version = "0.4.0"
 dependencies = [
  "axum",
+ "base64 0.22.1",
  "blake3",
  "font-loader",
  "futures-util",
@@ -3498,6 +3552,7 @@ dependencies = [
  "md5",
  "openh264",
  "rayon",
+ "reqwest 0.12.28",
  "rusqlite",
  "screenshots",
  "serde",
@@ -3522,6 +3577,7 @@ dependencies = [
  "tauri-plugin-window-state",
  "tokio",
  "tokio-tungstenite 0.23.1",
+ "url",
  "uuid",
  "webrtc",
  "windows 0.58.0",
@@ -3623,6 +3679,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3687,6 +3753,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "706bf8a5e8c8ddb99128c3291d31bd21f4bcde17f0f4c20ec678d85c74faa149"
 dependencies = [
  "log",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -4202,6 +4285,49 @@ dependencies = [
  "cc",
  "nasm-rs",
  "walkdir",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -5102,6 +5228,48 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "mime_guess",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
@@ -5419,6 +5587,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "schemars"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5530,6 +5707,29 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -6457,6 +6657,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6562,7 +6783,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "serde_repr",
@@ -7210,6 +7431,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7658,6 +7889,12 @@ checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
 dependencies = [
  "unic-common",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-bidi"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -40,6 +40,9 @@ tauri-plugin-sql = { version = "2", features = ["sqlite"] }
 tauri-plugin-store = "2"
 font-loader = "0.11"
 tauri-plugin-os = "2"
+reqwest = { version = "0.12", features = ["json", "multipart"] }
+base64 = "0.22"
+url = "2"
 sysinfo = "0.33"
 webrtc = "0.11"
 axum = { version = "0.7", features = ["ws"] }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -397,6 +397,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             module_runtime::module_fs_exists,
             module_runtime::module_fs_list,
             module_runtime::module_fs_remove,
+            module_runtime::net::module_net_request,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/module_runtime/manifest.rs
+++ b/src-tauri/src/module_runtime/manifest.rs
@@ -15,6 +15,13 @@ pub struct ModuleManifest {
     pub homepage: Option<String>,
     pub repository: Option<String>,
     pub license: Option<String>,
+    #[serde(default)]
+    pub permissions: Option<ModulePermissions>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModulePermissions {
+    pub network: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src-tauri/src/module_runtime/mod.rs
+++ b/src-tauri/src/module_runtime/mod.rs
@@ -1,12 +1,15 @@
 pub mod dev_server;
 pub mod install;
 pub mod manifest;
+pub mod net;
 pub mod protocol;
 pub mod registry;
 
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
+use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Manager};
 
@@ -18,6 +21,7 @@ use self::install::Installer;
 pub struct ModuleRuntime {
     pub modules_dir: PathBuf,
     pub registry: Arc<Mutex<Registry>>,
+    pub http_client: Client,
 }
 
 impl ModuleRuntime {
@@ -39,9 +43,17 @@ impl ModuleRuntime {
         let registry =
             Registry::open(&db_path).map_err(|e| format!("registry open failed: {e}"))?;
 
+        let http_client = Client::builder()
+            .timeout(Duration::from_secs(60))
+            .redirect(reqwest::redirect::Policy::limited(5))
+            .user_agent("Lumen/0.4.0")
+            .build()
+            .map_err(|e| format!("failed to create HTTP client: {e}"))?;
+
         Ok(Self {
             modules_dir: data_dir,
             registry: Arc::new(Mutex::new(registry)),
+            http_client,
         })
     }
 }

--- a/src-tauri/src/module_runtime/net.rs
+++ b/src-tauri/src/module_runtime/net.rs
@@ -1,0 +1,563 @@
+use std::collections::HashMap;
+use std::sync::PoisonError;
+use std::time::Duration;
+
+use base64::Engine as _;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Manager};
+use url::Url;
+
+use super::manifest::ModuleManifest;
+use super::ModuleRuntime;
+
+// ── Types ─────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum NetMethod {
+    Get,
+    Post,
+    Put,
+    Patch,
+    Delete,
+    Head,
+}
+
+impl NetMethod {
+    fn as_str(&self) -> &'static str {
+        match self {
+            NetMethod::Get => "GET",
+            NetMethod::Post => "POST",
+            NetMethod::Put => "PUT",
+            NetMethod::Patch => "PATCH",
+            NetMethod::Delete => "DELETE",
+            NetMethod::Head => "HEAD",
+        }
+    }
+
+    fn allows_body(&self) -> bool {
+        matches!(self, NetMethod::Post | NetMethod::Put | NetMethod::Patch)
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum NetResponseType {
+    Json,
+    Text,
+    Bytes,
+    None,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+pub enum ModuleNetRequestBody {
+    #[serde(rename = "json")]
+    Json { value: serde_json::Value },
+    #[serde(rename = "text")]
+    Text { value: String, #[serde(default)] content_type: Option<String> },
+    #[serde(rename = "bytes")]
+    Bytes { value_base64: String, #[serde(default)] content_type: Option<String> },
+    #[serde(rename = "form")]
+    Form { value: HashMap<String, String> },
+    #[serde(rename = "multipart")]
+    Multipart { parts: Vec<MultipartPart> },
+}
+
+#[derive(Debug, Deserialize)]
+pub struct MultipartPart {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub part_type: String,
+    pub value: Option<String>,
+    pub value_base64: Option<String>,
+    #[serde(default)]
+    pub filename: Option<String>,
+    #[serde(default)]
+    pub content_type: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ModuleNetRequest {
+    pub url: String,
+    #[serde(default)]
+    pub method: Option<NetMethod>,
+    #[serde(default)]
+    pub query: Option<HashMap<String, Vec<String>>>,
+    #[serde(default)]
+    pub headers: Option<HashMap<String, String>>,
+    #[serde(default)]
+    pub body: Option<ModuleNetRequestBody>,
+    #[serde(rename = "responseType", default)]
+    pub response_type: Option<NetResponseType>,
+    #[serde(rename = "timeoutMs", default)]
+    pub timeout_ms: Option<u64>,
+    #[serde(rename = "maxBytes", default)]
+    pub max_bytes: Option<u64>,
+    #[serde(rename = "followRedirects", default)]
+    pub follow_redirects: Option<bool>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct ModuleNetResponse {
+    pub ok: bool,
+    pub status: u16,
+    #[serde(rename = "statusText")]
+    pub status_text: String,
+    pub headers: HashMap<String, String>,
+    pub url: String,
+    pub redirected: bool,
+    pub data: serde_json::Value,
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct ModuleNetError {
+    pub code: String,
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<u16>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+}
+
+impl std::fmt::Display for ModuleNetError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[{}] {}", self.code, self.message)
+    }
+}
+
+// ── Permission matching ───────────────────────────────────────────
+
+fn is_private_host(host: &str) -> bool {
+    if host == "localhost" || host == "127.0.0.1" || host == "::1" {
+        return true;
+    }
+    if host.ends_with(".local") || host.ends_with(".localhost") {
+        return true;
+    }
+    if let Ok(ip) = host.parse::<std::net::IpAddr>() {
+        match ip {
+            std::net::IpAddr::V4(v4) => {
+                return v4.is_loopback()
+                    || v4.is_private()
+                    || v4.is_link_local()
+                    || v4.is_unspecified()
+                    || v4.is_multicast();
+            }
+            std::net::IpAddr::V6(v6) => {
+                return v6.is_loopback() || v6.is_unspecified() || v6.is_multicast();
+            }
+        }
+    }
+    false
+}
+
+fn match_url_pattern(url_str: &str, pattern: &str) -> bool {
+    fn inner(url_str: &str, pattern: &str) -> Option<bool> {
+        let url = Url::parse(url_str).ok()?;
+        let pattern_url = Url::parse(pattern).ok()?;
+
+        if url.scheme() != pattern_url.scheme() {
+            return Some(false);
+        }
+
+        let url_host = url.host_str().unwrap_or("");
+        let pattern_host = pattern_url.host_str().unwrap_or("");
+
+        if pattern_host.starts_with("*.") {
+            let suffix = &pattern_host[1..];
+            if !url_host.ends_with(suffix) {
+                return Some(false);
+            }
+            if url_host == &suffix[1..] {
+                return Some(false);
+            }
+        } else if url_host != pattern_host {
+            return Some(false);
+        }
+
+        let url_path = url.path();
+        let pattern_path = pattern_url.path();
+
+        if pattern_path.ends_with('*') {
+            let prefix = &pattern_path[..pattern_path.len() - 1];
+            if !url_path.starts_with(prefix) {
+                return Some(false);
+            }
+        } else if url_path != pattern_path {
+            return Some(false);
+        }
+
+        Some(true)
+    }
+    inner(url_str, pattern).unwrap_or(false)
+}
+
+fn check_url_allowed(
+    url_str: &str,
+    manifest: &ModuleManifest,
+) -> Result<(), ModuleNetError> {
+    let url = Url::parse(url_str).map_err(|_| ModuleNetError {
+        code: "invalid_url".into(),
+        message: format!("invalid URL: {url_str}"),
+        status: None,
+        url: Some(url_str.into()),
+    })?;
+
+    if url.scheme() != "https" {
+        return Err(ModuleNetError {
+            code: "blocked_url".into(),
+            message: "only https URLs are allowed".into(),
+            status: None,
+            url: Some(url_str.into()),
+        });
+    }
+
+    if let Some(host) = url.host_str() {
+        if is_private_host(host) {
+            return Err(ModuleNetError {
+                code: "blocked_url".into(),
+                message: format!("private network host blocked: {host}"),
+                status: None,
+                url: Some(url_str.into()),
+            });
+        }
+    }
+
+    if let Some(permissions) = &manifest.permissions {
+        if !permissions.network.is_empty() {
+            let allowed = permissions
+                .network
+                .iter()
+                .any(|p| match_url_pattern(url_str, p));
+            if !allowed {
+                return Err(ModuleNetError {
+                    code: "permission_denied".into(),
+                    message: format!("URL not allowed by module permissions: {url_str}"),
+                    status: None,
+                    url: Some(url_str.into()),
+                });
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// ── Request building ──────────────────────────────────────────────
+
+fn build_url(mut base_url: Url, query: Option<HashMap<String, Vec<String>>>) -> Url {
+    if let Some(query_params) = query {
+        {
+            let mut pairs = base_url.query_pairs_mut();
+            for (key, values) in query_params {
+                for value in values {
+                    pairs.append_pair(&key, &value);
+                }
+            }
+        }
+    }
+    base_url
+}
+
+fn build_request(
+    client: &Client,
+    input: &ModuleNetRequest,
+) -> Result<reqwest::RequestBuilder, ModuleNetError> {
+    let method_str = match &input.method {
+        Some(m) => m.as_str(),
+        None => {
+            if input.body.is_some() {
+                "POST"
+            } else {
+                "GET"
+            }
+        }
+    };
+
+    let method: reqwest::Method = method_str.parse().map_err(|_| ModuleNetError {
+        code: "network_error".into(),
+        message: format!("invalid HTTP method: {method_str}"),
+        status: None,
+        url: Some(input.url.clone()),
+    })?;
+
+    let allows_body = input
+        .method
+        .as_ref()
+        .map(|m| m.allows_body())
+        .unwrap_or(input.body.is_some());
+
+    let mut url = Url::parse(&input.url).map_err(|_| ModuleNetError {
+        code: "invalid_url".into(),
+        message: format!("invalid URL: {}", input.url),
+        status: None,
+        url: Some(input.url.clone()),
+    })?;
+
+    url = build_url(url, input.query.clone());
+
+    let mut req = client.request(method, url.clone());
+
+    if let Some(headers) = &input.headers {
+        let mut header_map = reqwest::header::HeaderMap::new();
+        for (key, value) in headers {
+            let lower = key.to_lowercase();
+            if matches!(
+                lower.as_str(),
+                "host" | "content-length" | "connection" | "transfer-encoding" | "upgrade"
+            ) || lower.starts_with("proxy-")
+                || lower.starts_with("sec-")
+            {
+                return Err(ModuleNetError {
+                    code: "permission_denied".into(),
+                    message: format!("header not allowed: {key}"),
+                    status: None,
+                    url: Some(url.to_string()),
+                });
+            }
+
+            let header_name = key.parse::<reqwest::header::HeaderName>().map_err(|_| {
+                ModuleNetError {
+                    code: "network_error".into(),
+                    message: format!("invalid header name: {key}"),
+                    status: None,
+                    url: Some(url.to_string()),
+                }
+            })?;
+
+            if let Ok(header_value) = value.parse::<reqwest::header::HeaderValue>() {
+                header_map.insert(header_name, header_value);
+            }
+        }
+        req = req.headers(header_map);
+    }
+
+    if let Some(body) = &input.body {
+        if !allows_body {
+            return Err(ModuleNetError {
+                code: "unsupported_body".into(),
+                message: format!("request body not allowed for {} requests", method_str),
+                status: None,
+                url: Some(url.to_string()),
+            });
+        }
+
+        match body {
+            ModuleNetRequestBody::Json { value } => {
+                req = req.json(value);
+            }
+            ModuleNetRequestBody::Text {
+                value,
+                content_type,
+            } => {
+                req = req.body(value.clone());
+                if let Some(ct) = content_type {
+                    req = req.header(reqwest::header::CONTENT_TYPE, ct.clone());
+                }
+            }
+            ModuleNetRequestBody::Bytes {
+                value_base64,
+                content_type,
+            } => {
+                let bytes = base64::engine::general_purpose::STANDARD
+                    .decode(value_base64)
+                    .map_err(|_| ModuleNetError {
+                        code: "unsupported_body".into(),
+                        message: "invalid base64 in request body".into(),
+                        status: None,
+                        url: Some(url.to_string()),
+                    })?;
+                req = req.body(bytes);
+                if let Some(ct) = content_type {
+                    req = req.header(reqwest::header::CONTENT_TYPE, ct.clone());
+                }
+            }
+            ModuleNetRequestBody::Form { value } => {
+                let pairs: Vec<(String, String)> = value.clone().into_iter().collect();
+                req = req.form(&pairs);
+            }
+            ModuleNetRequestBody::Multipart { parts: _ } => {
+                return Err(ModuleNetError {
+                    code: "unsupported_body".into(),
+                    message: "multipart body not yet supported".into(),
+                    status: None,
+                    url: Some(url.to_string()),
+                });
+            }
+        };
+    }
+
+    let timeout_ms = input.timeout_ms.unwrap_or(15_000).min(60_000);
+    req = req.timeout(Duration::from_millis(timeout_ms));
+
+    Ok(req)
+}
+
+// ── Tauri command ─────────────────────────────────────────────────
+
+#[tauri::command]
+pub async fn module_net_request(
+    app: AppHandle,
+    module_id: String,
+    input: ModuleNetRequest,
+) -> Result<ModuleNetResponse, ModuleNetError> {
+    let runtime = app.state::<ModuleRuntime>();
+
+    let entry = {
+        let reg = runtime.registry.lock().map_err(|e: PoisonError<_>| ModuleNetError {
+            code: "network_error".into(),
+            message: e.to_string(),
+            status: None,
+            url: Some(input.url.clone()),
+        })?;
+
+        reg.get(&module_id)
+            .map_err(|e: rusqlite::Error| ModuleNetError {
+                code: "network_error".into(),
+                message: e.to_string(),
+                status: None,
+                url: Some(input.url.clone()),
+            })?
+            .ok_or_else(|| ModuleNetError {
+                code: "permission_denied".into(),
+                message: format!("module not found: {module_id}"),
+                status: None,
+                url: Some(input.url.clone()),
+            })?
+    };
+
+    let manifest = super::manifest::load_manifest(&entry.path).map_err(|e| ModuleNetError {
+        code: "network_error".into(),
+        message: format!("failed to load module manifest: {e}"),
+        status: None,
+        url: Some(input.url.clone()),
+    })?;
+
+    check_url_allowed(&input.url, &manifest)?;
+
+    let client = &runtime.http_client;
+    let max_bytes = input.max_bytes.unwrap_or(10_000_000).min(50_000_000);
+    let response_type = input.response_type.clone().unwrap_or(NetResponseType::Json);
+
+    let request_builder = build_request(client, &input)?;
+    let response = request_builder.send().await.map_err(|e| {
+        if e.is_timeout() {
+            ModuleNetError {
+                code: "timeout".into(),
+                message: "request timed out".into(),
+                status: None,
+                url: None,
+            }
+        } else if e.is_connect() {
+            ModuleNetError {
+                code: "network_error".into(),
+                message: format!("connection failed: {e}"),
+                status: None,
+                url: None,
+            }
+        } else {
+            ModuleNetError {
+                code: "network_error".into(),
+                message: format!("request failed: {e}"),
+                status: None,
+                url: None,
+            }
+        }
+    })?;
+
+    let status = response.status();
+    let status_text = status.canonical_reason().unwrap_or("Unknown").to_string();
+    let response_url = response.url().to_string();
+    let redirected = response.url().as_str() != input.url;
+
+    let headers: HashMap<String, String> = response
+        .headers()
+        .iter()
+        .filter(|(k, _)| {
+            let lower = k.as_str().to_lowercase();
+            !matches!(
+                lower.as_str(),
+                "transfer-encoding"
+                    | "connection"
+                    | "keep-alive"
+                    | "proxy-authenticate"
+                    | "proxy-authorization"
+                    | "te"
+                    | "trailer"
+                    | "upgrade"
+            ) && !lower.starts_with("proxy-")
+        })
+        .map(|(k, v)| (k.as_str().to_string(), v.to_str().unwrap_or("").to_string()))
+        .collect();
+
+    let data = read_response_body(response, &response_type, max_bytes, &response_url).await?;
+
+    Ok(ModuleNetResponse {
+        ok: status.is_success(),
+        status: status.as_u16(),
+        status_text,
+        headers,
+        url: response_url,
+        redirected,
+        data,
+    })
+}
+
+async fn read_response_body(
+    response: reqwest::Response,
+    response_type: &NetResponseType,
+    max_bytes: u64,
+    response_url: &str,
+) -> Result<serde_json::Value, ModuleNetError> {
+    match response_type {
+        NetResponseType::Json | NetResponseType::Text => {
+            let text = response.text().await.map_err(|e| ModuleNetError {
+                code: "invalid_response".into(),
+                message: format!("failed to read response body: {e}"),
+                status: None,
+                url: Some(response_url.into()),
+            })?;
+
+            if text.len() > max_bytes as usize {
+                return Err(ModuleNetError {
+                    code: "response_too_large".into(),
+                    message: format!("response exceeds {} byte limit", max_bytes),
+                    status: None,
+                    url: Some(response_url.into()),
+                });
+            }
+
+            match response_type {
+                NetResponseType::Json => {
+                    Ok(serde_json::from_str(&text).unwrap_or(serde_json::Value::String(text)))
+                }
+                NetResponseType::Text => Ok(serde_json::Value::String(text)),
+                _ => unreachable!(),
+            }
+        }
+        NetResponseType::Bytes => {
+            let bytes = response.bytes().await.map_err(|e| ModuleNetError {
+                code: "invalid_response".into(),
+                message: format!("failed to read response body: {e}"),
+                status: None,
+                url: Some(response_url.into()),
+            })?;
+
+            if bytes.len() as u64 > max_bytes {
+                return Err(ModuleNetError {
+                    code: "response_too_large".into(),
+                    message: format!("response exceeds {} byte limit", max_bytes),
+                    status: None,
+                    url: Some(response_url.into()),
+                });
+            }
+
+            Ok(serde_json::Value::String(
+                base64::engine::general_purpose::STANDARD.encode(&bytes),
+            ))
+        }
+        NetResponseType::None => Ok(serde_json::Value::Null),
+    }
+}

--- a/src/components/miniplayer.tsx
+++ b/src/components/miniplayer.tsx
@@ -24,13 +24,16 @@ interface MiniPlayerProps {
 }
 
 function formatTime(seconds: number): string {
-  const m = Math.floor(seconds / 60)
+  if (!Number.isFinite(seconds) || seconds < 0) return '00:00';
+  const totalSeconds = Math.floor(seconds);
+  const h = Math.floor(totalSeconds / 3600);
+  const m = Math.floor((totalSeconds % 3600) / 60)
     .toString()
     .padStart(2, '0');
-  const s = Math.floor(seconds % 60)
+  const s = Math.floor(totalSeconds % 60)
     .toString()
     .padStart(2, '0');
-  return `${m}:${s}`;
+  return h > 0 ? `${h}:${m}:${s}` : `${m}:${s}`;
 }
 
 export function MiniPlayer({ className }: MiniPlayerProps) {
@@ -115,22 +118,33 @@ export function MiniPlayer({ className }: MiniPlayerProps) {
               )}
             </div>
           )}
-          <Slider
-            min={0}
-            max={player.localDuration}
-            value={[player.localTime]}
-            onValueChange={player.handleSliderChange}
-            onValueCommit={player.handleSliderCommit}
-            onPointerDown={() => player.setIsDragging(true)}
-            trackClassName="bg-muted"
-            rangeClassName="bg-primary"
-            thumbClassName="size-2.5 border-primary bg-primary shadow-none focus-visible:ring-0"
-          />
-          {(player.localTime > 0 || player.localDuration > 0) && (
-            <div className="flex justify-between text-xs text-muted-foreground">
-              <span>{formatTime(player.localTime)}</span>
-              <span>{formatTime(player.localDuration)}</span>
+          {player.isLiveStream ? (
+            <div className="flex h-5 items-center">
+              <span className="inline-flex h-5 items-center gap-1.5 rounded-full bg-red-500/10 px-2 text-[11px] font-semibold leading-none text-red-500">
+                <span className="size-1.5 rounded-full bg-red-500 shadow-[0_0_8px_rgba(239,68,68,0.75)]" />
+                AO VIVO
+              </span>
             </div>
+          ) : (
+            <>
+              <Slider
+                min={0}
+                max={Math.max(player.localDuration, 1)}
+                value={[Math.min(player.localTime, Math.max(player.localDuration, 1))]}
+                onValueChange={player.handleSliderChange}
+                onValueCommit={player.handleSliderCommit}
+                onPointerDown={() => player.setIsDragging(true)}
+                trackClassName="bg-muted"
+                rangeClassName="bg-primary"
+                thumbClassName="size-2.5 border-primary bg-primary shadow-none focus-visible:ring-0"
+              />
+              {(player.localTime > 0 || player.localDuration > 0) && (
+                <div className="flex justify-between text-xs text-muted-foreground">
+                  <span>{formatTime(player.localTime)}</span>
+                  <span>{formatTime(player.localDuration)}</span>
+                </div>
+              )}
+            </>
           )}
         </div>
       </div>

--- a/src/components/quick-shortcuts-modal.tsx
+++ b/src/components/quick-shortcuts-modal.tsx
@@ -175,7 +175,7 @@ function ResultRow({
 }) {
   const { t } = useTranslation();
   const theme = SOURCE_THEME[result.source];
-  const Icon = theme.icon;
+  const Icon = result.commandSpec?.icon ?? theme.icon;
 
   return (
     <button
@@ -763,3 +763,4 @@ export function QuickShortcutsModal() {
     </Dialog>
   );
 }
+

--- a/src/components/quick-shortcuts-modal.tsx
+++ b/src/components/quick-shortcuts-modal.tsx
@@ -693,7 +693,6 @@ function AppView({ app }: { app: ActiveApp }) {
 
   useEffect(() => {
     setValue(searchOptions?.initialQuery ?? '');
-    setSearchTrailing(undefined);
   }, [app.commandId, searchOptions?.initialQuery]);
 
   const searchTrailingProps = useMemo<CommanderSearchAccessoryProps>(

--- a/src/components/quick-shortcuts-modal.tsx
+++ b/src/components/quick-shortcuts-modal.tsx
@@ -35,6 +35,7 @@ import {
   type SearchScope,
   type SearchSource,
 } from '@/services/search-service';
+import type { CommanderSearchAccessoryProps, CommanderSearchTrailingComponent } from '@/modules/types';
 import { type ActiveApp, useCommandStore } from '@/stores/command-store';
 import { Button } from './ui/button';
 import { Dialog, DialogContent } from './ui/dialog';
@@ -280,6 +281,10 @@ function PaletteHeader({
   setInputValue,
   inputId,
   placeholder,
+  searchVisible = true,
+  searchPlaceholder,
+  SearchTrailing,
+  searchTrailingProps,
 }: {
   app?: ActiveApp;
   fullContent: boolean;
@@ -288,6 +293,10 @@ function PaletteHeader({
   setInputValue: (v: string) => void;
   inputId: string;
   placeholder?: string;
+  searchVisible?: boolean;
+  searchPlaceholder?: string;
+  SearchTrailing?: CommanderSearchTrailingComponent;
+  searchTrailingProps?: CommanderSearchAccessoryProps;
 }) {
   const { t } = useTranslation();
   const { popApp } = useCommandStore();
@@ -310,20 +319,24 @@ function PaletteHeader({
         </button>
       )}
 
-      <label
-        htmlFor={inputId}
-        className="flex h-10 flex-1 items-center gap-2 rounded-lg border border-border/60 bg-muted/30 px-3 focus-within:border-primary/40"
-      >
-        <Search className="size-4 shrink-0 text-muted-foreground" />
-        <input
-          ref={inputRef}
-          id={inputId}
-          value={inputValue}
-          onChange={(e) => setInputValue(e.target.value)}
-          placeholder={app ? app.title : (placeholder ?? t('Type a command or search...'))}
-          className="h-full w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
-        />
-      </label>
+      {searchVisible && (
+        <label
+          htmlFor={inputId}
+          className="flex h-10 flex-1 items-center gap-2 rounded-lg border border-border/60 bg-muted/30 px-3 focus-within:border-primary/40"
+        >
+          <Search className="size-4 shrink-0 text-muted-foreground" />
+          <input
+            ref={inputRef}
+            id={inputId}
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            placeholder={searchPlaceholder ?? (app ? app.title : (placeholder ?? t('Type a command or search...')))}
+            className="h-full w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+          />
+        </label>
+      )}
+
+      {SearchTrailing && searchTrailingProps && <SearchTrailing {...searchTrailingProps} />}
 
       {!app && (
         <Button
@@ -544,6 +557,7 @@ function RootView() {
         commandId: r.commandSpec.id,
         title: r.commandSpec.title,
         component: r.commandSpec.component,
+        search: r.commandSpec.commanderSearch,
       } satisfies ActiveApp);
       return;
     }
@@ -672,7 +686,20 @@ function AppView({ app }: { app: ActiveApp }) {
   const { close, popApp } = useCommandStore();
   const AppComponent = app.component;
   const inputId = useId();
-  const [value, setValue] = useState('');
+  const searchOptions = app.search && typeof app.search === 'object' ? app.search : undefined;
+  const searchVisible = app.search === true || !!searchOptions;
+  const [value, setValue] = useState(searchOptions?.initialQuery ?? '');
+  const [SearchTrailing, setSearchTrailing] = useState<CommanderSearchTrailingComponent>();
+
+  useEffect(() => {
+    setValue(searchOptions?.initialQuery ?? '');
+    setSearchTrailing(undefined);
+  }, [app.commandId, searchOptions?.initialQuery]);
+
+  const searchTrailingProps = useMemo<CommanderSearchAccessoryProps>(
+    () => ({ query: value, setQuery: setValue, close, back: popApp }),
+    [value, close, popApp]
+  );
 
   return (
     <div className="flex flex-col rounded-none bg-transparent">
@@ -683,15 +710,24 @@ function AppView({ app }: { app: ActiveApp }) {
         inputValue={value}
         setInputValue={setValue}
         inputId={inputId}
+        searchVisible={searchVisible}
+        searchPlaceholder={searchOptions?.placeholder}
+        SearchTrailing={SearchTrailing}
+        searchTrailingProps={searchTrailingProps}
       />
       <div className="min-h-[320px] flex-1 overflow-auto px-3 pb-3">
-        <AppComponent onClose={close} onBack={popApp} />
+        <AppComponent
+          onClose={close}
+          onBack={popApp}
+          query={value}
+          setQuery={setValue}
+          setSearchTrailing={setSearchTrailing}
+        />
       </div>
       <CommanderFooter showBack />
     </div>
   );
 }
-
 export function QuickShortcutsModal() {
   const { isOpen, toggle, close, activeApp, popApp } = useCommandStore();
 

--- a/src/components/quick-shortcuts-modal.tsx
+++ b/src/components/quick-shortcuts-modal.tsx
@@ -331,6 +331,12 @@ function PaletteHeader({
             value={inputValue}
             onChange={(e) => setInputValue(e.target.value)}
             placeholder={searchPlaceholder ?? (app ? app.title : (placeholder ?? t('Type a command or search...')))}
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="none"
+            spellCheck={false}
+            data-1p-ignore="true"
+            data-lpignore="true"
             className="h-full w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground"
           />
         </label>

--- a/src/components/quick-shortcuts-modal.tsx
+++ b/src/components/quick-shortcuts-modal.tsx
@@ -16,8 +16,11 @@ import {
 } from 'lucide-react';
 import {
   type ComponentType,
+  type Dispatch,
   Fragment,
   type KeyboardEvent,
+  type SetStateAction,
+  useCallback,
   useEffect,
   useId,
   useMemo,
@@ -27,6 +30,11 @@ import {
 import { useDebounceValue, useEventListener } from 'usehooks-ts';
 import { useTranslation } from '@/lib/i18n';
 import { cn } from '@/lib/utils';
+import type {
+  CommanderBackHandler,
+  CommanderSearchAccessoryProps,
+  CommanderSearchTrailingComponent,
+} from '@/modules/types';
 import {
   normalize,
   search as runSearch,
@@ -35,7 +43,6 @@ import {
   type SearchScope,
   type SearchSource,
 } from '@/services/search-service';
-import type { CommanderSearchAccessoryProps, CommanderSearchTrailingComponent } from '@/modules/types';
 import { type ActiveApp, useCommandStore } from '@/stores/command-store';
 import { Button } from './ui/button';
 import { Dialog, DialogContent } from './ui/dialog';
@@ -285,6 +292,7 @@ function PaletteHeader({
   searchPlaceholder,
   SearchTrailing,
   searchTrailingProps,
+  onBack,
 }: {
   app?: ActiveApp;
   fullContent: boolean;
@@ -297,9 +305,9 @@ function PaletteHeader({
   searchPlaceholder?: string;
   SearchTrailing?: CommanderSearchTrailingComponent;
   searchTrailingProps?: CommanderSearchAccessoryProps;
+  onBack?: () => void;
 }) {
   const { t } = useTranslation();
-  const { popApp } = useCommandStore();
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -311,7 +319,7 @@ function PaletteHeader({
       {app && (
         <button
           type="button"
-          onClick={popApp}
+          onClick={onBack}
           aria-label={t('Back')}
           className="flex size-10 shrink-0 items-center justify-center rounded-lg border border-border/60 bg-muted/30 text-muted-foreground transition-colors hover:bg-muted/60 hover:text-foreground"
         >
@@ -330,7 +338,10 @@ function PaletteHeader({
             id={inputId}
             value={inputValue}
             onChange={(e) => setInputValue(e.target.value)}
-            placeholder={searchPlaceholder ?? (app ? app.title : (placeholder ?? t('Type a command or search...')))}
+            placeholder={
+              searchPlaceholder ??
+              (app ? app.title : (placeholder ?? t('Type a command or search...')))
+            }
             autoComplete="off"
             autoCorrect="off"
             autoCapitalize="none"
@@ -688,7 +699,15 @@ function RootView() {
   );
 }
 
-function AppView({ app }: { app: ActiveApp }) {
+function AppView({
+  app,
+  onBackAction,
+  setBackHandler,
+}: {
+  app: ActiveApp;
+  onBackAction: () => Promise<void>;
+  setBackHandler: Dispatch<SetStateAction<CommanderBackHandler | undefined>>;
+}) {
   const { close, popApp } = useCommandStore();
   const AppComponent = app.component;
   const inputId = useId();
@@ -699,11 +718,18 @@ function AppView({ app }: { app: ActiveApp }) {
 
   useEffect(() => {
     setValue(searchOptions?.initialQuery ?? '');
-  }, [app.commandId, searchOptions?.initialQuery]);
+  }, [searchOptions?.initialQuery]);
+
+  useEffect(() => {
+    return () => {
+      setSearchTrailing(undefined);
+      setBackHandler(undefined);
+    };
+  }, [setBackHandler]);
 
   const searchTrailingProps = useMemo<CommanderSearchAccessoryProps>(
-    () => ({ query: value, setQuery: setValue, close, back: popApp }),
-    [value, close, popApp]
+    () => ({ query: value, setQuery: setValue, close, back: () => void onBackAction() }),
+    [value, close, onBackAction]
   );
 
   return (
@@ -719,22 +745,41 @@ function AppView({ app }: { app: ActiveApp }) {
         searchPlaceholder={searchOptions?.placeholder}
         SearchTrailing={SearchTrailing}
         searchTrailingProps={searchTrailingProps}
+        onBack={() => void onBackAction()}
       />
       <div className="min-h-[320px] flex-1 overflow-auto px-3 pb-3">
         <AppComponent
           onClose={close}
-          onBack={popApp}
+          onBack={() => void onBackAction()}
           query={value}
           setQuery={setValue}
           setSearchTrailing={setSearchTrailing}
+          setBackHandler={setBackHandler}
         />
       </div>
       <CommanderFooter showBack />
     </div>
   );
 }
+
 export function QuickShortcutsModal() {
   const { isOpen, toggle, close, activeApp, popApp } = useCommandStore();
+  const [appBackHandler, setAppBackHandler] = useState<CommanderBackHandler>();
+
+  const handleActiveAppBack = useCallback(async () => {
+    const handled = await appBackHandler?.();
+    if (handled) {
+      return;
+    }
+
+    popApp();
+  }, [appBackHandler, popApp]);
+
+  useEffect(() => {
+    if (!activeApp) {
+      setAppBackHandler(undefined);
+    }
+  }, [activeApp]);
 
   useEventListener('keydown', (event) => {
     if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'k') {
@@ -749,8 +794,8 @@ export function QuickShortcutsModal() {
       onOpenChange={(open, eventDetails) => {
         if (!open) {
           if (eventDetails?.reason === 'escape-key' && activeApp) {
-            popApp();
             eventDetails.cancel();
+            void handleActiveAppBack();
           } else {
             close();
           }
@@ -758,9 +803,18 @@ export function QuickShortcutsModal() {
       }}
     >
       <DialogContent showCloseButton={false} className="overflow-hidden p-0 sm:max-w-[760px]">
-        {activeApp ? <AppView app={activeApp} /> : <RootView />}
+        {activeApp ? (
+          <AppView
+            app={activeApp}
+            onBackAction={handleActiveAppBack}
+            setBackHandler={setAppBackHandler}
+          />
+        ) : (
+          <RootView />
+        )}
       </DialogContent>
     </Dialog>
   );
 }
+
 

--- a/src/modules/apis/domain.ts
+++ b/src/modules/apis/domain.ts
@@ -213,7 +213,9 @@ export function createPlayerHostAPI(): PlayerHostAPI {
       return 'idle';
     },
     play(track) {
-      globalBus.emit('player:play', { track });
+      if (!track) return;
+      const path = typeof track === 'string' ? track : track.path;
+      if (path) void usePlayerStore.getState().loadFile(path);
     },
     pause() {
       globalBus.emit('player:pause');

--- a/src/modules/apis/net.ts
+++ b/src/modules/apis/net.ts
@@ -1,5 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
-import type { NetAPI, NetRequest, NetResponse, NetError, NetQueryValue } from '../types';
+import type { NetAPI, NetRequest, NetRequestBody, NetResponse, NetError, NetQueryValue } from '../types';
 
 function normalizeQueryValue(v: NetQueryValue | NetQueryValue[]): string[] {
   if (Array.isArray(v)) return v.map(String);

--- a/src/modules/apis/net.ts
+++ b/src/modules/apis/net.ts
@@ -1,22 +1,75 @@
-import type { NetAPI } from '../types';
+import { invoke } from '@tauri-apps/api/core';
+import type { NetAPI, NetRequest, NetResponse, NetError, NetQueryValue } from '../types';
 
-export function createNetAPI(): NetAPI {
+function normalizeQueryValue(v: NetQueryValue | NetQueryValue[]): string[] {
+  if (Array.isArray(v)) return v.map(String);
+  if (v === null || v === undefined) return [''];
+  return [String(v)];
+}
+
+export function createNetAPI(moduleId: string): NetAPI {
   return {
-    async get<T = unknown>(url: string, opts?: RequestInit): Promise<T> {
-      const res = await fetch(url, { ...opts, method: 'GET' });
-      if (!res.ok) throw new Error(`[net] GET ${url} failed: ${res.status}`);
-      return res.json() as Promise<T>;
+    async request<T = unknown>(input: NetRequest): Promise<NetResponse<T>> {
+      const normalized: Record<string, unknown> = {};
+
+      normalized.url = input.url;
+      if (input.method) normalized.method = input.method;
+      if (input.query) {
+        normalized.query = Object.fromEntries(
+          Object.entries(input.query).map(([k, v]) => [k, normalizeQueryValue(v)]),
+        );
+      }
+      if (input.headers) normalized.headers = input.headers;
+      if (input.body) normalized.body = input.body;
+      if (input.responseType) normalized.responseType = input.responseType;
+      if (input.timeoutMs !== undefined) normalized.timeoutMs = input.timeoutMs;
+      if (input.maxBytes !== undefined) normalized.maxBytes = input.maxBytes;
+      if (input.followRedirects !== undefined) normalized.followRedirects = input.followRedirects;
+
+      return invoke<NetResponse<T>>('module_net_request', {
+        moduleId,
+        input: normalized,
+      });
     },
 
-    async post<T = unknown>(url: string, body: unknown, opts?: RequestInit): Promise<T> {
-      const res = await fetch(url, {
+    async get<T = unknown>(
+      url: string,
+      opts?: Omit<NetRequest, 'url' | 'method' | 'body'>,
+    ): Promise<T> {
+      const response = await this.request<T>({ ...opts, url, method: 'GET' });
+      if (!response.ok) {
+        const err = new Error(`GET ${url} failed: ${response.status}`) as NetError;
+        err.code = 'network_error';
+        err.status = response.status;
+        err.url = url;
+        throw err;
+      }
+      return response.data;
+    },
+
+    async post<T = unknown>(
+      url: string,
+      body?: NetRequestBody | unknown,
+      opts?: Omit<NetRequest, 'url' | 'method' | 'body'>,
+    ): Promise<T> {
+      let normalizedBody = body;
+      if (body !== undefined && !(typeof body === 'object' && body !== null && 'type' in body)) {
+        normalizedBody = { type: 'json' as const, value: body };
+      }
+      const response = await this.request<T>({
         ...opts,
+        url,
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', ...(opts?.headers ?? {}) },
-        body: JSON.stringify(body),
+        body: normalizedBody as never,
       });
-      if (!res.ok) throw new Error(`[net] POST ${url} failed: ${res.status}`);
-      return res.json() as Promise<T>;
+      if (!response.ok) {
+        const err = new Error(`POST ${url} failed: ${response.status}`) as NetError;
+        err.code = 'network_error';
+        err.status = response.status;
+        err.url = url;
+        throw err;
+      }
+      return response.data;
     },
   };
 }

--- a/src/modules/apis/ui.ts
+++ b/src/modules/apis/ui.ts
@@ -12,13 +12,15 @@ export function setBackgroundPickerOpener(fn: BgPickerOpener) {
 
 export function createUIAPI(openCommandPaletteFn: (prefilter?: string) => void): UIAPI {
   return {
-    notify({ title, message, level = 'info' }) {
-      if (level === 'error') {
-        toast.error(message, { description: title });
-      } else if (level === 'warn') {
-        toast.warning(message, { description: title });
-      } else {
-        toast.info(message, { description: title });
+    notify({ title, message, level = 'info', ...rest }) {
+      const opts = { description: title, ...rest };
+      switch (level) {
+        case 'error': toast.error(message, opts); break;
+        case 'warn': toast.warning(message, opts); break;
+        case 'success': toast.success(message, opts); break;
+        case 'loading': toast.loading(message, opts); break;
+        case 'custom': toast.custom(message, opts); break;
+        default: toast.info(message, opts);
       }
     },
 

--- a/src/modules/host.ts
+++ b/src/modules/host.ts
@@ -56,7 +56,7 @@ export async function createHost(
     fonts: createFontsAPI(),
 
     fs: createFsAPI(id),
-    net: createNetAPI(),
+    net: createNetAPI(id),
     i18n: createI18nAPI(),
     log: createLoggerAPI(id),
   };

--- a/src/modules/presenter-host.ts
+++ b/src/modules/presenter-host.ts
@@ -106,7 +106,7 @@ export async function createPresenterHost(manifest: ModuleManifest): Promise<Lum
     },
 
     fs: createFsAPI(id),
-    net: createNetAPI(),
+    net: createNetAPI(id),
     i18n: createI18nAPI(),
     log: createLoggerAPI(id),
   };

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -24,9 +24,26 @@ export interface PanelSpec {
   when?: () => boolean;
 }
 
+export interface CommanderSearchAccessoryProps {
+  query: string;
+  setQuery: (query: string) => void;
+  close: () => void;
+  back: () => void;
+}
+
+export type CommanderSearchTrailingComponent = React.ComponentType<CommanderSearchAccessoryProps>;
+
+export interface CommanderSearchOptions {
+  placeholder?: string;
+  initialQuery?: string;
+}
+
 export interface CommanderAppProps {
   onClose: () => void;
   onBack: () => void;
+  query?: string;
+  setQuery?: (query: string) => void;
+  setSearchTrailing?: React.Dispatch<React.SetStateAction<CommanderSearchTrailingComponent | undefined>>;
 }
 
 export interface CommandSpec {
@@ -39,6 +56,7 @@ export interface CommandSpec {
   type?: 'action' | 'app';
   run?: (args?: unknown) => unknown;
   component?: React.ComponentType<CommanderAppProps>;
+  commanderSearch?: boolean | CommanderSearchOptions;
 }
 
 export interface PanelsAPI {
@@ -52,6 +70,7 @@ export interface PrefixResult {
   badge?: string;
   run?: () => void;
   component?: React.ComponentType<CommanderAppProps>;
+  commanderSearch?: boolean | CommanderSearchOptions;
 }
 
 export interface PrefixSpec {

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -33,6 +33,8 @@ export interface CommanderSearchAccessoryProps {
 
 export type CommanderSearchTrailingComponent = React.ComponentType<CommanderSearchAccessoryProps>;
 
+export type CommanderBackHandler = () => boolean | undefined | Promise<boolean | undefined>;
+
 export interface CommanderSearchOptions {
   placeholder?: string;
   initialQuery?: string;
@@ -43,7 +45,10 @@ export interface CommanderAppProps {
   onBack: () => void;
   query?: string;
   setQuery?: (query: string) => void;
-  setSearchTrailing?: React.Dispatch<React.SetStateAction<CommanderSearchTrailingComponent | undefined>>;
+  setSearchTrailing?: React.Dispatch<
+    React.SetStateAction<CommanderSearchTrailingComponent | undefined>
+  >;
+  setBackHandler?: React.Dispatch<React.SetStateAction<CommanderBackHandler | undefined>>;
 }
 
 export interface CommandSpec {
@@ -423,14 +428,11 @@ export interface NetError extends Error {
 export interface NetAPI {
   request<T = unknown>(input: NetRequest): Promise<NetResponse<T>>;
 
-  get?<T = unknown>(
-    url: string,
-    opts?: Omit<NetRequest, 'url' | 'method' | 'body'>,
-  ): Promise<T>;
+  get?<T = unknown>(url: string, opts?: Omit<NetRequest, 'url' | 'method' | 'body'>): Promise<T>;
   post?<T = unknown>(
     url: string,
     body?: NetRequestBody | unknown,
-    opts?: Omit<NetRequest, 'url' | 'method' | 'body'>,
+    opts?: Omit<NetRequest, 'url' | 'method' | 'body'>
   ): Promise<T>;
 }
 

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -99,7 +99,7 @@ export interface SelectedBackground {
 }
 
 export interface UIAPI {
-  notify(opts: { title?: string; message: string; level?: 'info' | 'warn' | 'error' }): void;
+  notify(opts: { title?: string; message: string; level?: 'info' | 'warn' | 'error' | 'success' | 'loading' | 'custom'; [key: string]: unknown }): void;
   confirm(opts: { title: string; message: string; danger?: boolean }): Promise<boolean>;
   prompt(opts: { title: string; placeholder?: string; initial?: string }): Promise<string | null>;
   openCommandPalette(prefilter?: string): void;

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -336,9 +336,83 @@ export interface FsAPI {
   remove(path: string): Promise<void>;
 }
 
+// ── NetAPI ────────────────────────────────────────────────────────
+
+export type NetMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'HEAD';
+export type NetResponseType = 'json' | 'text' | 'bytes' | 'none';
+
+export type NetQueryValue = string | number | boolean | null | undefined;
+
+export type NetRequestBody =
+  | { type: 'json'; value: unknown }
+  | { type: 'text'; value: string; contentType?: string }
+  | { type: 'bytes'; valueBase64: string; contentType?: string }
+  | { type: 'form'; value: Record<string, NetQueryValue> }
+  | {
+      type: 'multipart';
+      parts: Array<
+        | { name: string; type: 'text'; value: string; contentType?: string }
+        | {
+            name: string;
+            type: 'bytes';
+            valueBase64: string;
+            filename?: string;
+            contentType?: string;
+          }
+      >;
+    };
+
+export interface NetRequest {
+  url: string;
+  method?: NetMethod;
+  query?: Record<string, NetQueryValue | NetQueryValue[]>;
+  headers?: Record<string, string>;
+  body?: NetRequestBody;
+  responseType?: NetResponseType;
+  timeoutMs?: number;
+  maxBytes?: number;
+  followRedirects?: boolean;
+}
+
+export interface NetResponse<T = unknown> {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  headers: Record<string, string>;
+  url: string;
+  redirected: boolean;
+  data: T;
+}
+
+export type NetErrorCode =
+  | 'permission_denied'
+  | 'invalid_url'
+  | 'blocked_url'
+  | 'timeout'
+  | 'network_error'
+  | 'response_too_large'
+  | 'invalid_response'
+  | 'unsupported_body'
+  | 'unsupported_response_type';
+
+export interface NetError extends Error {
+  code: NetErrorCode;
+  status?: number;
+  url?: string;
+}
+
 export interface NetAPI {
-  get<T = unknown>(url: string, opts?: RequestInit): Promise<T>;
-  post<T = unknown>(url: string, body: unknown, opts?: RequestInit): Promise<T>;
+  request<T = unknown>(input: NetRequest): Promise<NetResponse<T>>;
+
+  get?<T = unknown>(
+    url: string,
+    opts?: Omit<NetRequest, 'url' | 'method' | 'body'>,
+  ): Promise<T>;
+  post?<T = unknown>(
+    url: string,
+    body?: NetRequestBody | unknown,
+    opts?: Omit<NetRequest, 'url' | 'method' | 'body'>,
+  ): Promise<T>;
 }
 
 export interface I18nAPI {
@@ -405,6 +479,9 @@ export interface ModuleManifest {
   homepage?: string;
   repository?: string;
   license?: string;
+  permissions?: {
+    network: string[];
+  };
 }
 
 export type ModuleStatus = 'loading' | 'active' | 'faulted' | 'disabled';

--- a/src/services/search-service.ts
+++ b/src/services/search-service.ts
@@ -109,6 +109,7 @@ function prefixResultToSearchResult(r: import('@/modules/types').PrefixResult, s
       type: r.component ? 'app' : 'action',
       run: r.run,
       component: r.component,
+      commanderSearch: r.commanderSearch,
     },
   };
 }

--- a/src/stores/command-store.ts
+++ b/src/stores/command-store.ts
@@ -1,11 +1,12 @@
 import { create } from 'zustand';
-import type { CommanderAppProps, CommandSpec, PrefixSpec } from '@/modules/types';
+import type { CommanderAppProps, CommanderSearchOptions, CommandSpec, PrefixSpec } from '@/modules/types';
 import type React from 'react';
 
 export interface ActiveApp {
   commandId: string;
   title: string;
   component: React.ComponentType<CommanderAppProps>;
+  search?: boolean | CommanderSearchOptions;
 }
 
 interface CommandStore {

--- a/src/stores/player-store.ts
+++ b/src/stores/player-store.ts
@@ -15,6 +15,7 @@ interface PlayerStore {
   localArtist: string;
   localUrl: string | undefined;
   localMediaType: 'audio' | 'video' | 'stream' | undefined;
+  isLiveStream: boolean;
   isLoop: boolean;
   isScreenOpen: boolean;
   volume: number;
@@ -53,6 +54,7 @@ interface PlayerStore {
 let volumeCommitTimeout: ReturnType<typeof setTimeout> | null = null;
 let seekCommitTimeout: ReturnType<typeof setTimeout> | null = null;
 const SOCKET_COMMIT_DEBOUNCE_MS = 150;
+const LIVE_STREAM_MIN_DURATION_SECONDS = 24 * 60 * 60;
 
 async function getMediaWindow() {
   return WebviewWindow.getByLabel('media-window');
@@ -101,6 +103,16 @@ function getMediaTypeFromPath(filePath: string | null | undefined): PlayerStore[
   return 'audio';
 }
 
+function isLiveLikeYouTubeStream(
+  filePath: string | null | undefined,
+  seconds: number,
+  duration: number
+): boolean {
+  if (!filePath || !urlMediaService.parseYouTubeUrl(filePath)) return false;
+  if (!Number.isFinite(seconds) || !Number.isFinite(duration)) return false;
+  return duration >= LIVE_STREAM_MIN_DURATION_SECONDS;
+}
+
 export const usePlayerStore = create<PlayerStore>((set, get) => ({
   localTime: 0,
   localDuration: 0,
@@ -108,6 +120,7 @@ export const usePlayerStore = create<PlayerStore>((set, get) => ({
   localArtist: '',
   localUrl: undefined,
   localMediaType: undefined,
+  isLiveStream: false,
   isLoop: false,
   isScreenOpen: false,
   volume: 100,
@@ -142,24 +155,32 @@ export const usePlayerStore = create<PlayerStore>((set, get) => ({
       'video-progress',
       (event) => {
         if (get().isDragging) return;
-        set({ localTime: event.payload.seconds });
-        if (event.payload.duration > 0) {
-          set({ localDuration: event.payload.duration });
-          if (Math.abs(event.payload.duration - lastSavedDuration) > 1) {
-            lastSavedDuration = event.payload.duration;
-            saveSetting('last_duration', String(event.payload.duration)).catch(() => {});
+        const seconds = Number(event.payload.seconds) || 0;
+        const duration = Number(event.payload.duration) || 0;
+        const isLiveStream = isLiveLikeYouTubeStream(get().currentFilePath, seconds, duration);
 
-            const filePath = get().currentFilePath;
-            if (filePath) {
-              useQueueStore
-                .getState()
-                .updateMetadata(filePath, { duration: event.payload.duration })
-                .catch(() => {});
+        if (isLiveStream) {
+          set({ localTime: 0, localDuration: 0, isLiveStream: true });
+        } else {
+          set({ localTime: seconds, isLiveStream: false });
+          if (duration > 0) {
+            set({ localDuration: duration });
+            if (Math.abs(duration - lastSavedDuration) > 1) {
+              lastSavedDuration = duration;
+              saveSetting('last_duration', String(duration)).catch(() => {});
+
+              const filePath = get().currentFilePath;
+              if (filePath) {
+                useQueueStore
+                  .getState()
+                  .updateMetadata(filePath, { duration })
+                  .catch(() => {});
+              }
             }
           }
         }
 
-        const nextBucket = Math.floor(event.payload.seconds / 10);
+        const nextBucket = Math.floor(seconds / 10);
         if (get().isPlaying && nextBucket !== lastSyncBucket) {
           lastSyncBucket = nextBucket;
           void broadcastPlayerSync(get, 'interval');
@@ -235,6 +256,7 @@ export const usePlayerStore = create<PlayerStore>((set, get) => ({
         currentLyricSlideIndex: 0,
         currentLyricTotalSlides: 0,
         localMediaType: getMediaTypeFromPath(filePath),
+        isLiveStream: false,
         localTime: seekTime,
         localDuration: seekTime > 0 ? get().localDuration : 0,
       });
@@ -443,6 +465,7 @@ export const usePlayerStore = create<PlayerStore>((set, get) => ({
     set({
       isPlaying: true,
       localMediaType: isVideo ? 'video' : 'audio',
+      isLiveStream: false,
       restoredFilePath: null,
       currentFilePath: source,
       currentLyricPath: null,
@@ -536,6 +559,7 @@ export const usePlayerStore = create<PlayerStore>((set, get) => ({
       set({
         restoredFilePath: path,
         localMediaType: (type as 'audio' | 'video') ?? undefined,
+        isLiveStream: false,
         localTitle: title ?? '',
         localArtist: artist ?? '',
         localUrl: undefined,


### PR DESCRIPTION
## 📋 Description

Refactor the module SDK's networking layer to route through the Tauri backend, add Commander palette improvements for module apps, and fix YouTube livestream handling in the player.

### What was changed?

**Backend (Rust)**
- New `module_runtime::net` module with full HTTP client, permission checking, header filtering, timeout and size limits, and body type support (JSON, text, bytes, form)
- Module manifest extended with `permissions.network` for domain allowlisting
- Added reqwest 0.13, base64, url dependencies; aligned reqwest with Tauri's internal version

**Module SDK (TypeScript)**
- `NetAPI` refactored from raw `fetch` to `invoke('module_net_request')` with strongly typed request/response/error contracts
- `UIAPI.notify()` extended with `success` / `loading` levels and sonner option passthrough

**Commander Palette**
- Commander apps can now declare `commanderSearch` to show a search bar
- New `CommanderBackHandler` type for intercepting back navigation
- New `SearchTrailing` slot for custom accessories in the search bar
- Fixed: `popApp` unused variable in `AppView`
- Fixed: custom command icons now respected in result rows
- Fixed: search autofill disabled

**Player**
- Fixed: YouTube livestreams no longer show incorrect progress bar — replaced with live indicator
- Fixed: `player.play()` now correctly loads media via `playerStore.loadFile()` instead of a global bus event

### Why?

- Modules need a secure HTTP layer that enforces permissions and blocks private network access — raw `fetch` in the renderer cannot provide these guarantees
- Module apps needed search and back-navigation to build richer interfaces
- YouTube livestreams displayed a broken UI with an incrementing timer and non-functional slider

## 🔗 Related Issues

- Fixes #52
- Closes #53
- Relates to #31

## 🧪 How to Test

**Before:**
1. Modules using `host.net.get()` used `fetch` directly — no permission checks, no private network blocking
2. Commander apps had no search or back-navigation control
3. YouTube livestreams showed an incrementing timer and progress slider

**After:**
1. Modules using `host.net` route through the Tauri backend — permissions, timeouts, and URL validation are enforced
2. Commander apps with `commanderSearch: true` show a search bar; apps can provide a `setBackHandler` to intercept back navigation
3. YouTube livestreams show a live badge and hide the progress slider

## 📸 Screenshots / Recording

<!-- Logs, screenshots, or GIFs that demonstrate the fix. -->

## ✅ Checklist

- [x] Main flow tested manually
- [x] Checked for regressions in adjacent areas
- [ ] Behavior differences between dev and prod documented (if any)
- [ ] Tests added or updated
- [x] Self-reviewed

## 📝 Additional Notes

- Multipart request bodies are typed but return `"not yet supported"` — deferred implementation
- The YouTube search module (#53) is built on top of the NetAPI added here
- Docs updated: `docs/architecture/module-net-request-api.md`, `docs/module-api-reference.md`
