### PR TITLE
fix: notes editor, themes tab, avatar switcher, image viewer & fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@tiptap/react": "^3.27.2",
     "@tiptap/starter-kit": "^3.27.2",
     "@vitejs/plugin-react-swc": "^4.3.1",
+    "animejs": "^4.5.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,9 @@ importers:
       '@vitejs/plugin-react-swc':
         specifier: ^4.3.1
         version: 4.3.1(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0))
+      animejs:
+        specifier: ^4.5.0
+        version: 4.5.0
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1832,6 +1835,17 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       vite: ^4 || ^5 || ^6 || ^7 || ^8
+
+  animejs@4.5.0:
+    resolution: {integrity: sha512-NQimYX+lz8WaXonGS9zVVoviCIAjONeJayxacUditaivYLqyXgGjFKjuyl0aUUhFKm5MriX9ty1TGovNzoJQWA==}
+    peerDependencies:
+      '@types/three': '>=0.150.0'
+      three: '>=0.150.0'
+    peerDependenciesMeta:
+      '@types/three':
+        optional: true
+      three:
+        optional: true
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -4113,6 +4127,8 @@ snapshots:
       vite: 8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)
     transitivePeerDependencies:
       - '@swc/helpers'
+
+  animejs@4.5.0: {}
 
   ansi-regex@5.0.1: {}
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -21,6 +21,12 @@ struct WindowState {
     positions: Mutex<HashMap<String, (i32, i32)>>,
 }
 
+const MEDIA_WINDOW_LABEL: &str = "media-window";
+const MEDIA_WINDOW_MIN_WIDTH: f64 = 1050.0;
+const MEDIA_WINDOW_MIN_HEIGHT: f64 = 650.0;
+const MEDIA_WINDOW_INITIAL_WIDTH: f64 = 1280.0;
+const MEDIA_WINDOW_INITIAL_HEIGHT: f64 = 720.0;
+
 #[tauri::command]
 fn get_exe_dir() -> Result<String, String> {
     std::env::current_exe()
@@ -111,17 +117,24 @@ async fn create_window(
         }
     };
 
-    let window = tauri::WebviewWindowBuilder::new(
+    let mut builder = tauri::WebviewWindowBuilder::new(
         &app_handle,
         &label,
         tauri::WebviewUrl::App(route.unwrap_or_else(|| "/media-window".to_string()).into()),
     )
     .title(&title)
     .decorations(false)
-    .fullscreen(true)
-    .visible(false)
-    .build()
-    .map_err(|e| format!("Failed to create window: {}", e))?;
+    .visible(false);
+
+    if label == MEDIA_WINDOW_LABEL {
+        builder = builder
+            .inner_size(MEDIA_WINDOW_INITIAL_WIDTH, MEDIA_WINDOW_INITIAL_HEIGHT)
+            .min_inner_size(MEDIA_WINDOW_MIN_WIDTH, MEDIA_WINDOW_MIN_HEIGHT);
+    }
+
+    let window = builder
+        .build()
+        .map_err(|e| format!("Failed to create window: {}", e))?;
 
     window
         .set_position(tauri::Position::Physical(target_position))

--- a/src/app/media-window.tsx
+++ b/src/app/media-window.tsx
@@ -118,6 +118,10 @@ function StreamOverlay() {
   );
 }
 
+const FULLSCREEN_SIZE_TOLERANCE = 2;
+
+const delay = (ms: number) => new Promise((resolve) => window.setTimeout(resolve, ms));
+
 export const Route = createFileRoute('/media-window')({
   component: MediaWindowComponent,
 });
@@ -185,19 +189,22 @@ function MediaWindowComponent() {
   const toggleFullscreen = useCallback(async () => {
     try {
       const { getCurrentWebviewWindow } = await import('@tauri-apps/api/webviewWindow');
-      const window = getCurrentWebviewWindow();
+      const appWindow = getCurrentWebviewWindow();
 
-      if (window) {
-        const isCurrentlyFullscreen = await window.isFullscreen();
+      if (appWindow) {
+        const isCurrentlyFullscreen = await appWindow.isFullscreen();
         const next = !isCurrentlyFullscreen;
 
-        await window.setFullscreen(next);
-        await setDecorations(!next);
-        setIsFullscreen(next);
-
-        if (!next) {
+        if (next) {
+          await setDecorations(false);
+          await appWindow.setFullscreen(true);
+        } else {
+          await appWindow.setFullscreen(false);
+          await setDecorations(true);
           await saveCurrentPosition();
         }
+
+        setIsFullscreen(next);
       }
     } catch (error) {
       console.error('Failed to toggle fullscreen:', error);
@@ -220,12 +227,32 @@ function MediaWindowComponent() {
 
   const ensureDefaultWindowMode = useCallback(async () => {
     try {
-      const { getCurrentWebviewWindow } = await import('@tauri-apps/api/webviewWindow');
-      const window = getCurrentWebviewWindow();
+      const [{ getCurrentWebviewWindow }, { currentMonitor }] = await Promise.all([
+        import('@tauri-apps/api/webviewWindow'),
+        import('@tauri-apps/api/window'),
+      ]);
+      const appWindow = getCurrentWebviewWindow();
 
-      if (window) {
-        await window.setFullscreen(true);
+      if (appWindow) {
+        const [fullscreen, size, monitor] = await Promise.all([
+          appWindow.isFullscreen(),
+          appWindow.innerSize().catch(() => null),
+          currentMonitor().catch(() => null),
+        ]);
+        const hasFullscreenBounds =
+          !size ||
+          !monitor ||
+          (Math.abs(size.width - monitor.size.width) <= FULLSCREEN_SIZE_TOLERANCE &&
+            Math.abs(size.height - monitor.size.height) <= FULLSCREEN_SIZE_TOLERANCE);
+
         await setDecorations(false);
+
+        if (fullscreen && !hasFullscreenBounds) {
+          await appWindow.setFullscreen(false);
+          await delay(80);
+        }
+
+        await appWindow.setFullscreen(true);
         setIsFullscreen(true);
       }
     } catch (error) {
@@ -238,10 +265,26 @@ function MediaWindowComponent() {
   }, [ensureDefaultWindowMode]);
 
   useEffect(() => {
-    emit('media-window-ready').catch(() => { });
-    const onUnload = () => emit('module:presenter-window-closed').catch(() => { });
-    window.addEventListener('beforeunload', onUnload);
-    return () => window.removeEventListener('beforeunload', onUnload);
+    let detachCloseListener: (() => void) | undefined;
+
+    const notifyPresenterClosed = () => {
+      emit('module:presenter-window-closed').catch(() => { });
+    };
+
+    import('@tauri-apps/api/window')
+      .then(({ getCurrentWindow }) => getCurrentWindow().onCloseRequested(notifyPresenterClosed))
+      .then((unlisten) => {
+        detachCloseListener = unlisten;
+      })
+      .catch((error) => {
+        console.error('Failed to bind media window close listener:', error);
+      });
+
+    window.addEventListener('beforeunload', notifyPresenterClosed);
+    return () => {
+      detachCloseListener?.();
+      window.removeEventListener('beforeunload', notifyPresenterClosed);
+    };
   }, []);
 
   useEffect(() => {
@@ -308,6 +351,14 @@ function MediaWindowComponent() {
     const unlistenStreamOverlay = listen<{ active: boolean }>('stream-overlay-toggle', (event) => {
       setStreamOverlayActive(event.payload.active);
     });
+
+    Promise.all([
+      unlistenLyric,
+      unlistenStartSlide,
+      unlistenLoadUrl,
+      unlistenLoadImage,
+      unlistenStreamOverlay,
+    ]).then(() => emit('media-window-ready').catch(() => { }));
 
     return () => {
       unlistenLyric.then((f) => f());

--- a/src/app/media-window.tsx
+++ b/src/app/media-window.tsx
@@ -1,14 +1,14 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { invoke } from '@tauri-apps/api/core';
 import { emit, listen } from '@tauri-apps/api/event';
+import { readFile } from '@tauri-apps/plugin-fs';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useDebounceCallback, useEventListener, useInterval } from 'usehooks-ts';
+import { LyricPresentation } from '@/components/lyric-presentation';
+import { Videoplayer } from '@/components/ui/videoplayer';
 import { PresenterSlot } from '@/modules/components/PresenterSlot';
 import { bootPresenterModules } from '@/modules/presenter-injector';
 import { useModuleStore } from '@/modules/store';
-import { useDebounceCallback, useEventListener, useInterval } from 'usehooks-ts';
-
-import { LyricPresentation } from '@/components/lyric-presentation';
-import { Videoplayer } from '@/components/ui/videoplayer';
 
 function StreamOverlay() {
   const videoRef = useRef<HTMLVideoElement | null>(null);
@@ -29,7 +29,7 @@ function StreamOverlay() {
         return;
       }
       if (video.srcObject !== videoStream) video.srcObject = videoStream;
-      video.play().catch(() => {});
+      video.play().catch(() => { });
     };
 
     const send = (payload: Record<string, unknown>) => {
@@ -38,7 +38,9 @@ function StreamOverlay() {
 
     pc.ontrack = (event) => {
       if (event.track.kind === 'video') {
-        videoStream.getVideoTracks().forEach((t) => { videoStream.removeTrack(t); });
+        videoStream.getVideoTracks().forEach((t) => {
+          videoStream.removeTrack(t);
+        });
         videoStream.addTrack(event.track);
         attachVideo();
         if (event.track.muted) event.track.onunmute = () => attachVideo();
@@ -92,7 +94,7 @@ function StreamOverlay() {
         ) {
           await pc.addIceCandidate(payload.candidate);
         }
-      } catch {}
+      } catch { }
     };
 
     return () => {
@@ -109,7 +111,7 @@ function StreamOverlay() {
       ref={videoRef}
       autoPlay
       playsInline
-      className="absolute inset-0 h-full w-full object-contain bg-black [transform:translateZ(0)]"
+      className="absolute inset-0 h-full w-full object-contain bg-black transform-[translateZ(0)]"
     >
       <track kind="captions" />
     </video>
@@ -126,7 +128,25 @@ function MediaWindowComponent() {
   const [lyricPath, setLyricPath] = useState('');
   const [lyricStartIndex, setLyricStartIndex] = useState(0);
   const [imagePath, setImagePath] = useState<string | null>(null);
+  const [imageSrc, setImageSrc] = useState<string | undefined>();
   const [streamOverlayActive, setStreamOverlayActive] = useState(false);
+
+  useEffect(() => {
+    if (!imagePath) {
+      setImageSrc(undefined);
+      return;
+    }
+    let url: string;
+    readFile(imagePath)
+      .then((bytes) => {
+        url = URL.createObjectURL(new Blob([bytes]));
+        setImageSrc(url);
+      })
+      .catch(() => setImageSrc(undefined));
+    return () => {
+      if (url) URL.revokeObjectURL(url);
+    };
+  }, [imagePath]);
 
   const saveCurrentPosition = useCallback(async () => {
     try {
@@ -218,20 +238,23 @@ function MediaWindowComponent() {
   }, [ensureDefaultWindowMode]);
 
   useEffect(() => {
-    emit('media-window-ready').catch(() => {});
-    const onUnload = () => emit('module:presenter-window-closed').catch(() => {});
+    emit('media-window-ready').catch(() => { });
+    const onUnload = () => emit('module:presenter-window-closed').catch(() => { });
     window.addEventListener('beforeunload', onUnload);
     return () => window.removeEventListener('beforeunload', onUnload);
   }, []);
 
   useEffect(() => {
     bootPresenterModules()
-      .then(() => emit('module:presenter-ready').catch(() => {}))
+      .then(() => emit('module:presenter-ready').catch(() => { }))
       .catch(console.error);
 
-    const unlistenProject = listen<{ viewId: string; props: unknown }>('module:presenter-project', (e) => {
-      useModuleStore.getState().projectPanel(e.payload.viewId, e.payload.props);
-    });
+    const unlistenProject = listen<{ viewId: string; props: unknown }>(
+      'module:presenter-project',
+      (e) => {
+        useModuleStore.getState().projectPanel(e.payload.viewId, e.payload.props);
+      }
+    );
     const unlistenClear = listen('module:presenter-clear', () => {
       useModuleStore.getState().clearPresenter();
     });
@@ -274,7 +297,7 @@ function MediaWindowComponent() {
 
     const unlistenLoadUrl = listen('load-url', () => {
       setMode('video');
-      invoke('push_stream_blank').catch(() => {});
+      invoke('push_stream_blank').catch(() => { });
     });
 
     const unlistenLoadImage = listen<{ url: string }>('load-image', (event) => {
@@ -305,19 +328,10 @@ function MediaWindowComponent() {
   return (
     <div className="fixed inset-0 h-dvh w-dvw overflow-hidden bg-black">
       <Videoplayer className="h-full w-full" url="" autoplay muted={false} interactive={false} />
-      {imagePath && mode !== 'lyric' && (
-        <button
-          type="button"
-          aria-label="Close image"
-          className="absolute inset-0 z-10 flex items-center justify-center bg-black cursor-pointer"
-          onClick={() => setImagePath(null)}
-        >
-          <img
-            src={`asset://localhost/${imagePath.replace(/\\/g, '/')}`}
-            alt=""
-            className="max-h-full max-w-full object-contain"
-          />
-        </button>
+      {imageSrc && mode !== 'lyric' && (
+        <div className="absolute inset-0 z-10 w-dvw h-dvh bg-black">
+          <img src={imageSrc} alt="" className="w-full h-full object-contain" />
+        </div>
       )}
       {mode === 'lyric' && lyricPath && (
         <div className="absolute inset-0 z-10">
@@ -325,7 +339,7 @@ function MediaWindowComponent() {
         </div>
       )}
       {streamOverlayActive && (
-        <div className="absolute inset-0 z-[9999] [transform:translateZ(0)]">
+        <div className="absolute inset-0 z-9999 transform-[translateZ(0)]">
           <StreamOverlay />
         </div>
       )}

--- a/src/app/module-overlay-window.tsx
+++ b/src/app/module-overlay-window.tsx
@@ -31,11 +31,16 @@ function ModuleOverlayWindow() {
   const toggleFullscreen = useCallback(async () => {
     try {
       const { getCurrentWebviewWindow } = await import('@tauri-apps/api/webviewWindow');
-      const window = getCurrentWebviewWindow();
-      const nextFullscreen = !(await window.isFullscreen());
+      const appWindow = getCurrentWebviewWindow();
+      const nextFullscreen = !(await appWindow.isFullscreen());
 
-      await window.setFullscreen(nextFullscreen);
-      await setDecorations(!nextFullscreen);
+      if (nextFullscreen) {
+        await setDecorations(false);
+        await appWindow.setFullscreen(true);
+      } else {
+        await appWindow.setFullscreen(false);
+        await setDecorations(true);
+      }
     } catch (error) {
       console.error('Failed to toggle overlay fullscreen:', error);
     }

--- a/src/components/app-header.tsx
+++ b/src/components/app-header.tsx
@@ -1,8 +1,18 @@
 import { Link, useRouterState } from '@tanstack/react-router';
-import { Monitor, Star, Volume2, Wifi } from 'lucide-react';
+import { CheckIcon, Monitor, Smartphone, Star, Volume2 } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { cn } from '@/lib/utils';
+import { useProfileStore } from '@/stores/profile-store';
+import { useStreamingStore } from '@/stores/streaming-store';
 import { HeaderTrailingSlot } from '@/modules/components/HeaderTrailingSlot';
 import { SettingsDialog } from './settings-dialog';
 import { Card } from './ui/card';
@@ -17,8 +27,26 @@ const NAV_TABS = [
 
 type TabTo = (typeof NAV_TABS)[number]['to'];
 
+function getInitials(name: string): string {
+  return name
+    .split(' ')
+    .slice(0, 2)
+    .map((w) => w.charAt(0).toUpperCase())
+    .join('');
+}
+
 export function AppHeader() {
   const pathname = useRouterState({ select: (s) => s.location.pathname });
+
+  const profiles = useProfileStore((s) => s.profiles);
+  const activeProfileId = useProfileStore((s) => s.activeProfileId);
+  const setActiveProfile = useProfileStore((s) => s.setActiveProfile);
+  const activeProfile = profiles.find((p) => p.id === activeProfileId);
+  const profileName = activeProfile?.name ?? 'User';
+  const initials = getInitials(profileName);
+
+  const mobileConnected = useStreamingStore((s) => s.status.mobile_connected);
+  const mobileCount = Object.keys(useStreamingStore((s) => s.mobileStreams)).length;
 
   const activeTab: TabTo = (() => {
     const match = NAV_TABS.find((t) => t.to !== '/' && pathname.startsWith(t.to));
@@ -86,14 +114,51 @@ export function AppHeader() {
 
         <div className="flex min-w-0 items-center justify-end gap-3 w-56">
           <HeaderTrailingSlot />
-          <Wifi className="size-4 shrink-0 text-muted-foreground" />
+          <span className="relative inline-flex">
+            <Smartphone className={cn('size-4 shrink-0', mobileConnected ? 'text-primary' : 'text-muted-foreground')} />
+            {mobileCount > 0 && (
+              <span className="absolute -top-1.5 -right-1.5 flex min-w-[14px] h-3.5 items-center justify-center rounded-full bg-primary text-[10px] font-bold text-primary-foreground px-[3px] leading-none">
+                {mobileCount > 9 ? '+9' : mobileCount}
+              </span>
+            )}
+          </span>
           <Monitor className="size-4 shrink-0 text-muted-foreground" />
           <Volume2 className="size-4 shrink-0 text-muted-foreground" />
           <SettingsDialog />
-          <Avatar size="sm">
-            <AvatarImage src="" alt="User" />
-            <AvatarFallback>U</AvatarFallback>
-          </Avatar>
+          {profiles.length > 1 ? (
+            <DropdownMenu>
+              <DropdownMenuTrigger>
+                <Avatar size="sm">
+                  <AvatarImage src="" alt={profileName} />
+                  <AvatarFallback>{initials}</AvatarFallback>
+                </Avatar>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" sideOffset={8}>
+                <DropdownMenuGroup>
+                  <DropdownMenuLabel>Profiles</DropdownMenuLabel>
+                </DropdownMenuGroup>
+                {profiles.map((p) => (
+                  <DropdownMenuItem
+                    key={p.id}
+                    onClick={() => setActiveProfile(p.id)}
+                    className="flex items-center gap-2"
+                  >
+                    {p.id === activeProfileId && (
+                      <CheckIcon className="size-3.5 shrink-0" />
+                    )}
+                    <span className={p.id !== activeProfileId ? 'pl-5' : ''}>
+                      {p.name}
+                    </span>
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          ) : (
+            <Avatar size="sm">
+              <AvatarImage src="" alt={profileName} />
+              <AvatarFallback>{initials}</AvatarFallback>
+            </Avatar>
+          )}
         </div>
       </Card>
     </header>

--- a/src/components/app-header.tsx
+++ b/src/components/app-header.tsx
@@ -2,8 +2,8 @@ import { Link, useRouterState } from '@tanstack/react-router';
 import { Monitor, Star, Volume2, Wifi } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import { HeaderTrailingSlot } from '@/modules/components/HeaderTrailingSlot';
 import { cn } from '@/lib/utils';
+import { HeaderTrailingSlot } from '@/modules/components/HeaderTrailingSlot';
 import { SettingsDialog } from './settings-dialog';
 import { Card } from './ui/card';
 

--- a/src/components/app-header.tsx
+++ b/src/components/app-header.tsx
@@ -1,6 +1,7 @@
 import { Link, useRouterState } from '@tanstack/react-router';
+import { animate } from 'animejs';
 import { CheckIcon, Monitor, Smartphone, Star, Volume2 } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import {
   DropdownMenu,
@@ -53,24 +54,65 @@ export function AppHeader() {
     return match ? match.to : '/';
   })();
 
-  const [indicatorStyle, setIndicatorStyle] = useState({ left: 0, width: 0 });
-  const [ready, setReady] = useState(false);
   const navRef = useRef<HTMLElement>(null);
+  const indicatorRef = useRef<HTMLSpanElement>(null);
+  const animationRef = useRef<ReturnType<typeof animate> | null>(null);
+  const readyRef = useRef(false);
   const buttonRefs = useRef<Map<TabTo, HTMLAnchorElement>>(new Map());
 
   useEffect(() => {
-    const activeBtn = buttonRefs.current.get(activeTab);
+    const indicator = indicatorRef.current;
     const nav = navRef.current;
-    if (!activeBtn || !nav) return;
+    if (!indicator || !nav) return;
 
-    const navRect = nav.getBoundingClientRect();
-    const btnRect = activeBtn.getBoundingClientRect();
+    let frame = 0;
 
-    setIndicatorStyle({
-      left: btnRect.left - navRect.left,
-      width: btnRect.width,
+    const updateIndicator = () => {
+      const activeBtn = buttonRefs.current.get(activeTab);
+      if (!activeBtn) return;
+
+      const navRect = nav.getBoundingClientRect();
+      const btnRect = activeBtn.getBoundingClientRect();
+      const left = btnRect.left - navRect.left;
+      const width = btnRect.width;
+
+      if (!readyRef.current) {
+        animationRef.current?.cancel();
+        indicator.style.opacity = '1';
+        indicator.style.left = `${left}px`;
+        indicator.style.width = `${width}px`;
+        readyRef.current = true;
+        return;
+      }
+
+      animationRef.current?.cancel();
+      animationRef.current = animate(indicator, {
+        left: `${left}px`,
+        width: `${width}px`,
+        opacity: 1,
+        duration: 250,
+        ease: 'outCubic',
+      });
+    };
+
+    const scheduleUpdate = () => {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(updateIndicator);
+    };
+
+    const resizeObserver = new ResizeObserver(() => scheduleUpdate());
+    resizeObserver.observe(nav);
+    buttonRefs.current.forEach((button) => {
+      resizeObserver.observe(button);
     });
-    setReady(true);
+
+    scheduleUpdate();
+
+    return () => {
+      cancelAnimationFrame(frame);
+      animationRef.current?.cancel();
+      resizeObserver.disconnect();
+    };
   }, [activeTab]);
 
   return (
@@ -100,16 +142,11 @@ export function AppHeader() {
             </Link>
           ))}
 
-          {ready && (
-            <span
-              className="absolute bottom-0 h-0.5 bg-primary rounded-full"
-              style={{
-                left: indicatorStyle.left,
-                width: indicatorStyle.width,
-                transition: 'left 250ms ease, width 250ms ease',
-              }}
-            />
-          )}
+          <span
+            ref={indicatorRef}
+            className="absolute bottom-0 h-0.5 rounded-full bg-primary"
+            style={{ opacity: 0, left: 0, width: 0 }}
+          />
         </nav>
 
         <div className="flex min-w-0 items-center justify-end gap-3 w-56">

--- a/src/components/aside-panel.tsx
+++ b/src/components/aside-panel.tsx
@@ -19,7 +19,6 @@ import { CSS } from '@dnd-kit/utilities';
 import {
   BoldIcon,
   CheckCircle2,
-  CodeIcon,
   Heading1Icon,
   Heading2Icon,
   Heading3Icon,
@@ -597,11 +596,6 @@ function NotesTab() {
       children: <StrikethroughIcon />,
       action: () => editor?.chain().focus().toggleStrike().run(),
       active: editor?.isActive('strike'),
-    },
-    {
-      children: <CodeIcon />,
-      action: () => editor?.chain().focus().toggleCode().run(),
-      active: editor?.isActive('code'),
     },
     {
       children: <Heading1Icon />,

--- a/src/components/aside-panel.tsx
+++ b/src/components/aside-panel.tsx
@@ -16,9 +16,35 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { CheckCircle2, ListX, Tag, X, Zap } from 'lucide-react';
+import {
+  BoldIcon,
+  CheckCircle2,
+  CodeIcon,
+  Heading1Icon,
+  Heading2Icon,
+  Heading3Icon,
+  ItalicIcon,
+  ListIcon,
+  ListOrderedIcon,
+  ListX,
+  QuoteIcon,
+  StrikethroughIcon,
+  Tag,
+  UnderlineIcon,
+  X,
+  Zap,
+} from 'lucide-react';
 import type React from 'react';
-import { useEffect, useRef, useState } from 'react';
+import {
+  type RefObject,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react';
+import { TextEditor, type TextEditorRef } from '@/components/text-editor';
+import { type BubbleMenuItem, TextEditorBubbleMenu } from '@/components/text-editor-bubble-menu';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
@@ -165,9 +191,7 @@ export function AsidePanel() {
         </TabsContent>
 
         <TabsContent value="notes" className="flex-1 overflow-hidden mt-0">
-          <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
-            Coming soon
-          </div>
+          <NotesTab />
         </TabsContent>
 
         <TabsContent value="themes" className="flex-1 overflow-hidden mt-0">
@@ -522,6 +546,100 @@ function SortableQueueItem({
           </div>
         </div>
       </div>
+    </div>
+  );
+}
+
+function useEditorState(editorRef: RefObject<TextEditorRef | null>) {
+  const subscribe = useCallback(
+    (callback: () => void) => {
+      const editor = editorRef.current?.editor;
+      if (!editor) return () => { };
+      editor.on('transaction', callback);
+      editor.on('selectionUpdate', callback);
+      return () => {
+        editor.off('transaction', callback);
+        editor.off('selectionUpdate', callback);
+      };
+    },
+    [editorRef]
+  );
+
+  return useSyncExternalStore(
+    subscribe,
+    () => editorRef.current?.editor?.state ?? null,
+    () => null
+  );
+}
+
+function NotesTab() {
+  const editorRef = useRef<TextEditorRef | null>(null);
+  useEditorState(editorRef);
+  const editor = editorRef.current?.editor;
+
+  const items: BubbleMenuItem[] = [
+    {
+      children: <BoldIcon />,
+      action: () => editor?.chain().focus().toggleBold().run(),
+      active: editor?.isActive('bold'),
+    },
+    {
+      children: <ItalicIcon />,
+      action: () => editor?.chain().focus().toggleItalic().run(),
+      active: editor?.isActive('italic'),
+    },
+    {
+      children: <UnderlineIcon />,
+      action: () => editor?.chain().focus().toggleUnderline().run(),
+      active: editor?.isActive('underline'),
+    },
+    {
+      children: <StrikethroughIcon />,
+      action: () => editor?.chain().focus().toggleStrike().run(),
+      active: editor?.isActive('strike'),
+    },
+    {
+      children: <CodeIcon />,
+      action: () => editor?.chain().focus().toggleCode().run(),
+      active: editor?.isActive('code'),
+    },
+    {
+      children: <Heading1Icon />,
+      action: () => editor?.chain().focus().toggleHeading({ level: 1 }).run(),
+      active: editor?.isActive('heading', { level: 1 }),
+    },
+    {
+      children: <Heading2Icon />,
+      action: () => editor?.chain().focus().toggleHeading({ level: 2 }).run(),
+      active: editor?.isActive('heading', { level: 2 }),
+    },
+    {
+      children: <Heading3Icon />,
+      action: () => editor?.chain().focus().toggleHeading({ level: 3 }).run(),
+      active: editor?.isActive('heading', { level: 3 }),
+    },
+    {
+      children: <ListIcon />,
+      action: () => editor?.chain().focus().toggleBulletList().run(),
+      active: editor?.isActive('bulletList'),
+    },
+    {
+      children: <ListOrderedIcon />,
+      action: () => editor?.chain().focus().toggleOrderedList().run(),
+      active: editor?.isActive('orderedList'),
+    },
+    {
+      children: <QuoteIcon />,
+      action: () => editor?.chain().focus().toggleBlockquote().run(),
+      active: editor?.isActive('blockquote'),
+    },
+  ];
+
+  return (
+    <div className="relative size-full">
+      <TextEditor ref={editorRef} placeholder="Write your notes here...">
+        <TextEditorBubbleMenu editorRef={editorRef} items={items} />
+      </TextEditor>
     </div>
   );
 }

--- a/src/components/aside-panel.tsx
+++ b/src/components/aside-panel.tsx
@@ -76,7 +76,7 @@ import {
   EmptyTitle,
 } from '@/components/ui/empty';
 import { ScrollArea } from '@/components/ui/scroll-area';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Tabs, TabsContent, TabsIndicator, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { t } from '@/lib/i18n';
 import { cn } from '@/lib/utils';
 import { useModuleStore } from '@/modules/store';
@@ -134,24 +134,10 @@ export function AsidePanel() {
   const loadFile = usePlayerStore((s) => s.loadFile);
 
   const [activeTab, setActiveTab] = useState<TabValue>('queue');
-  const [indicatorStyle, setIndicatorStyle] = useState({ left: 0, width: 0 });
-  const [ready, setReady] = useState(false);
-  const navRef = useRef<HTMLDivElement>(null);
-  const triggerRefs = useRef<Map<TabValue, HTMLButtonElement>>(new Map());
 
   useEffect(() => {
     loadFromDb();
   }, [loadFromDb]);
-
-  useEffect(() => {
-    const activeBtn = triggerRefs.current.get(activeTab);
-    const nav = navRef.current;
-    if (!activeBtn || !nav) return;
-    const navRect = nav.getBoundingClientRect();
-    const btnRect = activeBtn.getBoundingClientRect();
-    setIndicatorStyle({ left: btnRect.left - navRect.left, width: btnRect.width });
-    setReady(true);
-  }, [activeTab]);
 
   return (
     <Card className="flex flex-col w-full h-full overflow-hidden">
@@ -160,7 +146,7 @@ export function AsidePanel() {
         onValueChange={(v) => setActiveTab(v as TabValue)}
         className="flex flex-col h-full"
       >
-        <div ref={navRef} className="relative border-b border-border shrink-0">
+        <div className="relative border-b border-border shrink-0">
           <TabsList
             variant="line"
             className="w-full justify-between rounded-none border-none px-2 h-10"
@@ -169,25 +155,13 @@ export function AsidePanel() {
               <TabsTrigger
                 key={tab.value}
                 value={tab.value}
-                ref={(el: HTMLButtonElement | null) => {
-                  if (el) triggerRefs.current.set(tab.value, el);
-                }}
                 className="flex-none px-4 after:hidden"
               >
                 {tab.label}
               </TabsTrigger>
             ))}
+            <TabsIndicator className="bg-primary" />
           </TabsList>
-          {ready && (
-            <span
-              className="absolute bottom-0 h-0.5 bg-primary rounded-full"
-              style={{
-                left: indicatorStyle.left,
-                width: indicatorStyle.width,
-                transition: 'left 250ms ease, width 250ms ease',
-              }}
-            />
-          )}
         </div>
 
         <TabsContent value="queue" className="flex-1 overflow-hidden mt-0">

--- a/src/components/aside-panel.tsx
+++ b/src/components/aside-panel.tsx
@@ -67,10 +67,13 @@ import {
 } from '@/components/ui/dialog';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { t } from '@/lib/i18n';
 import { cn } from '@/lib/utils';
 import { useModuleStore } from '@/modules/store';
 import type { QueueTriggerSpec } from '@/modules/types';
+import { notesService } from '@/services/notes-service';
 import { usePlayerStore } from '@/stores/player-store';
+import { useProfileStore } from '@/stores/profile-store';
 import {
   type ListEntry,
   type TriggerInstance,
@@ -99,9 +102,9 @@ function getDownloadStatusLabel(item: QueueItem): string | null {
 }
 
 const TABS: { value: TabValue; label: string }[] = [
-  { value: 'queue', label: 'Queue' },
-  { value: 'notes', label: 'Notes' },
-  { value: 'themes', label: 'Themes' },
+  { value: 'queue', label: t('Queue') },
+  { value: 'notes', label: t('Notes') },
+  { value: 'themes', label: t('Themes') },
 ];
 
 export function AsidePanel() {
@@ -189,7 +192,7 @@ export function AsidePanel() {
           />
         </TabsContent>
 
-        <TabsContent value="notes" className="flex-1 overflow-hidden mt-0">
+        <TabsContent value="notes" className="flex-1 mt-0">
           <NotesTab />
         </TabsContent>
 
@@ -576,6 +579,25 @@ function NotesTab() {
   useEditorState(editorRef);
   const editor = editorRef.current?.editor;
 
+  const activeProfileId = useProfileStore((s) => s.activeProfileId);
+  const [defaultValue, setDefaultValue] = useState('');
+
+  useEffect(() => {
+    if (!activeProfileId) return;
+    notesService.loadNotes(activeProfileId).then((content) => {
+      setDefaultValue(content);
+      editorRef.current?.setMarkdown(content);
+    });
+  }, [activeProfileId]);
+
+  const handleChange = useCallback(
+    (md: string) => {
+      if (!activeProfileId) return;
+      notesService.saveNotes(activeProfileId, md);
+    },
+    [activeProfileId]
+  );
+
   const items: BubbleMenuItem[] = [
     {
       children: <BoldIcon />,
@@ -631,7 +653,13 @@ function NotesTab() {
 
   return (
     <div className="relative size-full">
-      <TextEditor ref={editorRef} placeholder="Write your notes here...">
+      <TextEditor
+        ref={editorRef}
+        defaultValue={defaultValue}
+        onChange={handleChange}
+        debounce={500}
+        placeholder={t('Write your notes here...')}
+      >
         <TextEditorBubbleMenu editorRef={editorRef} items={items} />
       </TextEditor>
     </div>

--- a/src/components/aside-panel.tsx
+++ b/src/components/aside-panel.tsx
@@ -517,7 +517,7 @@ function SortableQueueItem({
           'flex items-center rounded-lg touch-none select-none',
           isCurrent
             ? 'border border-primary/40 bg-primary/5'
-            : 'hover:bg-accent/50 transition-colors'
+            : 'hover:bg-accent/70 transition-colors'
         )}
       >
         <div className="flex flex-1 items-center justify-between min-w-0 px-3 py-2">

--- a/src/components/aside-panel.tsx
+++ b/src/components/aside-panel.tsx
@@ -19,13 +19,16 @@ import { CSS } from '@dnd-kit/utilities';
 import {
   BoldIcon,
   CheckCircle2,
+  CheckIcon,
   Heading1Icon,
   Heading2Icon,
   Heading3Icon,
+  ImageIcon,
   ItalicIcon,
   ListIcon,
   ListOrderedIcon,
   ListX,
+  Loader2,
   QuoteIcon,
   StrikethroughIcon,
   Tag,
@@ -65,13 +68,23 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from '@/components/ui/empty';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { t } from '@/lib/i18n';
 import { cn } from '@/lib/utils';
 import { useModuleStore } from '@/modules/store';
 import type { QueueTriggerSpec } from '@/modules/types';
+import { mediaDbService } from '@/services/media-db-service';
 import { notesService } from '@/services/notes-service';
+import { thumbnailService } from '@/services/thumbnail-service';
+import type { FileInfo } from '@/services/types';
 import { usePlayerStore } from '@/stores/player-store';
 import { useProfileStore } from '@/stores/profile-store';
 import {
@@ -197,9 +210,7 @@ export function AsidePanel() {
         </TabsContent>
 
         <TabsContent value="themes" className="flex-1 overflow-hidden mt-0">
-          <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
-            Coming soon
-          </div>
+          <ThemesTab />
         </TabsContent>
       </Tabs>
     </Card>
@@ -663,6 +674,118 @@ function NotesTab() {
         <TextEditorBubbleMenu editorRef={editorRef} items={items} />
       </TextEditor>
     </div>
+  );
+}
+
+function ThemesTab() {
+  const profiles = useProfileStore((s) => s.profiles);
+  const activeProfileId = useProfileStore((s) => s.activeProfileId);
+  const updateProfile = useProfileStore((s) => s.updateProfile);
+  const activeProfile = profiles.find((p) => p.id === activeProfileId);
+
+  const [themes, setThemes] = useState<FileInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setLoading(true);
+    mediaDbService
+      .listThemes()
+      .then(setThemes)
+      .catch(() => setThemes([]))
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <div className="size-full overflow-hidden">
+      {loading ? (
+        <div className="flex items-center justify-center h-full">
+          <Loader2 className="size-5 text-muted-foreground animate-spin" />
+        </div>
+      ) : themes.length === 0 ? (
+        <Empty className="h-full">
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <ImageIcon />
+            </EmptyMedia>
+            <EmptyTitle>{t('No themes yet')}</EmptyTitle>
+            <EmptyDescription>
+              {t('Add images or videos to the themes folder in settings.')}
+            </EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      ) : (
+        <ScrollArea className="h-full">
+          <div className="grid grid-cols-[repeat(auto-fill,minmax(100px,1fr))] gap-2 p-3">
+            {themes.map((file) => (
+              <ThemeThumbnail
+                key={file.path}
+                file={file}
+                isActive={activeProfile?.defaultBackground?.src === file.path}
+                onClick={() => {
+                  if (activeProfileId) {
+                    updateProfile(activeProfileId, {
+                      defaultBackground: { type: 'theme', src: file.path, name: file.name },
+                    });
+                  }
+                }}
+              />
+            ))}
+          </div>
+        </ScrollArea>
+      )}
+    </div>
+  );
+}
+
+function ThemeThumbnail({
+  file,
+  isActive,
+  onClick,
+}: {
+  file: FileInfo;
+  isActive: boolean;
+  onClick: () => void;
+}) {
+  const [displaySrc, setDisplaySrc] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    thumbnailService
+      .getThumbnail(file.path)
+      .then((url) => {
+        if (!cancelled) setDisplaySrc(url);
+      })
+      .catch(() => { });
+    return () => {
+      cancelled = true;
+    };
+  }, [file.path]);
+
+  return (
+    <button
+      type="button"
+      tabIndex={0}
+      onClick={onClick}
+      className={cn(
+        'relative group aspect-video rounded-lg overflow-hidden transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring cursor-pointer',
+        isActive ? 'ring-2 ring-primary ring-offset-2 ring-offset-background' : 'hover:opacity-90'
+      )}
+    >
+      {displaySrc ? (
+        <img src={displaySrc} alt={file.name} className="size-full object-cover" />
+      ) : (
+        <div className="size-full bg-card animate-pulse opacity-70 flex items-center justify-center">
+          <Loader2 className="size-4 text-muted-foreground animate-spin" />
+        </div>
+      )}
+      {isActive && (
+        <div className="absolute inset-0 flex items-center justify-center bg-black/20 pointer-events-none">
+          <div className="rounded-full bg-black/60 p-1.5">
+            <CheckIcon className="size-4 text-white" />
+          </div>
+        </div>
+      )}
+    </button>
   );
 }
 

--- a/src/components/aside-panel.tsx
+++ b/src/components/aside-panel.tsx
@@ -349,7 +349,7 @@ function QueueTab({
                 items={entries.map((e) => e.id)}
                 strategy={verticalListSortingStrategy}
               >
-                <div className="px-4 py-3 space-y-1">
+                <div className="py-3 space-y-1">
                   {entries.map((entry) => {
                     if (entry.kind === 'item') {
                       const isCurrent = entry.item.file.path === currentFilePath;

--- a/src/components/error-boundary.tsx
+++ b/src/components/error-boundary.tsx
@@ -1,7 +1,7 @@
-import React, { Component, type ReactNode } from 'react';
-import { Card } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
 import { AlertTriangle } from 'lucide-react';
+import React, { Component, type ReactNode } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
 
 interface ErrorBoundaryProps {
   children: ReactNode;
@@ -59,9 +59,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
                 {this.state.error.message}
               </p>
             </div>
-            <Button onClick={this.handleRetry}>
-              Try Again
-            </Button>
+            <Button onClick={this.handleRetry}>Try Again</Button>
           </div>
         </Card>
       );

--- a/src/components/file-list-item.tsx
+++ b/src/components/file-list-item.tsx
@@ -214,6 +214,15 @@ export function FileListItem({
         </Button>
       </ContextMenuTrigger>
       <ContextMenuContent side="bottom">
+        {mediaType === 'image' && onDoubleClick && (
+          <>
+            <ContextMenuItem onClick={() => onDoubleClick(file)}>
+              <ImageIcon className="h-4 w-4" aria-hidden="true" />
+              Open
+            </ContextMenuItem>
+            <ContextMenuSeparator />
+          </>
+        )}
         {(onPlayNext || onAddToQueue) && (
           <>
             {onPlayNext && (

--- a/src/components/lyric-background-modal.tsx
+++ b/src/components/lyric-background-modal.tsx
@@ -1,7 +1,6 @@
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { join } from '@tauri-apps/api/path';
 import { exists, mkdir, readDir, remove, stat, writeFile } from '@tauri-apps/plugin-fs';
-import { t, useTranslation } from '@/lib/i18n';
 import {
   CheckIcon,
   DownloadIcon,
@@ -22,6 +21,7 @@ import {
 } from 'react';
 import { toast } from 'sonner';
 import { useDebounceValue } from 'usehooks-ts';
+import { t, useTranslation } from '@/lib/i18n';
 import { cn } from '@/lib/utils';
 import { getThemesPath } from '@/services/app-paths';
 import { mediaDbService } from '@/services/media-db-service';
@@ -154,16 +154,18 @@ interface MediaThumbnailProps {
   onDelete?: () => void;
 }
 
-
 function MediaThumbnail({ file, selected, onClick, onDelete }: MediaThumbnailProps) {
   const [displaySrc, setDisplaySrc] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
 
-    thumbnailService.getThumbnail(file.path).then((url) => {
-      if (!cancelled) setDisplaySrc(url);
-    }).catch(() => { });
+    thumbnailService
+      .getThumbnail(file.path)
+      .then((url) => {
+        if (!cancelled) setDisplaySrc(url);
+      })
+      .catch(() => { });
 
     return () => {
       cancelled = true;
@@ -437,7 +439,7 @@ export function LyricBackgroundModal({ ref }: { ref?: Ref<LyricBackgroundModalRe
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      <DialogContent className="sm:max-w-[56.25rem] p-0 gap-0 overflow-hidden">
+      <DialogContent className="sm:max-w-225 p-0 gap-0 overflow-hidden">
         <DialogHeader className="px-6 pt-5 pb-0">
           <DialogTitle className="text-base font-semibold">Select Media</DialogTitle>
         </DialogHeader>
@@ -480,10 +482,10 @@ export function LyricBackgroundModal({ ref }: { ref?: Ref<LyricBackgroundModalRe
 
           <TabsContent
             value="themes"
-            className="px-6 py-4 flex flex-col gap-3 min-h-[25rem] h-[40dvh]"
+            className="px-6 py-4 flex flex-col gap-3 min-h-100 h-[40dvh]"
           >
             {themes.length === 0 ? (
-              <Empty className="min-h-[25rem] h-[40dvh]">
+              <Empty className="min-h-100 h-[40dvh]">
                 <EmptyHeader>
                   <EmptyMedia variant="icon">
                     <ImageIcon />
@@ -497,7 +499,7 @@ export function LyricBackgroundModal({ ref }: { ref?: Ref<LyricBackgroundModalRe
             ) : (
               <ScrollArea
                 ref={themesScrollRef}
-                className="min-h-[25rem] h-[40dvh]"
+                className="min-h-100 h-[40dvh]"
                 viewportClassName="pt-1 px-1.5"
               >
                 <div
@@ -546,15 +548,15 @@ export function LyricBackgroundModal({ ref }: { ref?: Ref<LyricBackgroundModalRe
             </div>
             <ScrollArea
               ref={unsplashScrollRef}
-              className="min-h-[22rem] h-[34dvh]"
+              className="min-h-88 h-[34dvh]"
               viewportClassName="pt-1 px-1.5"
             >
               {unsplashLoading && unsplashResults.length === 0 ? (
-                <div className="flex items-center justify-center min-h-[20rem]">
+                <div className="flex items-center justify-center min-h-80">
                   <ImageLoader className="mx-auto" />
                 </div>
               ) : hasSearched && unsplashResults.length === 0 ? (
-                <Empty className="h-full min-h-[20rem]">
+                <Empty className="h-full min-h-80">
                   <EmptyHeader>
                     <EmptyMedia variant="icon">
                       <ImageIcon />
@@ -594,7 +596,11 @@ export function LyricBackgroundModal({ ref }: { ref?: Ref<LyricBackgroundModalRe
                                 }
                                 onKeyDown={(e) => {
                                   if (e.key === 'Enter' || e.key === ' ')
-                                    setSelected({ type: 'image', src: photo.urls.raw, name: label });
+                                    setSelected({
+                                      type: 'image',
+                                      src: photo.urls.raw,
+                                      name: label,
+                                    });
                                 }}
                                 className={cn(
                                   'group relative aspect-video rounded-lg overflow-hidden transition-all focus-visible:outline-none cursor-pointer',
@@ -653,7 +659,7 @@ export function LyricBackgroundModal({ ref }: { ref?: Ref<LyricBackgroundModalRe
           </TabsContent>
 
           {/* <TabsContent value="video" className="px-6 py-4">
-            <ScrollArea className="min-h-[25rem] h-[40dvh]">
+            <ScrollArea className="min-h-100 h-[40dvh]">
               {loading ? (
                 <LoadingGrid />
               ) : videos.length === 0 ? (

--- a/src/components/lyric-presentation.tsx
+++ b/src/components/lyric-presentation.tsx
@@ -132,7 +132,7 @@ export function LyricPresentation({ filePath, startIndex = 0 }: { filePath: stri
       alignment: lyricData.metadata.alignment || 'center',
       background,
       active: true,
-    }).catch(() => {});
+    }).catch(() => { });
 
     invoke('push_stream_slide', {
       update: {
@@ -145,7 +145,7 @@ export function LyricPresentation({ filePath, startIndex = 0 }: { filePath: stri
         total_slides: lyricData.slides.length,
         active: true,
       },
-    }).catch(() => {});
+    }).catch(() => { });
   }, [currentSlide, filePath, lyricData, profileBackground]);
 
   const totalSlides = lyricData?.slides.length ?? 0;
@@ -252,13 +252,13 @@ export function LyricPresentation({ filePath, startIndex = 0 }: { filePath: stri
         <img
           src={slideBgSrc}
           alt=""
-          className="absolute inset-0 z-[1] w-full h-full object-cover"
+          className="absolute inset-0 z-1 w-full h-full object-cover"
           aria-hidden
         />
       )}
 
       <div
-        className="absolute inset-0 z-[2] flex items-center justify-center overflow-hidden p-[5%]"
+        className="absolute inset-0 z-2 flex items-center justify-center overflow-hidden p-[5%]"
         style={{
           opacity: textVisible ? 1 : 0,
           transition: `opacity ${fadeMs}ms ease`,

--- a/src/components/media-panel.tsx
+++ b/src/components/media-panel.tsx
@@ -41,9 +41,39 @@ export function MediaPanel() {
   const { t } = useTranslation();
   const player = usePlayerStore();
   const { addToQueue, playNext } = useQueueStore();
-  const loadLyricPreview = useLyricEditStore((s) => s.loadLyric);
   const openLyricModal = useLyricModalStore((s) => s.open);
   const [activeMedia, setActiveMedia] = useState<MediaType | null>(null);
+
+  const handleFileDoubleClick = useCallback((file: FileInfo) => {
+    if (activeMedia === 'audio' || activeMedia === 'video') {
+      player.loadFile(file.path);
+    }
+    if (activeMedia === 'lyrics') {
+      player.presentLyric(file.path);
+    }
+    if (activeMedia === 'image') {
+      player.presentImage(file.path);
+    }
+  }, [activeMedia, player]);
+
+  const handleFileEdit = useCallback((file: FileInfo) => {
+    if (activeMedia === 'lyrics') {
+      openLyricModal(file.path);
+    }
+  }, [activeMedia, openLyricModal]);
+
+  const handlePlayNext = useCallback((file: FileInfo) => {
+    if (activeMedia === 'video') {
+      playNext(file);
+    }
+  }, [activeMedia, playNext]);
+
+  const handleAddToQueue = useCallback((file: FileInfo) => {
+    if (activeMedia === 'video') {
+      addToQueue(file);
+    }
+  }, [activeMedia, addToQueue]);
+
   const [searchQuery, setSearchQuery] = useState('');
   const [files, setFiles] = useState<FileInfo[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -76,8 +106,14 @@ export function MediaPanel() {
     count: files.length,
     getScrollElement: () => parentRef.current,
     estimateSize: () => 80,
-    overscan: 10,
+    overscan: 6,
+    measureElement: (el) => el.getBoundingClientRect().height,
+    getItemKey: (index) => files[index]?.path ?? index,
   });
+
+  useEffect(() => {
+    virtualizer.measure();
+  }, [virtualizer]);
 
   const loadFiles = useCallback(
     async (mediaType: MediaType) => {
@@ -119,12 +155,6 @@ export function MediaPanel() {
       case 'ArrowUp':
         e.preventDefault();
         setFocusedIndex((prev) => (prev > 0 ? prev - 1 : -1));
-        break;
-      case 'Enter':
-        e.preventDefault();
-        if (focusedIndex >= 0) {
-          console.log('File clicked:', files[focusedIndex].name);
-        }
         break;
       case 'Delete':
         e.preventDefault();
@@ -353,6 +383,7 @@ export function MediaPanel() {
                     {virtualizer.getVirtualItems().map((virtualItem) => (
                       <div
                         key={virtualItem.key}
+                        ref={virtualizer.measureElement}
                         data-index={virtualItem.index}
                         style={{
                           position: 'absolute',
@@ -369,23 +400,13 @@ export function MediaPanel() {
                             isFocused={virtualItem.index === focusedIndex}
                             onClick={(file) => {
                               if (activeMedia === 'lyrics') {
-                                loadLyricPreview(file.path);
+                                useLyricEditStore.getState().loadLyric(file.path);
                               }
                             }}
-                            onDoubleClick={
-                              activeMedia === 'audio' || activeMedia === 'video'
-                                ? (file) => player.loadFile(file.path)
-                                : activeMedia === 'lyrics'
-                                  ? (file) => player.presentLyric(file.path)
-                                  : undefined
-                            }
-                            onEdit={
-                              activeMedia === 'lyrics'
-                                ? (file) => openLyricModal(file.path)
-                                : undefined
-                            }
-                            onPlayNext={activeMedia === 'video' ? playNext : undefined}
-                            onAddToQueue={activeMedia === 'video' ? addToQueue : undefined}
+                            onDoubleClick={handleFileDoubleClick}
+                            onEdit={handleFileEdit}
+                            onPlayNext={handlePlayNext}
+                            onAddToQueue={handleAddToQueue}
                           />
                         </div>
                       </div>

--- a/src/components/media-panel.tsx
+++ b/src/components/media-panel.tsx
@@ -12,7 +12,6 @@ import {
   Video,
 } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { useTranslation } from '@/lib/i18n';
 import { toast } from 'sonner';
 import { DeleteFileAlert } from '@/components/delete-file-alert';
 import { FileListItem } from '@/components/file-list-item';
@@ -20,6 +19,7 @@ import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { useAnnounce } from '@/hooks/use-announce';
+import { useTranslation } from '@/lib/i18n';
 import { cn } from '@/lib/utils';
 import { type FileInfo, fileInitService, fileManagementService, type MediaType } from '@/services';
 import { useLyricEditStore } from '@/stores/lyric-edit-store';

--- a/src/components/miniplayer.tsx
+++ b/src/components/miniplayer.tsx
@@ -85,8 +85,8 @@ export function MiniPlayer({ className }: MiniPlayerProps) {
           remoteThumbnailUrl: hit.remote_thumbnail_url ?? undefined,
           downloadStatus:
             hit.download_status === 'not_downloaded' ||
-            hit.download_status === 'downloaded' ||
-            hit.download_status === 'missing'
+              hit.download_status === 'downloaded' ||
+              hit.download_status === 'missing'
               ? hit.download_status
               : hit.original_url
                 ? 'not_downloaded'

--- a/src/components/quick-shortcuts-modal.tsx
+++ b/src/components/quick-shortcuts-modal.tsx
@@ -525,12 +525,12 @@ function RootView() {
     if (results.activePrefix) {
       return results.commands.length
         ? [
-            {
-              key: 'commands' as SearchScope,
-              heading: results.activePrefix.title,
-              results: results.commands,
-            },
-          ]
+          {
+            key: 'commands' as SearchScope,
+            heading: results.activePrefix.title,
+            results: results.commands,
+          },
+        ]
         : [];
     }
     const g: Array<{ key: SearchScope; heading: string; results: SearchResult[] }> = [];
@@ -737,7 +737,7 @@ function AppView({
       <PaletteHeader
         app={app}
         fullContent={false}
-        setFullContent={() => {}}
+        setFullContent={() => { }}
         inputValue={value}
         setInputValue={setValue}
         inputId={inputId}

--- a/src/components/settings-dialog.tsx
+++ b/src/components/settings-dialog.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useTranslation } from '@/lib/i18n';
 import {
   ChevronDown,
   Info,
@@ -15,8 +14,8 @@ import {
   Wifi,
 } from 'lucide-react';
 import { useState } from 'react';
-
 import { useAppVersion } from '@/hooks/use-app-version';
+import { useTranslation } from '@/lib/i18n';
 import { cn } from '@/lib/utils';
 import { useProfileStore } from '@/stores/profile-store';
 import { type SettingsSection, useSettingsStore } from '@/stores/settings-store';
@@ -32,7 +31,10 @@ import { Dialog, DialogClose, DialogContent, DialogTrigger } from './ui/dialog';
 import { ScrollArea } from './ui/scroll-area';
 import { Separator } from './ui/separator';
 
-const SECTION_TITLES: Record<SettingsSection, { label: string; title: string; description?: string }> = {
+const SECTION_TITLES: Record<
+  SettingsSection,
+  { label: string; title: string; description?: string }
+> = {
   theme: { label: 'Application settings', title: 'Configure themes, devices and transmission' },
   remote_general: { label: 'Remote Access', title: 'General Access' },
   remote_permissions: { label: 'Remote Access', title: 'Device Permissions' },

--- a/src/components/settings-dialog.tsx
+++ b/src/components/settings-dialog.tsx
@@ -82,7 +82,7 @@ export const SettingsDialog = () => {
         showCloseButton={false}
         className="w-full p-0 gap-0 sm:max-w-[60dvw] h-full max-h-[70dvh] flex"
       >
-        <Card className="w-56 shrink-0 p-0 border-0 rounded-l-xl rounded-r-none gap-0">
+        <Card className="w-56 shrink-0 p-0 border-0 rounded-none rounded-l-xl gap-0">
           <CardHeader className="p-3 flex-row items-center justify-between">
             <div className="flex items-center gap-2">
               <Sparkles className="size-4 text-primary" />

--- a/src/components/settings/theme-section.tsx
+++ b/src/components/settings/theme-section.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import { readFile } from '@tauri-apps/plugin-fs';
-import { useTranslation } from '@/lib/i18n';
 import { ImagePlus, X } from 'lucide-react';
 import { type RefObject, useEffect, useRef, useState } from 'react';
 import { useBoolean, useOnClickOutside } from 'usehooks-ts';
 import { useTheme } from '@/hooks/use-theme';
+import { useTranslation } from '@/lib/i18n';
 import { cn } from '@/lib/utils';
 import type { Profile } from '@/services/profile-service';
 import { useProfileStore } from '@/stores/profile-store';
@@ -48,7 +48,7 @@ function BackgroundPreview({ background }: { background: Profile['defaultBackgro
 
   if (!background) {
     return (
-      <div className="size-full bg-gradient-to-br from-slate-700 via-slate-800 to-slate-900" />
+      <div className="size-full bg-linear-to-br from-slate-700 via-slate-800 to-slate-900" />
     );
   }
 
@@ -148,15 +148,15 @@ export function ThemeSection() {
                 >
                   {profile.name}
                 </Button>
-                {profiles.length > 1 && (
+                {profile.id !== 'default' && profiles.length > 1 && (
                   <button
                     onClick={(e) => {
                       e.stopPropagation();
                       removeProfile(profile.id);
                     }}
-                    className="absolute -top-1 -right-1 hidden group-hover:flex size-4 rounded-full bg-destructive text-destructive-foreground items-center justify-center"
+                    className="absolute p-0 -top-1 -right-1 opacity-0 group-hover:opacity-100 transition-opacity size-3 rounded-full bg-destructive text-destructive-foreground flex items-center justify-center shadow-sm"
                   >
-                    <X className="size-2.5" />
+                    <X className="size-3" />
                   </button>
                 )}
               </div>

--- a/src/components/text-editor-bubble-menu.tsx
+++ b/src/components/text-editor-bubble-menu.tsx
@@ -48,7 +48,8 @@ function TextEditorBubbleMenu({
       >
         {items.map((item, idx) => (
           <ToggleGroupItem
-            className="rounded"
+            size="sm"
+            className="rounded h-6 min-h-6"
             key={idx}
             value={String(idx)}
             onPressedChange={() => item.action()}

--- a/src/components/text-editor-bubble-menu.tsx
+++ b/src/components/text-editor-bubble-menu.tsx
@@ -21,6 +21,7 @@ function TextEditorBubbleMenu({
   ...props
 }: TextEditorBubbleMenuProps) {
   const editor = editorRef.current?.editor;
+  // TODO: Resolve bubble menu style and functionality
 
   if (!editor) return null;
 

--- a/src/components/text-editor-bubble-menu.tsx
+++ b/src/components/text-editor-bubble-menu.tsx
@@ -1,6 +1,7 @@
 import { BubbleMenu } from '@tiptap/react/menus';
 import type { ComponentProps, ReactNode, RefObject } from 'react';
 import type { TextEditorRef } from '@/components/text-editor';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { cn } from '@/lib/utils';
 
 export type BubbleMenuItem = {
@@ -21,9 +22,12 @@ function TextEditorBubbleMenu({
   ...props
 }: TextEditorBubbleMenuProps) {
   const editor = editorRef.current?.editor;
-  // TODO: Resolve bubble menu style and functionality
 
   if (!editor) return null;
+
+  const pressedValues = items
+    .map((item, idx) => (item.active ? String(idx) : null))
+    .filter((v): v is string => v !== null);
 
   return (
     <BubbleMenu
@@ -35,19 +39,24 @@ function TextEditorBubbleMenu({
       )}
       {...props}
     >
-      {items.map((item) => (
-        <button
-          key={String(item.children)}
-          type="button"
-          onClick={item.action}
-          className={cn(
-            'inline-flex size-7 items-center justify-center rounded-md text-sm transition-colors hover:bg-muted',
-            item.active && 'bg-muted text-foreground'
-          )}
-        >
-          {item.children}
-        </button>
-      ))}
+      <ToggleGroup
+        className="gap-1"
+        variant="secondary"
+        size="sm"
+        value={pressedValues}
+        onValueChange={() => { }}
+      >
+        {items.map((item, idx) => (
+          <ToggleGroupItem
+            className="rounded"
+            key={idx}
+            value={String(idx)}
+            onPressedChange={() => item.action()}
+          >
+            {item.children}
+          </ToggleGroupItem>
+        ))}
+      </ToggleGroup>
     </BubbleMenu>
   );
 }

--- a/src/components/text-editor-toolbar.tsx
+++ b/src/components/text-editor-toolbar.tsx
@@ -35,7 +35,7 @@ type TextEditorToolbarProps = ComponentProps<'div'> & {
 function useEditorState(editorRef: RefObject<TextEditorRef | null>) {
   const subscribe = (callback: () => void) => {
     const editor = editorRef.current?.editor;
-    if (!editor) return () => {};
+    if (!editor) return () => { };
     editor.on('transaction', callback);
     editor.on('selectionUpdate', callback);
     return () => {

--- a/src/components/text-editor.tsx
+++ b/src/components/text-editor.tsx
@@ -126,7 +126,7 @@ const TextEditor = forwardRef<TextEditorRef, TextEditorProps>(
         {children}
         <EditorContent
           editor={editor}
-          className="prose prose-sm flex-1 h-full w-full dark:prose-invert max-w-none size-full [&_.tiptap]:size-full [&_.tiptap]:p-4 [&_.tiptap_p.is-editor-empty:first-child::before]:text-muted-foreground [&_.tiptap_p.is-editor-empty:first-child::before]:content-[attr(data-placeholder)] [&_.tiptap_p.is-editor-empty:first-child::before]:float-left [&_.tiptap_p.is-editor-empty:first-child::before]:h-0 [&_.tiptap_p.is-editor-empty:first-child::before]:pointer-events-none"
+          className="prose prose-sm dark:prose-invert max-w-none flex-1 h-full w-full size-full [&_.tiptap]:size-full [&_.tiptap]:p-4 [&_.tiptap_p.is-editor-empty:first-child::before]:text-muted-foreground [&_.tiptap_p.is-editor-empty:first-child::before]:content-[attr(data-placeholder)] [&_.tiptap_p.is-editor-empty:first-child::before]:float-left [&_.tiptap_p.is-editor-empty:first-child::before]:h-0 [&_.tiptap_p.is-editor-empty:first-child::before]:pointer-events-none [&_h1]:text-xl [&_h1]:font-bold [&_h2]:text-lg [&_h2]:font-bold [&_h3]:text-2lg [&_h3]:font-bold [&_h4]:text-lg [&_h4]:font-semibold [&_h5]:text-base [&_h5]:font-semibold [&_h6]:text-sm [&_h6]:font-semibold [&_ul]:list-disc [&_ul]:pl-6 [&_ol]:list-decimal [&_ol]:pl-6"
         />
       </div>
     );

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -17,7 +17,7 @@ const buttonVariants = cva(
         outline:
           'border border-input bg-background/55 shadow-xs hover:bg-accent hover:text-accent-foreground',
         secondary: 'bg-primary/5 text-secondary-foreground shadow-xs hover:bg-primary/10',
-        ghost: 'hover:bg-accent hover:bg-primary/10 duration-300',
+        ghost: 'hover:bg-accent/70 duration-300',
         link: 'text-primary underline-offset-4 hover:underline',
       },
       size: {

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -51,7 +51,7 @@ function ScrollBar({
       data-orientation={orientation}
       orientation={orientation}
       className={cn(
-        'flex touch-none p-px transition-colors select-none data-[orientation=horizontal]:h-2.5 data-[orientation=horizontal]:flex-col data-[orientation=horizontal]:border-t data-[orientation=horizontal]:border-t-transparent data-[orientation=vertical]:h-full data-[orientation=vertical]:w-2 data-[orientation=vertical]:border-l data-[orientation=vertical]:border-l-transparent opacity-0 data-[hovering]:opacity-100 data-[hovering]:delay-0 data-[hovering]:pointer-events-auto data-[scrolling]:opacity-100 data-[scrolling]:duration-0 data-[scrolling]:pointer-events-auto',
+        'flex touch-none p-px transition-colors select-none data-[orientation=horizontal]:h-2.5 data-[orientation=horizontal]:flex-col data-[orientation=horizontal]:border-t data-[orientation=horizontal]:border-t-transparent data-[orientation=vertical]:h-full data-[orientation=vertical]:w-2 data-[orientation=vertical]:border-l data-[orientation=vertical]:border-l-transparent opacity-0 data-hovering:opacity-100 data-hovering:delay-0 data-hovering:pointer-events-auto data-scrolling:opacity-100 data-scrolling:duration-0 data-scrolling:pointer-events-auto',
         className
       )}
       {...props}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { Tabs as TabsPrimitive } from '@base-ui/react/tabs';
+import { animate } from 'animejs';
 import { cva, type VariantProps } from 'class-variance-authority';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { cn } from '@/lib/utils';
 
@@ -65,31 +66,99 @@ function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
 
 function TabsIndicator({ className }: { className?: string }) {
   const ref = useRef<HTMLSpanElement>(null);
-  const [style, setStyle] = useState({ left: 0, width: 0 });
-  const [ready, setReady] = useState(false);
+  const animationRef = useRef<ReturnType<typeof animate> | null>(null);
+  const readyRef = useRef(false);
 
   useEffect(() => {
     const el = ref.current;
     if (!el) return;
 
+    let frame = 0;
+    let observedElements = new Set<Element>();
+
     const update = () => {
-      const parent = el.parentElement;
-      if (!parent) return;
-      const active = parent.querySelector<HTMLElement>('[data-slot="tabs-trigger"][data-active]');
+      const list = el.parentElement;
+      if (!list) return;
+
+      const active = list.querySelector<HTMLElement>('[data-slot="tabs-trigger"][data-active]');
       if (!active) return;
-      const parentRect = parent.getBoundingClientRect();
+
+      const anchor = el.offsetParent instanceof HTMLElement ? el.offsetParent : list;
+      const anchorRect = anchor.getBoundingClientRect();
       const activeRect = active.getBoundingClientRect();
-      setStyle({ left: activeRect.left - parentRect.left, width: activeRect.width });
-      setReady(true);
+      const left = activeRect.left - anchorRect.left;
+      const width = activeRect.width;
+
+      if (!readyRef.current) {
+        animationRef.current?.cancel();
+        el.style.opacity = '1';
+        el.style.left = `${left}px`;
+        el.style.width = `${width}px`;
+        readyRef.current = true;
+        return;
+      }
+
+      animationRef.current?.cancel();
+      animationRef.current = animate(el, {
+        left: `${left}px`,
+        width: `${width}px`,
+        opacity: 1,
+        duration: 250,
+        ease: 'outCubic',
+      });
     };
 
-    update();
+    const scheduleUpdate = () => {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(update);
+    };
 
-    const observer = new MutationObserver(update);
-    const parent = el.parentElement;
-    if (parent) observer.observe(parent, { subtree: true, attributeFilter: ['data-active'] });
+    const resizeObserver = new ResizeObserver(() => scheduleUpdate());
 
-    return () => observer.disconnect();
+    const observeLayoutElements = () => {
+      const list = el.parentElement;
+      if (!list) return;
+
+      const nextObserved = new Set<Element>([list]);
+      if (el.offsetParent) nextObserved.add(el.offsetParent);
+
+      list.querySelectorAll<HTMLElement>('[data-slot="tabs-trigger"]').forEach((trigger) => {
+        nextObserved.add(trigger);
+      });
+
+      observedElements.forEach((element) => {
+        if (!nextObserved.has(element)) resizeObserver.unobserve(element);
+      });
+
+      nextObserved.forEach((element) => {
+        if (!observedElements.has(element)) resizeObserver.observe(element);
+      });
+
+      observedElements = nextObserved;
+    };
+
+    observeLayoutElements();
+    scheduleUpdate();
+
+    const observer = new MutationObserver(() => {
+      observeLayoutElements();
+      scheduleUpdate();
+    });
+    const list = el.parentElement;
+    if (list) {
+      observer.observe(list, {
+        childList: true,
+        subtree: true,
+        attributeFilter: ['data-active'],
+      });
+    }
+
+    return () => {
+      cancelAnimationFrame(frame);
+      animationRef.current?.cancel();
+      observer.disconnect();
+      resizeObserver.disconnect();
+    };
   }, []);
 
   return (
@@ -97,10 +166,9 @@ function TabsIndicator({ className }: { className?: string }) {
       ref={ref}
       className={cn('absolute bottom-0 h-0.5 rounded-full', className)}
       style={{
-        opacity: ready ? 1 : 0,
-        left: style.left,
-        width: style.width,
-        transition: 'left 250ms ease, width 250ms ease',
+        opacity: 0,
+        left: 0,
+        width: 0,
       }}
     />
   );

--- a/src/hooks/use-announce.ts
+++ b/src/hooks/use-announce.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useCallback } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 /**
  * Custom hook for screen reader announcements

--- a/src/hooks/use-media-init.ts
+++ b/src/hooks/use-media-init.ts
@@ -16,7 +16,7 @@ export function useMediaInit(): UseMediaInitResult {
     async function initialize() {
       try {
         const isTauri = typeof window !== 'undefined' && '__TAURI__' in window;
-        
+
         if (!isTauri) {
           setState({ isInitialized: true, error: null });
           return;

--- a/src/lib/module-ui.ts
+++ b/src/lib/module-ui.ts
@@ -1,48 +1,6 @@
-import { Button, type ButtonProps } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
-import { Label } from "@/components/ui/label";
-import { Switch } from "@/components/ui/switch";
-import { Separator } from "@/components/ui/separator";
-import { Badge } from "@/components/ui/badge";
-import { Skeleton } from "@/components/ui/skeleton";
-import { Slider } from "@/components/ui/slider";
-import { Checkbox } from "@/components/ui/checkbox";
-import { Progress } from "@/components/ui/progress";
-import { Toggle, toggleVariants } from "@/components/ui/toggle";
-import { ToggleGroup as _ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
-import {
-  HoverCard as _HoverCard,
-  HoverCardContent,
-  HoverCardTrigger,
-} from "@/components/ui/hover-card";
-import { Kbd, KbdGroup } from "@/components/ui/kbd";
-import {
-  Combobox as _Combobox,
-  ComboboxInput,
-  ComboboxContent,
-  ComboboxList,
-  ComboboxItem,
-  ComboboxGroup,
-  ComboboxLabel,
-  ComboboxCollection,
-  ComboboxEmpty,
-  ComboboxSeparator,
-} from "@/components/ui/combobox";
-
-import {
-  Dialog as _Dialog,
-  DialogClose,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogOverlay,
-  DialogPortal,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog";
-
+import { TextEditor as _TextEditor, type TextEditorRef } from '@/components/text-editor';
+import { type BubbleMenuItem, TextEditorBubbleMenu } from '@/components/text-editor-bubble-menu';
+import { TextEditorToolbar } from '@/components/text-editor-toolbar';
 import {
   AlertDialog as _AlertDialog,
   AlertDialogAction,
@@ -56,8 +14,17 @@ import {
   AlertDialogPortal,
   AlertDialogTitle,
   AlertDialogTrigger,
-} from "@/components/ui/alert-dialog";
-
+} from '@/components/ui/alert-dialog';
+import {
+  Avatar as _Avatar,
+  AvatarBadge,
+  AvatarFallback,
+  AvatarGroup,
+  AvatarGroupCount,
+  AvatarImage,
+} from '@/components/ui/avatar';
+import { Badge } from '@/components/ui/badge';
+import { Button, type ButtonProps } from '@/components/ui/button';
 import {
   Card as _Card,
   CardContent,
@@ -65,45 +32,44 @@ import {
   CardFooter,
   CardHeader,
   CardTitle,
-} from "@/components/ui/card";
-
+} from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
 import {
-  Tabs as _Tabs,
-  TabsContent,
-  TabsIndicator,
-  TabsList,
-  TabsTrigger,
-} from "@/components/ui/tabs";
-
+  Combobox as _Combobox,
+  ComboboxCollection,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxGroup,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxLabel,
+  ComboboxList,
+  ComboboxSeparator,
+} from '@/components/ui/combobox';
 import {
-  Select as _Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectLabel,
-  SelectScrollDownButton,
-  SelectScrollUpButton,
-  SelectSeparator,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-
+  Dialog as _Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
 import {
-  Tooltip as _Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-
-import {
-  Popover as _Popover,
-  PopoverContent,
-  PopoverDescription,
-  PopoverHeader,
-  PopoverTitle,
-  PopoverTrigger,
-} from "@/components/ui/popover";
-
+  Drawer as _Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerOverlay,
+  DrawerPortal,
+  DrawerTitle,
+  DrawerTrigger,
+} from '@/components/ui/drawer';
 import {
   DropdownMenu as _DropdownMenu,
   DropdownMenuCheckboxItem,
@@ -120,8 +86,57 @@ import {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-
+} from '@/components/ui/dropdown-menu';
+import {
+  Empty as _Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from '@/components/ui/empty';
+import {
+  HoverCard as _HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from '@/components/ui/hover-card';
+import { Input } from '@/components/ui/input';
+import {
+  InputGroup as _InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+  InputGroupText,
+  InputGroupTextarea,
+} from '@/components/ui/input-group';
+import { Kbd, KbdGroup } from '@/components/ui/kbd';
+import { Label } from '@/components/ui/label';
+import {
+  Popover as _Popover,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { Progress } from '@/components/ui/progress';
+import { ScrollArea as _ScrollArea, ScrollBar } from '@/components/ui/scroll-area';
+import {
+  Select as _Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectScrollDownButton,
+  SelectScrollUpButton,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Separator } from '@/components/ui/separator';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Slider } from '@/components/ui/slider';
+import { Switch } from '@/components/ui/switch';
 import {
   Table as _Table,
   TableBody,
@@ -131,64 +146,23 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from "@/components/ui/table";
-
+} from '@/components/ui/table';
 import {
-  Avatar as _Avatar,
-  AvatarBadge,
-  AvatarFallback,
-  AvatarGroup,
-  AvatarGroupCount,
-  AvatarImage,
-} from "@/components/ui/avatar";
-
+  Tabs as _Tabs,
+  TabsContent,
+  TabsIndicator,
+  TabsList,
+  TabsTrigger,
+} from '@/components/ui/tabs';
+import { Textarea } from '@/components/ui/textarea';
+import { Toggle, toggleVariants } from '@/components/ui/toggle';
+import { ToggleGroup as _ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import {
-  Drawer as _Drawer,
-  DrawerClose,
-  DrawerContent,
-  DrawerDescription,
-  DrawerFooter,
-  DrawerHeader,
-  DrawerOverlay,
-  DrawerPortal,
-  DrawerTitle,
-  DrawerTrigger,
-} from "@/components/ui/drawer";
-
-import {
-  Empty as _Empty,
-  EmptyContent,
-  EmptyDescription,
-  EmptyHeader,
-  EmptyMedia,
-  EmptyTitle,
-} from "@/components/ui/empty";
-
-import {
-  InputGroup as _InputGroup,
-  InputGroupAddon,
-  InputGroupButton,
-  InputGroupInput,
-  InputGroupText,
-  InputGroupTextarea,
-} from "@/components/ui/input-group";
-
-import {
-  ScrollArea as _ScrollArea,
-  ScrollBar,
-} from "@/components/ui/scroll-area";
-
-import {
-  TextEditor as _TextEditor,
-  type TextEditorRef,
-} from "@/components/text-editor";
-
-import { TextEditorToolbar } from "@/components/text-editor-toolbar";
-
-import {
-  TextEditorBubbleMenu,
-  type BubbleMenuItem,
-} from "@/components/text-editor-bubble-menu";
+  Tooltip as _Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 
 const Dialog = Object.assign(_Dialog, {
   DialogClose,
@@ -351,40 +325,40 @@ const TextEditor = Object.assign(_TextEditor, {
 });
 
 export {
+  AlertDialog,
+  Avatar,
+  Badge,
+  type BubbleMenuItem,
   Button,
   type ButtonProps,
-  Input,
-  Textarea,
-  Label,
-  Switch,
-  Separator,
-  Badge,
-  Skeleton,
-  Slider,
+  Card,
   Checkbox,
-  Progress,
-  Toggle,
-  toggleVariants,
-  Kbd,
-  KbdGroup,
   Combobox,
   Dialog,
-  AlertDialog,
-  Card,
-  Tabs,
-  Select,
-  Tooltip,
-  Popover,
-  DropdownMenu,
-  Table,
-  Avatar,
   Drawer,
+  DropdownMenu,
   Empty,
+  HoverCard,
+  Input,
   InputGroup,
+  Kbd,
+  KbdGroup,
+  Label,
+  Popover,
+  Progress,
   ScrollArea,
+  Select,
+  Separator,
+  Skeleton,
+  Slider,
+  Switch,
+  Table,
+  Tabs,
+  Textarea,
   TextEditor,
   type TextEditorRef,
-  type BubbleMenuItem,
+  Toggle,
   ToggleGroup,
-  HoverCard,
+  Tooltip,
+  toggleVariants,
 };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,6 @@
-import { clsx, type ClassValue } from "clsx";
-import { twMerge } from "tailwind-merge";
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
 
 export function cn(...inputs: ClassValue[]) {
-	return twMerge(clsx(inputs));
+  return twMerge(clsx(inputs));
 }

--- a/src/services/app-paths.ts
+++ b/src/services/app-paths.ts
@@ -34,6 +34,11 @@ export async function getProfilesPath(): Promise<string> {
   return join(base, 'config', 'profiles');
 }
 
+export async function getNotesPath(): Promise<string> {
+  const base = await getAppBasePath();
+  return join(base, 'files', 'notes');
+}
+
 export async function getDbPath(): Promise<string> {
   const base = await getAppBasePath();
   const dbFile = await join(base, 'lumen.db');

--- a/src/services/notes-service.ts
+++ b/src/services/notes-service.ts
@@ -1,0 +1,27 @@
+import { join } from '@tauri-apps/api/path';
+import { exists, mkdir, readTextFile, writeTextFile } from '@tauri-apps/plugin-fs';
+import { getNotesPath } from './app-paths';
+
+class NotesService {
+  async loadNotes(profileId: string): Promise<string> {
+    const filePath = await this.#getFilePath(profileId);
+    if (!(await exists(filePath))) return '';
+    return readTextFile(filePath);
+  }
+
+  async saveNotes(profileId: string, content: string): Promise<void> {
+    const dir = await getNotesPath();
+    if (!(await exists(dir))) {
+      await mkdir(dir, { recursive: true });
+    }
+    const filePath = await join(dir, `${profileId}.md`);
+    await writeTextFile(filePath, content);
+  }
+
+  async #getFilePath(profileId: string): Promise<string> {
+    const dir = await getNotesPath();
+    return join(dir, `${profileId}.md`);
+  }
+}
+
+export const notesService = new NotesService();

--- a/src/stores/profile-store.ts
+++ b/src/stores/profile-store.ts
@@ -106,7 +106,7 @@ export const useProfileStore = create<ProfileState>((set, get) => ({
 
   removeProfile: async (id) => {
     const { profiles, activeProfileId } = get();
-    if (profiles.length <= 1) return;
+    if (id === 'default' || profiles.length <= 1) return;
     await deleteProfileFile(id);
     const remaining = profiles.filter((p) => p.id !== id);
     let newActiveId = activeProfileId;


### PR DESCRIPTION
## 📋 Description

Bugfix and refactor batch across the application.

### What was changed?
- **Notes Editor**: Added rich text editor with bubble menu; fixed heading/list styles and toggle behavior
- **Notes Persistence**: Per-profile persistent notes saved as markdown files
- **Themes Tab**: Functional themes tab with thumbnails and profile background selection
- **Avatar & Profile Switcher**: Dynamic avatar with profile switcher dropdown and device count badge; protected default profile from removal, fixed remove button hover visibility
- **Image Viewer**: Implemented using readFile + blob URL, context menu Open item; refactored media panel handlers
- **Tab Indicator**: Fixed position loss on panel resize using animeJS + ResizeObserver
- **Media Window**: Stabilized presenter lifecycle
- **Queue UI**: Adjusted hover opacity on queue items and ghost buttons; removed horizontal padding
- **Lint**: Applied lint fixes across the codebase

### Why?
Multiple bugs and UI inconsistencies identified across notes, themes, profiles, media, and queue areas. This batch addresses them together with the corresponding feature implementations.

## 🔗 Related Issues

- Closes #63
- Closes #60
- Closes #59
- Closes #61
- Closes #62
- Closes #64
- Closes #65
- Closes #66
- Closes #67
- Closes #68

## 🧪 How to Test

**Before:**
- Notes tab had no editor or persistence
- Tab indicator lost position on resize
- Default profile could be removed
- No image viewer for media files
- Themes tab was non-functional

**After:**
- Notes tab has rich text editor with working bubble menu and per-profile markdown persistence
- Tab indicator follows correctly on panel resize
- Default profile cannot be removed; remove button visible on hover
- Images open in viewer via readFile blob URL or context menu
- Themes tab shows thumbnails and allows background selection
- Avatar shows profile switcher with device count badge
- Media window presenter lifecycle is stable
- Queue items have correct hover styling

## 📸 Screenshots / Recording

<!-- Logs, screenshots, or GIFs that demonstrate the fix. -->

## ✅ Checklist

- [ ] Main flow tested manually
- [ ] Checked for regressions in adjacent areas
- [ ] Behavior differences between dev and prod documented (if any)
- [ ] Tests added or updated
- [ ] Self-reviewed

## 📝 Additional Notes

<!-- Known risks, trade-offs, follow-ups, or out-of-scope items. -->