### PR TITLE
Refactor: audio playback, store helpers, and presenter controls slot

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -325,7 +325,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .plugin(tauri_plugin_fs::init())
         .plugin(
             tauri_plugin_window_state::Builder::new()
-                .with_state_flags(StateFlags::all() & !StateFlags::DECORATIONS)
+                .with_state_flags(StateFlags::all() & !StateFlags::DECORATIONS & !StateFlags::VISIBLE)
                 .build(),
         )
         .plugin(tauri_plugin_log::Builder::new().build())
@@ -436,7 +436,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             .show(move |keep_in_background| {
                                 if keep_in_background {
                                     let _ = app.save_window_state(
-                                        StateFlags::all() & !StateFlags::DECORATIONS,
+                                        StateFlags::all() & !StateFlags::DECORATIONS & !StateFlags::VISIBLE,
                                     );
                                     let _ = win.hide();
                                 } else {

--- a/src/app/media-window.tsx
+++ b/src/app/media-window.tsx
@@ -313,8 +313,6 @@ function MediaWindowComponent() {
 
       if (appWindow) {
         await setDecorations(false);
-        await appWindow.show();
-        await appWindow.setFullscreen(true);
         setIsFullscreen(true);
       }
     } catch (error) {

--- a/src/components/presenter-controls.tsx
+++ b/src/components/presenter-controls.tsx
@@ -766,6 +766,8 @@ function PresenterSequence({
   sequenceRef,
   sequenceContentRef,
   isMinimized,
+  active,
+  totalItems,
 }: {
   kind: PresenterKind;
   lyricData: LyricData | null;
@@ -776,6 +778,8 @@ function PresenterSequence({
   sequenceRef: React.RefObject<HTMLDivElement | null>;
   sequenceContentRef: React.RefObject<HTMLDivElement | null>;
   isMinimized: boolean;
+  active: boolean;
+  totalItems: number;
 }) {
   return (
     <div
@@ -815,7 +819,12 @@ function PresenterSequence({
           </div>
           <ScrollBar orientation="horizontal" />
         </ScrollArea>
-        <PresenterControlsSlot />
+        <PresenterControlsSlot
+          kind={kind}
+          active={active}
+          slideIndex={lyricSlideIndex}
+          totalSlides={totalItems}
+        />
       </div>
     </div>
   );
@@ -969,6 +978,8 @@ export function PresenterControls({ className }: PresenterControlsProps) {
         sequenceRef={sequenceRef}
         sequenceContentRef={sequenceContentRef}
         isMinimized={isMinimized}
+        active={presenter.active}
+        totalItems={totalItems}
       />
     </Card>
   );

--- a/src/components/presenter-controls.tsx
+++ b/src/components/presenter-controls.tsx
@@ -17,6 +17,7 @@ import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { useTranslation } from '@/lib/i18n';
 import { cn } from '@/lib/utils';
+import { PresenterControlsSlot } from '@/modules/components/PresenterControlsSlot';
 import { useModuleStore } from '@/modules/store';
 import type { StageBackdropChangeDetail } from '@/modules/types';
 import { type LyricData, type LyricSlide, lyricService } from '@/services/lyric-service';
@@ -63,12 +64,15 @@ type PresenterShortcutEvent =
   | 'presenter:exit';
 
 function emitPresenterEvent(event: PresenterShortcutEvent) {
-  emit(event).catch(() => {});
+  emit(event).catch(() => { });
 }
 
 function fileNameFromPath(path: string | null | undefined) {
   if (!path) return undefined;
-  return path.split(/[\\/]/).pop()?.replace(/\.[^/.]+$/, '');
+  return path
+    .split(/[\\/]/)
+    .pop()
+    ?.replace(/\.[^/.]+$/, '');
 }
 
 function getInitialPresenterState(): PresenterState {
@@ -714,7 +718,11 @@ function PresenterShortcuts({
           className={shortcutButtonClass}
           onClick={onClick}
         >
-          {Icon ? <Icon className="size-3" /> : <ShortcutLabel shortcut={shortcut} label={t(label)} />}
+          {Icon ? (
+            <Icon className="size-3" />
+          ) : (
+            <ShortcutLabel shortcut={shortcut} label={t(label)} />
+          )}
           {Icon ? t(label) : null}
         </Button>
       ))}
@@ -785,28 +793,29 @@ function PresenterSequence({
           <div className="flex gap-3 px-1 pb-3 pt-1">
             {kind === 'lyrics' && lyricData
               ? lyricItems.map((slide, index) => (
-                  <LyricSequenceThumbnail
-                    key={`${index}-${slide.lines.join('|')}`}
-                    slide={slide}
-                    isSelected={lyricSlideIndex === index}
-                    lyricData={lyricData}
-                    profileBackground={profileBackground}
-                    onClick={() => {
-                      emit('lyric-start-slide', { startIndex: index }).catch(() => {});
-                      emit('presenter:select-slide', { kind, index }).catch(() => {});
-                    }}
-                  />
-                ))
+                <LyricSequenceThumbnail
+                  key={`${index}-${slide.lines.join('|')}`}
+                  slide={slide}
+                  isSelected={lyricSlideIndex === index}
+                  lyricData={lyricData}
+                  profileBackground={profileBackground}
+                  onClick={() => {
+                    emit('lyric-start-slide', { startIndex: index }).catch(() => { });
+                    emit('presenter:select-slide', { kind, index }).catch(() => { });
+                  }}
+                />
+              ))
               : fallbackSlides.map((slide, index) => (
-                  <FallbackSequenceThumbnail
-                    key={slide.id}
-                    slide={slide}
-                    onClick={() => emit('presenter:select-slide', { kind, index }).catch(() => {})}
-                  />
-                ))}
+                <FallbackSequenceThumbnail
+                  key={slide.id}
+                  slide={slide}
+                  onClick={() => emit('presenter:select-slide', { kind, index }).catch(() => { })}
+                />
+              ))}
           </div>
           <ScrollBar orientation="horizontal" />
         </ScrollArea>
+        <PresenterControlsSlot />
       </div>
     </div>
   );
@@ -832,9 +841,8 @@ export function PresenterControls({ className }: PresenterControlsProps) {
   });
 
   useEffect(() => {
-    const unlistenDisplayState = listen<PresenterDisplayState>(
-      'presenter:display-state',
-      (event) => setDisplayState(event.payload)
+    const unlistenDisplayState = listen<PresenterDisplayState>('presenter:display-state', (event) =>
+      setDisplayState(event.payload)
     );
 
     return () => {
@@ -844,9 +852,9 @@ export function PresenterControls({ className }: PresenterControlsProps) {
 
   const activeDisplayModes = useMemo(
     () =>
-      (Object.entries(displayState)
+      Object.entries(displayState)
         .filter(([, active]) => active)
-        .map(([key]) => key) as PresenterDisplayMode[]),
+        .map(([key]) => key) as PresenterDisplayMode[],
     [displayState]
   );
 
@@ -866,10 +874,10 @@ export function PresenterControls({ className }: PresenterControlsProps) {
       if (nextIndex === currentIndex) return;
 
       if (presenter.kind === 'lyrics') {
-        emit('lyric-start-slide', { startIndex: nextIndex }).catch(() => {});
+        emit('lyric-start-slide', { startIndex: nextIndex }).catch(() => { });
       }
 
-      emit('presenter:select-slide', { kind: presenter.kind, index: nextIndex }).catch(() => {});
+      emit('presenter:select-slide', { kind: presenter.kind, index: nextIndex }).catch(() => { });
     },
     [currentIndex, presenter.kind, totalItems]
   );

--- a/src/modules/components/PresenterControlsSlot.tsx
+++ b/src/modules/components/PresenterControlsSlot.tsx
@@ -1,0 +1,50 @@
+import { useMemo } from 'react';
+import type React from 'react';
+import { useModuleStore } from '../store';
+import type { PanelProps, PanelSpec } from '../types';
+import { ModuleErrorBoundary } from './ModuleErrorBoundary';
+
+interface PresenterControlsSlotProps {
+  panelProps?: PanelProps;
+}
+
+type SlotPanel = {
+  moduleId: string;
+  spec: PanelSpec;
+};
+
+export function PresenterControlsSlot({ panelProps = {} }: PresenterControlsSlotProps) {
+  const panelMap = useModuleStore((s) => s.panels);
+  const panels = useMemo(() => {
+    const result: SlotPanel[] = [];
+
+    for (const [moduleId, specs] of panelMap.entries()) {
+      for (const spec of specs) {
+        if (spec.slot === 'presenter.controls.item') {
+          result.push({ moduleId, spec });
+        }
+      }
+    }
+
+    return result;
+  }, [panelMap]);
+
+  if (panels.length === 0) return null;
+
+  return (
+    <>
+      {panels.map(({ moduleId, spec }, index) => {
+        if (spec.when && !spec.when()) return null;
+
+        const Component = spec.component as React.ComponentType<PanelProps>;
+        const panelKey = `${moduleId}:${spec.id}:${index}`;
+
+        return (
+          <ModuleErrorBoundary key={panelKey} moduleId={moduleId} panelId={spec.id}>
+            <Component {...panelProps} />
+          </ModuleErrorBoundary>
+        );
+      })}
+    </>
+  );
+}

--- a/src/modules/components/PresenterControlsSlot.tsx
+++ b/src/modules/components/PresenterControlsSlot.tsx
@@ -1,11 +1,14 @@
 import { useMemo } from 'react';
 import type React from 'react';
 import { useModuleStore } from '../store';
-import type { PanelProps, PanelSpec } from '../types';
+import type { PanelSpec } from '../types';
 import { ModuleErrorBoundary } from './ModuleErrorBoundary';
 
-interface PresenterControlsSlotProps {
-  panelProps?: PanelProps;
+export interface PresenterControlsSlotProps {
+  kind: 'lyrics' | 'image' | 'presentation' | null;
+  active: boolean;
+  slideIndex: number;
+  totalSlides: number;
 }
 
 type SlotPanel = {
@@ -13,7 +16,7 @@ type SlotPanel = {
   spec: PanelSpec;
 };
 
-export function PresenterControlsSlot({ panelProps = {} }: PresenterControlsSlotProps) {
+export function PresenterControlsSlot({ kind, active, slideIndex, totalSlides }: PresenterControlsSlotProps) {
   const panelMap = useModuleStore((s) => s.panels);
   const panels = useMemo(() => {
     const result: SlotPanel[] = [];
@@ -36,12 +39,12 @@ export function PresenterControlsSlot({ panelProps = {} }: PresenterControlsSlot
       {panels.map(({ moduleId, spec }, index) => {
         if (spec.when && !spec.when()) return null;
 
-        const Component = spec.component as React.ComponentType<PanelProps>;
+        const Component = spec.component as unknown as React.ComponentType<PresenterControlsSlotProps>;
         const panelKey = `${moduleId}:${spec.id}:${index}`;
 
         return (
           <ModuleErrorBoundary key={panelKey} moduleId={moduleId} panelId={spec.id}>
-            <Component {...panelProps} />
+            <Component kind={kind} active={active} slideIndex={slideIndex} totalSlides={totalSlides} />
           </ModuleErrorBoundary>
         );
       })}

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -7,6 +7,7 @@ export interface Disposable {
 export type SlotName =
   | 'dialog'
   | 'presenter.content'
+  | 'presenter.controls.item'
   | 'sidebar.right.tabs'
   | 'app.header.trailing';
 

--- a/src/stores/player-store.ts
+++ b/src/stores/player-store.ts
@@ -1,5 +1,6 @@
 import { invoke } from '@tauri-apps/api/core';
 import { emit, listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { readFile } from '@tauri-apps/plugin-fs';
 import { WebviewWindow } from '@tauri-apps/api/webviewWindow';
 import { create } from 'zustand';
 import { getSetting, saveSetting } from '@/services/db';
@@ -57,6 +58,53 @@ let seekCommitTimeout: ReturnType<typeof setTimeout> | null = null;
 let pendingMute = false;
 const SOCKET_COMMIT_DEBOUNCE_MS = 150;
 const LIVE_STREAM_MIN_DURATION_SECONDS = 24 * 60 * 60;
+
+let audioElement: HTMLAudioElement | null = null;
+let audioBlobUrl: string | null = null;
+
+function getAudioPlayer(): HTMLAudioElement {
+  if (!audioElement) {
+    audioElement = new Audio();
+    audioElement.addEventListener('timeupdate', () => {
+      const store = usePlayerStore.getState();
+      if (store.isDragging) return;
+      if (audioElement && audioElement.duration) {
+        store.sendWs({
+          event: 'progress',
+          value: audioElement.currentTime,
+          duration: audioElement.duration,
+        });
+      }
+    });
+    audioElement.addEventListener('ended', () => {
+      usePlayerStore.getState().handleStop();
+    });
+  }
+  return audioElement;
+}
+
+async function playAudio(source: string, seekTime: number): Promise<void> {
+  const audio = getAudioPlayer();
+  audio.pause();
+  audio.src = '';
+  if (audioBlobUrl) {
+    URL.revokeObjectURL(audioBlobUrl);
+    audioBlobUrl = null;
+  }
+
+  if (seekTime > 0) {
+    const blobUrl = URL.createObjectURL(new Blob([await readFile(source)]));
+    audioBlobUrl = blobUrl;
+    audio.src = blobUrl;
+    audio.currentTime = seekTime;
+  } else {
+    const blobUrl = URL.createObjectURL(new Blob([await readFile(source)]));
+    audioBlobUrl = blobUrl;
+    audio.src = blobUrl;
+  }
+
+  await audio.play();
+}
 
 async function getMediaWindow() {
   return WebviewWindow.getByLabel('media-window');
@@ -314,7 +362,21 @@ export const usePlayerStore = create<PlayerStore>((set, get) => ({
   },
 
   handlePlayPause: async () => {
-    const { sendWs, isPlaying, restoredFilePath, localTime } = get();
+    const { sendWs, isPlaying, restoredFilePath, localTime, localMediaType } = get();
+
+    if (localMediaType === 'audio' && audioElement) {
+      if (audioElement.paused) {
+        await audioElement.play();
+        set({ isPlaying: true });
+        sendWs({ event: 'play_pause' });
+      } else {
+        audioElement.pause();
+        set({ isPlaying: false });
+        sendWs({ event: 'play_pause' });
+      }
+      void broadcastPlayerSync(get, 'play_pause');
+      return;
+    }
 
     if (restoredFilePath) {
       const seekTime = get().localTime;
@@ -340,7 +402,13 @@ export const usePlayerStore = create<PlayerStore>((set, get) => ({
   },
 
   handleStop: async () => {
-    const { sendWs } = get();
+    const { sendWs, localMediaType } = get();
+
+    if (localMediaType === 'audio' && audioElement) {
+      audioElement.pause();
+      audioElement.currentTime = 0;
+    }
+
     sendWs({ event: 'stop' });
     set({ localTime: 0, isPlaying: false });
     saveSetting('last_time', '0').catch(() => {});
@@ -382,6 +450,9 @@ export const usePlayerStore = create<PlayerStore>((set, get) => ({
   handleVolumeCommit: (value) => {
     const v = value[0] ?? get().volume;
     set({ volume: v });
+    if (audioElement) {
+      audioElement.volume = v / 100;
+    }
     if (volumeCommitTimeout) {
       clearTimeout(volumeCommitTimeout);
     }
@@ -397,6 +468,9 @@ export const usePlayerStore = create<PlayerStore>((set, get) => ({
     const { isMuted, sendWs } = get();
     pendingMute = true;
     set({ isMuted: !isMuted });
+    if (audioElement) {
+      audioElement.muted = !isMuted;
+    }
     sendWs({ event: 'mute' });
     void broadcastPlayerSync(get, 'mute');
   },
@@ -410,7 +484,10 @@ export const usePlayerStore = create<PlayerStore>((set, get) => ({
       try {
         await invoke('create_window', { label: 'media-window', title: 'Media Player' });
         const win = await getMediaWindow();
-        await win?.show();
+        if (win) {
+          await win.show();
+          await win.setFullscreen(true);
+        }
         set({ isScreenOpen: true });
       } catch {}
       return;
@@ -447,6 +524,12 @@ export const usePlayerStore = create<PlayerStore>((set, get) => ({
   handleSliderCommit: (value) => {
     const newTime = value[0] ?? get().localTime;
     set({ localTime: newTime, isDragging: false });
+
+    const { localMediaType } = get();
+    if (localMediaType === 'audio' && audioElement) {
+      audioElement.currentTime = newTime;
+    }
+
     if (seekCommitTimeout) {
       clearTimeout(seekCommitTimeout);
     }
@@ -462,6 +545,40 @@ export const usePlayerStore = create<PlayerStore>((set, get) => ({
   loadFile: async (filePath: string, seekTime = 0) => {
     const source = normalizeMediaSource(filePath);
     const isVideo = getMediaTypeFromPath(source) === 'video';
+
+    if (!isVideo) {
+      try {
+        await playAudio(source, seekTime);
+      } catch {
+        return;
+      }
+
+      const deadline = Date.now() + 3000;
+      while (get().ws?.readyState !== WebSocket.OPEN) {
+        if (Date.now() >= deadline) break;
+        await new Promise((r) => setTimeout(r, 50));
+      }
+
+      get().sendWs({ event: 'load_url', url: source, value: seekTime });
+      set({
+        isPlaying: true,
+        localMediaType: 'audio',
+        isLiveStream: false,
+        restoredFilePath: null,
+        currentFilePath: source,
+        currentLyricPath: null,
+        currentLyricSlideIndex: 0,
+        currentLyricTotalSlides: 0,
+        localTime: seekTime > 0 ? seekTime : 0,
+        localDuration: seekTime > 0 ? get().localDuration : 0,
+      });
+
+      saveSetting('last_media_path', source).catch(() => {});
+      saveSetting('last_media_type', 'audio').catch(() => {});
+      saveSetting('last_time', '0').catch(() => {});
+      void broadcastPlayerSync(get, 'load_url');
+      return;
+    }
 
     let win = await getMediaWindow();
     if (!win) {
@@ -484,7 +601,7 @@ export const usePlayerStore = create<PlayerStore>((set, get) => ({
     get().sendWs({ event: 'load_url', url: source, value: seekTime });
     set({
       isPlaying: true,
-      localMediaType: isVideo ? 'video' : 'audio',
+      localMediaType: 'video',
       isLiveStream: false,
       restoredFilePath: null,
       currentFilePath: source,
@@ -496,12 +613,13 @@ export const usePlayerStore = create<PlayerStore>((set, get) => ({
     });
 
     saveSetting('last_media_path', source).catch(() => {});
-    saveSetting('last_media_type', isVideo ? 'video' : 'audio').catch(() => {});
+    saveSetting('last_media_type', 'video').catch(() => {});
     saveSetting('last_time', '0').catch(() => {});
     void broadcastPlayerSync(get, 'load_url');
 
-    if (isVideo && win) {
+    if (win) {
       await win.show();
+      await win.setFullscreen(true);
       set({ isScreenOpen: true });
     }
   },
@@ -538,6 +656,7 @@ export const usePlayerStore = create<PlayerStore>((set, get) => ({
 
     if (win) {
       await win.show();
+      await win.setFullscreen(true);
       set({ isScreenOpen: true });
     }
   },
@@ -560,6 +679,7 @@ export const usePlayerStore = create<PlayerStore>((set, get) => ({
 
     if (win) {
       await win.show();
+      await win.setFullscreen(true);
       set({ isScreenOpen: true });
     }
   },

--- a/src/stores/player-store.ts
+++ b/src/stores/player-store.ts
@@ -1,14 +1,14 @@
 import { invoke } from '@tauri-apps/api/core';
 import { emit, listen, type UnlistenFn } from '@tauri-apps/api/event';
-import { readFile } from '@tauri-apps/plugin-fs';
 import { WebviewWindow } from '@tauri-apps/api/webviewWindow';
+import { readFile } from '@tauri-apps/plugin-fs';
 import { create } from 'zustand';
+import { useModuleStore } from '@/modules/store';
 import { getSetting, saveSetting } from '@/services/db';
 import { remoteSyncService } from '@/services/remote-sync-service';
 import { urlMediaService } from '@/services/url-media-service';
-import { useQueueStore } from '@/stores/queue-store';
 import { useQueueEntriesStore } from '@/stores/queue-entries-store';
-import { useModuleStore } from '@/modules/store';
+import { useQueueStore } from '@/stores/queue-store';
 
 interface PlayerStore {
   localTime: number;
@@ -68,7 +68,7 @@ function getAudioPlayer(): HTMLAudioElement {
     audioElement.addEventListener('timeupdate', () => {
       const store = usePlayerStore.getState();
       if (store.isDragging) return;
-      if (audioElement && audioElement.duration) {
+      if (audioElement?.duration) {
         store.sendWs({
           event: 'progress',
           value: audioElement.currentTime,
@@ -92,15 +92,12 @@ async function playAudio(source: string, seekTime: number): Promise<void> {
     audioBlobUrl = null;
   }
 
+  const blobUrl = URL.createObjectURL(new Blob([await readFile(source)]));
+  audioBlobUrl = blobUrl;
+  audio.src = blobUrl;
+
   if (seekTime > 0) {
-    const blobUrl = URL.createObjectURL(new Blob([await readFile(source)]));
-    audioBlobUrl = blobUrl;
-    audio.src = blobUrl;
     audio.currentTime = seekTime;
-  } else {
-    const blobUrl = URL.createObjectURL(new Blob([await readFile(source)]));
-    audioBlobUrl = blobUrl;
-    audio.src = blobUrl;
   }
 
   await audio.play();
@@ -136,6 +133,29 @@ async function waitForMediaWindowReady(timeoutMs = 3000): Promise<void> {
       finish(() => reject(new Error('Timed out waiting for media window readiness')));
     }, timeoutMs);
   });
+}
+
+async function ensureMediaWindow(): Promise<WebviewWindow | null> {
+  const existing = await getMediaWindow();
+  if (existing) return existing;
+
+  try {
+    const readyPromise = waitForMediaWindowReady();
+    await invoke('create_window', { label: 'media-window', title: 'Media Player' });
+    await readyPromise;
+    return await getMediaWindow();
+  } catch {
+    return null;
+  }
+}
+
+async function waitForWsOpen(get: () => PlayerStore, timeoutMs = 3000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (get().ws?.readyState !== WebSocket.OPEN) {
+    if (Date.now() >= deadline) return false;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  return true;
 }
 
 function normalizeMediaSource(source: string): string {
@@ -552,56 +572,23 @@ export const usePlayerStore = create<PlayerStore>((set, get) => ({
       } catch {
         return;
       }
-
-      const deadline = Date.now() + 3000;
-      while (get().ws?.readyState !== WebSocket.OPEN) {
-        if (Date.now() >= deadline) break;
-        await new Promise((r) => setTimeout(r, 50));
-      }
-
-      get().sendWs({ event: 'load_url', url: source, value: seekTime });
-      set({
-        isPlaying: true,
-        localMediaType: 'audio',
-        isLiveStream: false,
-        restoredFilePath: null,
-        currentFilePath: source,
-        currentLyricPath: null,
-        currentLyricSlideIndex: 0,
-        currentLyricTotalSlides: 0,
-        localTime: seekTime > 0 ? seekTime : 0,
-        localDuration: seekTime > 0 ? get().localDuration : 0,
-      });
-
-      saveSetting('last_media_path', source).catch(() => {});
-      saveSetting('last_media_type', 'audio').catch(() => {});
-      saveSetting('last_time', '0').catch(() => {});
-      void broadcastPlayerSync(get, 'load_url');
-      return;
+      await waitForWsOpen(get);
     }
 
-    let win = await getMediaWindow();
-    if (!win) {
-      try {
-        const readyPromise = waitForMediaWindowReady();
-        await invoke('create_window', { label: 'media-window', title: 'Media Player' });
-        await readyPromise;
-        win = await getMediaWindow();
-      } catch {
-        return;
-      }
-    }
-
-    const deadline = Date.now() + 3000;
-    while (get().ws?.readyState !== WebSocket.OPEN) {
-      if (Date.now() >= deadline) return;
-      await new Promise((r) => setTimeout(r, 50));
+    if (isVideo) {
+      const win = await ensureMediaWindow();
+      if (!win) return;
+      const ok = await waitForWsOpen(get);
+      if (!ok) return;
+      await win.show();
+      await win.setFullscreen(true);
+      set({ isScreenOpen: true });
     }
 
     get().sendWs({ event: 'load_url', url: source, value: seekTime });
     set({
       isPlaying: true,
-      localMediaType: 'video',
+      localMediaType: isVideo ? 'video' : 'audio',
       isLiveStream: false,
       restoredFilePath: null,
       currentFilePath: source,
@@ -613,35 +600,17 @@ export const usePlayerStore = create<PlayerStore>((set, get) => ({
     });
 
     saveSetting('last_media_path', source).catch(() => {});
-    saveSetting('last_media_type', 'video').catch(() => {});
+    saveSetting('last_media_type', isVideo ? 'video' : 'audio').catch(() => {});
     saveSetting('last_time', '0').catch(() => {});
     void broadcastPlayerSync(get, 'load_url');
-
-    if (win) {
-      await win.show();
-      await win.setFullscreen(true);
-      set({ isScreenOpen: true });
-    }
   },
 
   presentLyric: async (filePath: string, startIndex = 0) => {
-    let win = await getMediaWindow();
-    if (!win) {
-      try {
-        const readyPromise = waitForMediaWindowReady();
-        await invoke('create_window', { label: 'media-window', title: 'Media Player' });
-        await readyPromise;
-        win = await getMediaWindow();
-      } catch {
-        return;
-      }
-    }
+    const win = await ensureMediaWindow();
+    if (!win) return;
 
-    const deadline = Date.now() + 3000;
-    while (get().ws?.readyState !== WebSocket.OPEN) {
-      if (Date.now() >= deadline) return;
-      await new Promise((r) => setTimeout(r, 50));
-    }
+    const ok = await waitForWsOpen(get);
+    if (!ok) return;
 
     await emit('load-lyric', { url: filePath });
     get().sendWs({ event: 'load_lyric', url: filePath, startIndex });
@@ -654,34 +623,21 @@ export const usePlayerStore = create<PlayerStore>((set, get) => ({
     });
     void broadcastPlayerSync(get, 'load_lyric');
 
-    if (win) {
-      await win.show();
-      await win.setFullscreen(true);
-      set({ isScreenOpen: true });
-    }
+    await win.show();
+    await win.setFullscreen(true);
+    set({ isScreenOpen: true });
   },
 
   presentImage: async (filePath: string) => {
-    let win = await getMediaWindow();
-    if (!win) {
-      try {
-        const readyPromise = waitForMediaWindowReady();
-        await invoke('create_window', { label: 'media-window', title: 'Media Player' });
-        await readyPromise;
-        win = await getMediaWindow();
-      } catch {
-        return;
-      }
-    }
+    const win = await ensureMediaWindow();
+    if (!win) return;
 
     await emit('load-image', { url: filePath });
     set({ currentImagePath: filePath, currentLyricPath: null });
 
-    if (win) {
-      await win.show();
-      await win.setFullscreen(true);
-      set({ isScreenOpen: true });
-    }
+    await win.show();
+    await win.setFullscreen(true);
+    set({ isScreenOpen: true });
   },
 
   restoreLastMedia: async () => {


### PR DESCRIPTION
## 📋 Description

Refactor and optimization of the player store with audio playback improvements and module slot addition.

### What was changed?
- **player-store.ts**: Replaced react-player dependency for audio with local \HTMLAudioElement\ (readFile + blob URL). Extracted duplicated patterns into \nsureMediaWindow()\ and \waitForWsOpen()\ helpers. Unified setState/saveSettings in \loadFile\.
- **media-window.tsx**: Removed \show()\ and \setFullscreen()\ from \nsureDefaultWindowMode\ — window no longer auto-shows on mount.
- **presenter-controls.tsx**: Added \PresenterControlsSlot\ for module panel integration. Slot receives typed props (\kind\, \ctive\, \slideIndex\, \	otalSlides\).
- **modules/types.ts**: Added \presenter.controls.item\ slot name.
- **modules/components/PresenterControlsSlot.tsx**: New component rendering registered panels for the slot.
- **main.rs**: Excluded \StateFlags::VISIBLE\ from window state to prevent restored windows from auto-showing before fullscreen activation.

### Why?
- Audio files no longer require opening the media window (no black screen for audio-only playback).
- Reduced code duplication by extracting helpers used in \loadFile\, \presentLyric\, \presentImage\.
- Module SDK integration allows third-party modules to add custom content to the presenter controls bar.

## 🔗 Related Issues

- Relates to module SDK slot expansion

## 🧪 How to Test

**Before:**
1. Playing an audio file opened a blank media window unnecessarily.
2. Duplicated window-creation and WS-wait code in 4+ call sites.

**After:**
1. Audio plays locally without creating the media window.
2. Common patterns extracted into reusable helpers.
3. Modules can register \presenter.controls.item\ panels.

## ✅ Checklist

- [x] Main flow tested manually
- [x] Checked for regressions in adjacent areas
- [x] Behavior differences between dev and prod documented (if any)
- [x] Self-reviewed