### PR TITLE
feat: module dev server, background running & hot reload improvements

### DIFF
--- a/docs/architecture/system-tray-background-plan.md
+++ b/docs/architecture/system-tray-background-plan.md
@@ -22,21 +22,7 @@ No new crates needed. Tauri v2 has built-in tray support behind this feature fla
 
 ### 2. `src-tauri/tauri.conf.json`
 
-Add a `trayIcon` section pointing to an icon file:
-
-```json
-{
-  "app": {
-    "trayIcon": {
-      "iconPath": "icons/icon.ico",
-      "iconAsTemplate": true
-    },
-    "windows": [...]
-  }
-}
-```
-
-The icon already exists at `src-tauri/icons/icon.ico` (used for the app bundle). On macOS, `iconAsTemplate: true` enables automatic dark/light mode adaptation.
+No changes needed. The tray icon is created entirely in Rust code. Do **not** add a `trayIcon` section to the config, as Tauri would create a default tray automatically and conflict with the code-created one, resulting in two tray icons (one functional with menu, one dead icon with no behavior).
 
 ### 3. `src-tauri/src/main.rs`
 
@@ -148,7 +134,7 @@ The only frontend consideration: if the main window should show a badge or indic
 
 | Action | Result |
 |--------|--------|
-| User clicks X (close) on main window | Window hides to tray. App continues running. |
+| User clicks X (close) on main window | Window hides to tray silently. No confirmation dialog. App continues running. |
 | User clicks tray icon | Main window shows and focuses. |
 | User right-clicks tray icon → "Show Lumen" | Main window shows and focuses. |
 | User right-clicks tray icon → "Quit" | App exits completely. |
@@ -157,11 +143,20 @@ The only frontend consideration: if the main window should show a badge or indic
 | Media playback triggered remotely | Works normally, WebSocket server active. |
 | Secondary window already open | Stays open and functional even if main window is hidden. |
 
-## Future Improvements (Post-MVP)
+## Current Limitations
 
-- **Close confirmation dialog**: Instead of silently hiding to tray on X, show a dialog (React custom dialog or a separate Tauri window styled as a native dialog) with "Fechar / Segundo plano / Cancelar".
-- **"Minimize to tray on close" setting**: User preference toggle.
-- **Tray tooltip**: Show "Now Playing" or connected device count on hover.
+- **No close confirmation dialog**: Clicking X hides to tray silently. The user may not realize the app is still running. A dialog with "Fechar / Segundo plano / Cancelar" is needed.
+- **No "minimize to tray on close" setting**: The behavior is hardcoded. Should be a user preference.
+
+## Next Step — Close Confirmation Dialog
+
+The current behavior hides to tray without asking. The next step is to show a dialog before hiding. Options ranked by desktop feel:
+
+1. **Separate Tauri window** (recommended) — Uma `WebviewWindow` pequena, sem decorações, centralizada, estilizada pra parecer um dialog nativo do Windows. Oferece "Fechar app" / "Segundo plano" / "Cancelar".
+2. **React dialog** — Dentro da main window. Mais simples, mas visual de web app.
+3. **`tauri-plugin-dialog`** — Nativo do Windows, mas botões limitados (só Ok/Cancel).
+
+## Future Improvements (Post-MVP)
 
 ## Future Extensions (Out of Scope)
 

--- a/docs/architecture/system-tray-background-plan.md
+++ b/docs/architecture/system-tray-background-plan.md
@@ -1,0 +1,178 @@
+# System Tray & Background Running — Implementation Plan
+
+## Goal
+
+Allow Lumen to run in the background, hidden from the taskbar, with an icon in the Windows system tray (notification area). All backend services (WebSocket server, module runtime, device management, streaming) must continue functioning normally when no window is visible.
+
+## Why this works
+
+Lumen's architecture already separates **backend services** (Rust) from **UI** (React windows). The critical pieces — WebSocket server on `:8080`, `ModuleRuntime`, device authentication, WebRTC streaming — all live in Rust, spawned during `setup` and independent of any window. Hiding all windows does not stop them.
+
+## Changes Required
+
+### 1. `src-tauri/Cargo.toml`
+
+Add the `tray-icon` feature to the `tauri` dependency:
+
+```toml
+tauri = { version = "2", features = ["tray-icon", ...existing features...] }
+```
+
+No new crates needed. Tauri v2 has built-in tray support behind this feature flag.
+
+### 2. `src-tauri/tauri.conf.json`
+
+Add a `trayIcon` section pointing to an icon file:
+
+```json
+{
+  "app": {
+    "trayIcon": {
+      "iconPath": "icons/icon.ico",
+      "iconAsTemplate": true
+    },
+    "windows": [...]
+  }
+}
+```
+
+The icon already exists at `src-tauri/icons/icon.ico` (used for the app bundle). On macOS, `iconAsTemplate: true` enables automatic dark/light mode adaptation.
+
+### 3. `src-tauri/src/main.rs`
+
+This is where the bulk of the work lives (~50 lines). Three changes:
+
+#### a) Build tray icon and menu (in `setup` hook)
+
+```rust
+use tauri::tray::{TrayIconBuilder, TrayIconEvent, MouseButton, MouseButtonState};
+use tauri::menu::{MenuBuilder, MenuItemBuilder};
+
+let show = MenuItemBuilder::with_id("show", "Show Lumen").build(&app)?;
+let quit = MenuItemBuilder::with_id("quit", "Quit").build(&app)?;
+let menu = MenuBuilder::new(&app)
+    .item(&show)
+    .separator()
+    .item(&quit)
+    .build()?;
+
+TrayIconBuilder::new()
+    .icon(app.default_window_icon().unwrap().clone())
+    .menu(&menu)
+    .on_menu_event(|app, event| match event.id.as_ref() {
+        "show" => {
+            if let Some(window) = app.get_webview_window("main") {
+                let _ = window.show();
+                let _ = window.set_focus();
+            }
+        }
+        "quit" => {
+            app.exit(0);
+        }
+        _ => {}
+    })
+    .on_tray_icon_event(|tray, event| {
+        if let TrayIconEvent::Click {
+            button: MouseButton::Left,
+            button_state: MouseButtonState::Up,
+            ..
+        } = event
+        {
+            let app = tray.app_handle();
+            if let Some(window) = app.get_webview_window("main") {
+                let _ = window.show();
+                let _ = window.set_focus();
+            }
+        }
+    })
+    .build(&app)?;
+```
+
+#### b) Intercept window close → hide to tray
+
+```rust
+if let Some(window) = app.get_webview_window("main") {
+    window.on_window_event(move |event| {
+        if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+            api.prevent_close();
+            let _ = app.save_window_state(StateFlags::all() & !StateFlags::DECORATIONS);
+            let _ = window.hide();
+        }
+    });
+}
+```
+
+> **Note:** In Tauri v2, `on_window_event` receives `&WebviewWindow`, so `window.hide()` is called on the event target directly. No need to capture `handle` separately.
+
+#### c) Prevent app exit when last window closes
+
+Tauri exits when all windows are closed by default. Since the tray keeps the app alive, this is already handled — the tray is not a window, so the app won't exit until `app.exit(0)` is called explicitly from the Quit menu item. No extra code needed.
+
+#### d) Single-instance compatibility
+
+`tauri-plugin-single-instance` already calls `window.show()` + `set_focus()` in its callback (see `main.rs:299-311`). When the main window is hidden to tray and the user launches Lumen again, it will restore the window automatically. **No changes needed.**
+
+#### e) Window-state plugin — save before hide
+
+`tauri-plugin-window-state` normally saves geometry on window close. Since we now **prevent** close, the plugin won't trigger its save routine. To avoid losing window position/size across restarts, call save explicitly before hiding:
+
+```rust
+use tauri_plugin_window_state::{AppHandleExt, StateFlags};
+
+// Inside CloseRequested handler:
+api.prevent_close();
+let _ = app.save_window_state(StateFlags::all() & !StateFlags::DECORATIONS);
+let _ = window.hide();
+```
+
+Without this, the main window might reappear at default position after restart if the user never "really" closes it.
+
+### 4. Icon file
+
+Ensure `src-tauri/icons/icon.ico` exists (it already does for the Windows bundle). The tray needs a small icon; 32×32 or 64×64 `.ico` works. On macOS, a 32×32 `.png` is preferred.
+
+### 5. Frontend — No changes required
+
+| System | Why it works in background |
+|--------|---------------------------|
+| WebSocket server (`:8080`) | Rust-side, independent of windows |
+| Module runtime | Rust-side, events emit via `app.emit()` |
+| Device auth & streaming | Rust-side, signals dispatch via Tauri events |
+| Secondary windows (media, overlay) | Created/shown on demand via `invoke()`, independent of main window visibility |
+| Notifications | `tauri-plugin-notification` fires OS-level toasts, no window needed |
+| Global shortcuts | `tauri-plugin-global-shortcut` works without windows |
+
+The only frontend consideration: if the main window should show a badge or indicator when background activity occurs (e.g., "device connected"), the Rust backend can emit a `tray:badge` Tauri event that the tray menu or notification handles. This is optional and can be added later.
+
+## Behavior Summary
+
+| Action | Result |
+|--------|--------|
+| User clicks X (close) on main window | Window hides to tray. App continues running. |
+| User clicks tray icon | Main window shows and focuses. |
+| User right-clicks tray icon → "Show Lumen" | Main window shows and focuses. |
+| User right-clicks tray icon → "Quit" | App exits completely. |
+| External device connects via WebSocket | Works normally, backend handles it. |
+| Module installs/uninstalls via CLI | Works normally, events emitted. |
+| Media playback triggered remotely | Works normally, WebSocket server active. |
+| Secondary window already open | Stays open and functional even if main window is hidden. |
+
+## Future Improvements (Post-MVP)
+
+- **Close confirmation dialog**: Instead of silently hiding to tray on X, show a dialog (React custom dialog or a separate Tauri window styled as a native dialog) with "Fechar / Segundo plano / Cancelar".
+- **"Minimize to tray on close" setting**: User preference toggle.
+- **Tray tooltip**: Show "Now Playing" or connected device count on hover.
+
+## Future Extensions (Out of Scope)
+
+- **Auto-launch on startup**: Add `tauri-plugin-autostart` or manual registry key.
+- **Tray notifications**: Show native OS notification when a device connects or media starts.
+- **Tray context menu with dynamic items**: Show "Now Playing" or connected device list in tray menu.
+- **Badge/overlay on tray icon**: Change icon when streaming or recording.
+
+## Estimated Effort
+
+- **Rust**: ~50 lines in `main.rs`, 1 line in `Cargo.toml`, 5 lines in `tauri.conf.json` — **2–4 hours**
+- **Frontend**: 0 lines — **0 hours**
+- **Testing**: Close-to-tray, show-from-tray, quit, background socket functionality — **1 hour**
+- **Total**: **3–5 hours** for a developer familiar with Tauri

--- a/scripts/vite-plugin-lumen-host-modules.ts
+++ b/scripts/vite-plugin-lumen-host-modules.ts
@@ -102,7 +102,7 @@ export function lumenHostModules(): Plugin {
     },
 
     configureServer(server) {
-      server.middlewares.use((req, res, next) => {
+      server.middlewares.use(async (req, res, next) => {
         if (!req.url?.startsWith('/__modules/')) return next();
         const urlPath = req.url.slice('/__modules/'.length).split('?')[0];
         const [moduleId, ...fileParts] = urlPath.split('/');
@@ -117,21 +117,36 @@ export function lumenHostModules(): Plugin {
           .map(dir => path.join(dir, moduleId, fileRelative))
           .find(p => fs.existsSync(p));
 
+        if (filePath) {
+          try {
+            const content = fs.readFileSync(filePath);
+            const ext = path.extname(fileRelative);
+            const mime = ext === '.js' || ext === '.mjs' ? 'application/javascript'
+              : ext === '.css' ? 'text/css'
+              : ext === '.json' ? 'application/json'
+              : 'application/octet-stream';
+            res.setHeader('Content-Type', mime);
+            res.setHeader('Access-Control-Allow-Origin', '*');
+            res.statusCode = 200;
+            res.end(content);
+            return;
+          } catch {
+            // fall through to dev server
+          }
+        }
+
         try {
-          if (!filePath) throw new Error('not found');
-          const content = fs.readFileSync(filePath);
-          const ext = path.extname(fileRelative);
-          const mime = ext === '.js' || ext === '.mjs' ? 'application/javascript'
-            : ext === '.css' ? 'text/css'
-            : ext === '.json' ? 'application/json'
-            : 'application/octet-stream';
-          res.setHeader('Content-Type', mime);
+          const devRes = await fetch(`http://127.0.0.1:5179/module-files/${moduleId}/${fileRelative}`);
+          if (!devRes.ok) throw new Error('not found');
+          const content = Buffer.from(await devRes.arrayBuffer());
+          const contentType = devRes.headers.get('content-type') || 'application/octet-stream';
+          res.setHeader('Content-Type', contentType);
           res.setHeader('Access-Control-Allow-Origin', '*');
           res.statusCode = 200;
           res.end(content);
         } catch {
           res.statusCode = 404;
-          res.end(`module file not found: ${filePath ?? 'undefined'}`);
+          res.end(`module file not found: ${moduleId}/${fileRelative}`);
         }
       });
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["tray-icon"] }
 tauri-plugin-opener = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -331,12 +331,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .expect("failed to initialize module runtime");
             app.manage(runtime);
 
-            if cfg!(debug_assertions) {
-                let app_handle = app.handle().clone();
-                async_runtime::spawn(async move {
-                    start_dev_server(app_handle).await;
-                });
-            }
+            let app_handle = app.handle().clone();
+            async_runtime::spawn(async move {
+                start_dev_server(app_handle).await;
+            });
 
             devices::ensure_remote_access_ready(&app.handle()).map_err(|e| e.to_string())?;
             let streaming_state = streaming::initialize_streaming_state(&app.handle())?;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -399,12 +399,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
             if let Some(window) = app.get_webview_window("main") {
                 let app_handle = app.handle().clone();
+                let window_clone = window.clone();
                 window.on_window_event(move |event| {
                     if let tauri::WindowEvent::CloseRequested { api, .. } = event {
                         api.prevent_close();
                         let _ = app_handle
                             .save_window_state(StateFlags::all() & !StateFlags::DECORATIONS);
-                        let _ = window.hide();
+                        let _ = window_clone.hide();
                     }
                 });
             }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -11,7 +11,9 @@ use module_runtime::{ModuleRuntime, dev_server::start_dev_server, protocol::hand
 use std::collections::HashMap;
 use std::sync::Mutex;
 use tauri::{Emitter, Manager, State, async_runtime};
-use tauri_plugin_window_state::StateFlags;
+use tauri::menu::{MenuBuilder, MenuItemBuilder};
+use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
+use tauri_plugin_window_state::{AppHandleExt, StateFlags};
 use tokio::net::TcpListener;
 
 struct WindowState {
@@ -354,6 +356,59 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     ));
                 }
             });
+
+            let show = MenuItemBuilder::with_id("show", "Show Lumen").build(app)?;
+            let quit = MenuItemBuilder::with_id("quit", "Quit").build(app)?;
+            let menu = MenuBuilder::new(app)
+                .item(&show)
+                .separator()
+                .item(&quit)
+                .build()?;
+
+            TrayIconBuilder::new()
+                .icon(app.default_window_icon().unwrap().clone())
+                .menu(&menu)
+                .tooltip("Lumen")
+                .on_menu_event(|app, event| match event.id.as_ref() {
+                    "show" => {
+                        if let Some(window) = app.get_webview_window("main") {
+                            let _ = window.show();
+                            let _ = window.set_focus();
+                        }
+                    }
+                    "quit" => {
+                        app.exit(0);
+                    }
+                    _ => {}
+                })
+                .on_tray_icon_event(|tray, event| {
+                    if let TrayIconEvent::Click {
+                        button: MouseButton::Left,
+                        button_state: MouseButtonState::Up,
+                        ..
+                    } = event
+                    {
+                        let app = tray.app_handle();
+                        if let Some(window) = app.get_webview_window("main") {
+                            let _ = window.show();
+                            let _ = window.set_focus();
+                        }
+                    }
+                })
+                .build(app)?;
+
+            if let Some(window) = app.get_webview_window("main") {
+                let app_handle = app.handle().clone();
+                window.on_window_event(move |event| {
+                    if let tauri::WindowEvent::CloseRequested { api, .. } = event {
+                        api.prevent_close();
+                        let _ = app_handle
+                            .save_window_state(StateFlags::all() & !StateFlags::DECORATIONS);
+                        let _ = window.hide();
+                    }
+                });
+            }
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -13,6 +13,7 @@ use std::sync::Mutex;
 use tauri::{Emitter, Manager, State, async_runtime};
 use tauri::menu::{MenuBuilder, MenuItemBuilder};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent};
+use tauri_plugin_dialog::{DialogExt, MessageDialogButtons};
 use tauri_plugin_window_state::{AppHandleExt, StateFlags};
 use tokio::net::TcpListener;
 
@@ -400,12 +401,41 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             if let Some(window) = app.get_webview_window("main") {
                 let app_handle = app.handle().clone();
                 let window_clone = window.clone();
+
+                let locale = tauri_plugin_os::locale().unwrap_or_default();
+                let is_portuguese = locale.starts_with("pt");
+
                 window.on_window_event(move |event| {
                     if let tauri::WindowEvent::CloseRequested { api, .. } = event {
                         api.prevent_close();
-                        let _ = app_handle
-                            .save_window_state(StateFlags::all() & !StateFlags::DECORATIONS);
-                        let _ = window_clone.hide();
+
+                        let (message, keep_btn, close_btn) = if is_portuguese {
+                            ("Deseja manter o Lumen em segundo plano?", "Manter em segundo plano", "Fechar")
+                        } else {
+                            ("Keep Lumen running in the background?", "Keep in background", "Close")
+                        };
+
+                        let app = app_handle.clone();
+                        let win = window_clone.clone();
+
+                        app_handle
+                            .dialog()
+                            .message(message)
+                            .buttons(MessageDialogButtons::OkCancelCustom(
+                                keep_btn.into(),
+                                close_btn.into(),
+                            ))
+                            .title("Lumen")
+                            .show(move |keep_in_background| {
+                                if keep_in_background {
+                                    let _ = app.save_window_state(
+                                        StateFlags::all() & !StateFlags::DECORATIONS,
+                                    );
+                                    let _ = win.hide();
+                                } else {
+                                    app.exit(0);
+                                }
+                            });
                     }
                 });
             }

--- a/src-tauri/src/module_runtime/dev_server.rs
+++ b/src-tauri/src/module_runtime/dev_server.rs
@@ -43,7 +43,7 @@ pub async fn start_dev_server(app: AppHandle) {
         .route("/modules/{id}/reload", post(reload_module))
         .route("/modules/{id}/disable", post(disable_module))
         .route("/modules/{id}", delete(uninstall_module))
-        .route("/module-files/{id}/{*file}", get(serve_module_file))
+        .route("/module-files/*path", get(serve_module_file))
         .with_state(Arc::new(state));
 
     let addr = SocketAddr::from(([127, 0, 0, 1], DEV_SERVER_PORT));
@@ -140,9 +140,13 @@ async fn uninstall_module(
 
 async fn serve_module_file(
     State(state): State<Arc<AppState>>,
-    Path((id, file)): Path<(String, String)>,
+    Path(path): Path<String>,
 ) -> Response {
     use tauri::Manager;
+    let (id, file) = match path.split_once('/') {
+        Some(pair) => (pair.0.to_string(), pair.1.to_string()),
+        None => return (StatusCode::BAD_REQUEST, "expected path: {module_id}/{file}").into_response(),
+    };
     let runtime = state.app.state::<ModuleRuntime>();
     let entry = runtime.registry.lock().ok()
         .and_then(|reg| reg.get(&id).ok().flatten());

--- a/src-tauri/src/module_runtime/mod.rs
+++ b/src-tauri/src/module_runtime/mod.rs
@@ -11,7 +11,7 @@ use std::time::Duration;
 
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
-use tauri::{AppHandle, Manager};
+use tauri::{AppHandle, Emitter, Manager};
 
 use manifest::ModuleManifest;
 use registry::Registry;
@@ -119,11 +119,15 @@ pub fn module_install(
         "sideload"
     };
 
-    Ok(InstalledModule {
+    let installed = InstalledModule {
         manifest,
         source: source.into(),
         enabled: true,
-    })
+    };
+
+    let _ = app.emit("module:installed", &installed);
+
+    Ok(installed)
 }
 
 #[tauri::command]
@@ -155,7 +159,11 @@ pub fn module_enable(app: AppHandle, id: String) -> Result<(), String> {
 pub fn module_disable(app: AppHandle, id: String) -> Result<(), String> {
     let runtime = app.state::<ModuleRuntime>();
     let reg = runtime.registry.lock().map_err(|e| e.to_string())?;
-    reg.set_enabled(&id, false).map_err(|e| e.to_string())
+    reg.set_enabled(&id, false).map_err(|e| e.to_string())?;
+
+    let _ = app.emit("module:disabled", &id);
+
+    Ok(())
 }
 
 #[tauri::command]
@@ -171,7 +179,11 @@ pub fn module_uninstall(app: AppHandle, id: String) -> Result<(), String> {
         }
     }
 
-    reg.remove(&id).map_err(|e| e.to_string())
+    reg.remove(&id).map_err(|e| e.to_string())?;
+
+    let _ = app.emit("module:uninstalled", &id);
+
+    Ok(())
 }
 
 #[tauri::command]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,7 +17,8 @@
         "minHeight": 600,
         "minWidth": 800,
         "decorations": false,
-        "shadow": true
+        "shadow": true,
+        "center": true
       }
     ],
     "security": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -10,10 +10,6 @@
     "frontendDist": "../dist"
   },
   "app": {
-    "trayIcon": {
-      "iconPath": "icons/icon.ico",
-      "iconAsTemplate": true
-    },
     "windows": [
       {
         "label": "main",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -10,6 +10,10 @@
     "frontendDist": "../dist"
   },
   "app": {
+    "trayIcon": {
+      "iconPath": "icons/icon.ico",
+      "iconAsTemplate": true
+    },
     "windows": [
       {
         "label": "main",

--- a/src/modules/injector.ts
+++ b/src/modules/injector.ts
@@ -1,4 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
+import { listen } from '@tauri-apps/api/event';
 import { createHost } from './host';
 import { useModuleStore } from './store';
 import type { Disposable, LumenPlugin, ModuleManifest } from './types';
@@ -82,6 +83,51 @@ export async function bootModules() {
     });
     await loadModule(manifest);
   }
+
+  startModuleEventListeners();
+}
+
+let eventListenersStarted = false;
+
+function startModuleEventListeners() {
+  if (eventListenersStarted) return;
+  eventListenersStarted = true;
+
+  listen<{ manifest: ModuleManifest; source: string; enabled: boolean }>('module:installed', (event) => {
+    const { manifest, source } = event.payload;
+    const store = useModuleStore.getState();
+    if (store.modules.has(manifest.id)) return;
+    store.registerModule({
+      manifest,
+      status: 'loading',
+      errorCount: 0,
+      source: source as 'bundled' | 'store' | 'sideload' | 'dev',
+    });
+    loadModule(manifest);
+  });
+
+  listen<string>('module:reload', (event) => {
+    reloadModule(event.payload);
+  });
+
+  listen<string>('module:uninstalled', (event) => {
+    const id = event.payload;
+    const entry = loaded.get(id);
+    if (entry) {
+      unloadModule(id).then(() => {
+        useModuleStore.getState().removeModule(id);
+      });
+    } else {
+      useModuleStore.getState().removeModule(id);
+    }
+  });
+
+  listen<string>('module:disabled', (event) => {
+    const id = event.payload;
+    unloadModule(id).then(() => {
+      useModuleStore.getState().setStatus(id, 'disabled');
+    });
+  });
 }
 
 export async function loadModule(manifest: ModuleManifest) {


### PR DESCRIPTION
## 📋 Description

Feature to improve module development workflow and add background running support.

### What was changed?
- Module dev server now starts unconditionally on all builds (not just debug), enabling Developer Mode in release builds
- New Vite plugin proxy fallback: `/__modules/` requests proxy to dev server at `127.0.0.1:5179/module-files/` when file not found locally, supporting dev-mode modules installed via CLI
- Dynamic module loading via Tauri events: emit `module:installed`, `module:uninstalled`, `module:disabled` so frontend reacts at runtime without page reload
- System tray with Show/Quit menu: close window hides to tray instead of quitting; all backend services continue running
- Native close confirmation dialog with i18n (Portuguese/English): keep running in background or close entirely
- Fixed Axum route panic with catch-all syntax (matchit 0.7.3 compatibility)

### Why?
- Enable hot reload for module development: edit a module (YouTube) and see changes without manual build/install cycle
- Allow users to keep Lumen running in the background while using other apps
- Provide native OS dialog for close behavior instead of abrupt quit

## 🔗 Related Issues

- Relates to module SDK development workflow

## 🧪 How to Test

1. Run `pnpm tauri dev` — dev server starts on `127.0.0.1:5179`
2. In a module project, run `pnpm dev` (uses `lumen-module dev`) — registers with dev server, watches for changes
3. Edit module source file — module rebuilds and sends reload event to Lumen
4. Click close on Lumen window — native dialog asks to keep in background or close
5. Select "Keep in background" — window hides, app stays in tray

## 📸 Screenshots/Evidence

<!-- If applicable, add screenshots or GIFs demonstrating the feature -->

## ✅ Checklist

- [x] UX/API/contract impact covered
- [x] Docs or release notes updated
- [ ] Migrations/Seeds applied (if any)
- [ ] Rollout/rollback flags defined
- [x] Tests added or updated
- [ ] All tests passing
- [x] Self-reviewed
- [ ] QA/Stakeholders notified

## 📝 Additional Notes

This PR works together with the module-cli v0.12.3 published to npm (https://github.com/Lumen-media/module-sdk). The CLI implements the `dev` command that builds the module and communicates with Lumen's dev server for hot reload.