### PR TITLE
refactor(module-system): surface window reliability, module loading perf and module API extensions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/fix-refactor.md
+++ b/.github/PULL_REQUEST_TEMPLATE/fix-refactor.md
@@ -18,25 +18,29 @@ Bugfix or refactor. Summarize the change objectively.
 ## 🧪 How to Test
 
 **Before:**
-1.
-2.
+1. Step to reproduce the bug / current behavior.
+2. Expected (buggy/old) result.
 
 **After:**
-1.
-2.
+1. Steps to validate the fix (flows, flags, user roles).
+2. Edge cases or regressions to check.
+3. Expected result.
 
-## 📸 Screenshots / Recording
+## 📸 Screenshots / Evidence
 
-<!-- Logs, screenshots, or GIFs that demonstrate the fix. -->
+<!-- If applicable, add logs, screenshots, or GIFs demonstrating the fix -->
 
 ## ✅ Checklist
 
+- [ ] Bug reproduced before the change (if applicable)
 - [ ] Main flow tested manually
-- [ ] Checked for regressions in adjacent areas
+- [ ] Edge cases / adjacent areas checked for regressions
 - [ ] Behavior differences between dev and prod documented (if any)
+- [ ] Docs or release notes updated (if applicable)
 - [ ] Tests added or updated
+- [ ] All tests passing
 - [ ] Self-reviewed
 
 ## 📝 Additional Notes
 
-<!-- Known risks, trade-offs, follow-ups, or out-of-scope items. -->
+<!-- Known risks, trade-offs, planned follow-ups, or out-of-scope limits -->

--- a/docs/architecture/system-fonts-font-weights.md
+++ b/docs/architecture/system-fonts-font-weights.md
@@ -1,0 +1,82 @@
+# System Fonts & Font Weights — Architecture Design
+
+## Overview
+
+Lumen needs to enumerate installed system fonts and, for module UIs, know which **font weights** (e.g., 100–900) are available per font family so modules can render a weight selector (regular, bold, etc.).
+
+Today `get_system_fonts` (`src-tauri/src/main.rs`) returns only **family names** as `Vec<String>`, using the `font_loader` crate:
+
+```rust
+fn get_system_fonts() -> Vec<String> {
+    let mut families: Vec<String> = font_loader::system_fonts::query_all();
+    families.sort_unstable();
+    families.dedup();
+    families
+}
+```
+
+The `font_loader` crate on Windows enumerates fonts via GDI (`EnumFontFamiliesExW`) and **discards per-face metadata** — `query_all()` / `query_specific()` return `Vec<String>` with no `weight`/`style`/`stretch`. This makes it impossible to answer "what weights does this family have?" with the current dependency.
+
+---
+
+## Requirements
+
+- Cross-platform: the app targets **Windows, macOS, and Linux**.
+- Modules need, per font family: list of available **weights** and **styles**.
+- Low risk: ideally no breaking change to the existing `FontsAPI.list()` contract consumed by modules.
+- Minimal performance impact: font enumeration happens once on demand, not on every render.
+
+---
+
+## Evaluated Options
+
+### 1. `fontdb` crate (pure Rust, cross-platform)
+
+- Adds `fontdb` to `Cargo.toml`; depends on `ttf-parser`, `log`, `memmap2`, `walkdir`, `libm` — the latter four are **already** in the lockfile. Only new crate: `ttf-parser`.
+- `Database::load_system_fonts()` + `.faces()` yields `family`, `weight` (100–900), `style`, `stretch`.
+- Same crate used by the resvg/usvg ecosystem.
+- **Trade-off:** enumerates by **scanning font files on disk** rather than querying the OS font catalog — felt "heavy/indirect" compared to a native API. Impact is negligible (one-time scan), but this was the deciding factor against proceeding now.
+
+### 2. Native APIs per OS (Windows: DirectWrite, macOS: CoreText, Linux: fontconfig)
+
+- No new crate on Windows — the `windows` crate is already a dependency; would add the `Win32_Graphics_DirectWrite` feature and ~60–80 lines of COM/`unsafe` code.
+- `IDWriteFontCollection::GetFontFamily` → `IDWriteFont::GetWeight()` (1–999), `GetStyle()`, `GetStretch()`.
+- **Trade-off:** Windows-only unless implemented per-OS (CoreText on macOS, fontconfig on Linux). More code, more maintenance.
+
+### 3. `font_loader` extended / alternative crate
+
+- Current `font_loader` (v0.11) cannot expose weights — rejected.
+- Other crates were not evaluated as better than `fontdb`.
+
+### 4. JS-only: `queryLocalFonts()` (WebView2/Chromium)
+
+- Exposes `family`, `weight`, `style` in the browser.
+- **Trade-off:** requires a secure context **and a user permission prompt**, which is unreliable inside the Tauri WebView. Rejected.
+
+---
+
+## Decision (as of now)
+
+**Deferred — not implemented.** The only cross-platform pure-Rust option (`fontdb`) scans font files directly instead of using the native OS font catalog, which was not deemed worth it for a weight selector. No code was changed; the existing `get_system_fonts` remains `Vec<String>`.
+
+If the weight-selector feature becomes a priority, the preferred path is **native APIs per OS** (DirectWrite on Windows + fontconfig on Linux + CoreText on macOS), keeping `font_loader` only when font **bytes** are needed, and exposing a new `FontsAPI.listDetailed()` alongside the existing `list()` to avoid breaking modules.
+
+---
+
+## Contract Considerations (future work)
+
+Changing `get_system_fonts` to return objects instead of `string[]` is a **breaking change** for the module contract:
+
+- Lumen consumers: `src/modules/apis/fonts.ts`, `src/hooks/use-local-fonts.ts`.
+- Installed modules (e.g., bible-module) call `fonts.list()` at `main.ts` and `store.ts`.
+- A new command `get_system_fonts_detailed` (or a new `FontsAPI.listDetailed()` method) is the additive, non-breaking route: old modules keep working, new ones use the rich shape.
+
+Proposed rich shape:
+
+```ts
+interface FontFamilyInfo {
+  family: string;
+  weights: number[];   // e.g. [100, 400, 700]
+  styles: string[];    // e.g. ["normal", "italic"]
+}
+```

--- a/docs/module-api-reference.md
+++ b/docs/module-api-reference.md
@@ -26,6 +26,17 @@ export default class MyModule extends LumenPlugin {
 }
 ```
 
+> **⚠️ Do not store host API objects in reactive state.** Host objects (`host.queue`, `host.presentation`, etc.) contain closures and internal references. Placing them in Zustand, Redux, `useState`, or any observable store triggers unnecessary comparisons on every state update, degrading performance. Store them in a plain `let` / `const` variable at module scope instead.
+>
+> ```ts
+> // ❌ Wrong — causes performance issues
+> useMyStore.getState().init({ queue: host.queue });
+>
+> // ✅ Right — module-level variable, no reactive overhead
+> let apiQueue: QueueHostAPI | null = null;
+> apiQueue = host.queue;
+> ```
+
 ### `manifest.json`
 
 ```json

--- a/docs/module-api-reference.md
+++ b/docs/module-api-reference.md
@@ -1094,6 +1094,54 @@ function TimerSummary({ value, onEdit }: { value: TimerConfig; onEdit: () => voi
 Returns a `Disposable` — registered trigger is removed on module unload.
 
 
+## `host.queue.registerAction`
+
+Registers a module-only action for programmatic use via `addTrigger`. Unlike `registerTrigger`, actions do **not** appear in the queue panel context menu — only the module itself can create queue instances through `addTrigger`.
+
+Actions serve as pure execution triggers controlled entirely by module code. The operator never sees or configures them.
+
+```ts
+host.queue.registerAction({
+  id: 'my-module.show-slide',
+  onFire(config) {
+    host.presentation.project('my-module-slide', { data: config });
+  },
+})
+
+// Later, from a component or handler:
+host.queue.addTrigger?.('my-module.show-slide', {
+  slideIndex: 3,
+  title: 'Announcements',
+})
+```
+
+### When to use `registerAction` vs `registerTrigger`
+
+| Use `registerAction` when... | Use `registerTrigger` when... |
+|---|---|
+| The module decides what and when to add | The operator decides what and when to add |
+| Config is pre-determined by module logic | Config must be chosen by the operator (dialog) |
+| No operator-facing UI is needed | Full config UI (`ConfigComponent`, `SummaryComponent`) is needed |
+| Examples: verse bookmark, quick-slide, auto-generated items | Examples: countdown timer, custom announcement builder |
+
+### `QueueActionSpec<T>`
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | `string` | ✓ | Unique identifier (`module-id.name`) |
+| `onFire` | `(config: T) => void` | ✓ | Called when the queue auto-advances past this action |
+
+Returns a `Disposable` — registered action is removed on module unload.
+
+### Auto-advance flow
+
+Same as triggers: when the queue auto-advances and encounters an action instance, `onFire` is called with the config passed via `addTrigger`. The action is responsible for calling `host.queue.next()` when done to unblock the queue.
+
+### How trigger entries are resolved
+
+When the queue encounters a `kind: 'trigger'` entry, it looks up the `triggerId` in both `queueTriggerSpecs` and `queueActionSpecs`. If found in either, the corresponding `onFire` is called. This means actions and triggers share the same entry format — the only difference is visibility in the queue panel.
+
+
 ---
 
 ## Full example

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -209,23 +209,29 @@ async fn create_surface_window(
     route: Option<String>,
     options: Option<SurfaceWindowOptions>,
 ) -> Result<(), String> {
-    let main_window = app_handle
-        .get_webview_window("main")
-        .ok_or_else(|| "Main window not found".to_string())?;
-
-    let main_position = main_window
-        .outer_position()
-        .map_err(|e| format!("Failed to get main window position: {}", e))?;
-
     let options = options.unwrap_or_default();
-    let width = options.width.unwrap_or(960.0);
-    let height = options.height.unwrap_or(640.0);
     let min_width = options.min_width.unwrap_or(720.0);
     let min_height = options.min_height.unwrap_or(480.0);
 
+    let (width, height) = {
+        let w = options.width;
+        let h = options.height;
+        if w.is_some() && h.is_some() {
+            (w.unwrap(), h.unwrap())
+        } else {
+            match app_handle.primary_monitor().ok().flatten() {
+                Some(monitor) => {
+                    let size = monitor.size();
+                    (w.unwrap_or(size.width as f64), h.unwrap_or(size.height as f64))
+                }
+                None => (w.unwrap_or(960.0), h.unwrap_or(640.0))
+            }
+        }
+    };
+
     let maximized = options.maximized.unwrap_or(false);
 
-    let window = tauri::WebviewWindowBuilder::new(
+    let _ = tauri::WebviewWindowBuilder::new(
         &app_handle,
         &label,
         tauri::WebviewUrl::App(route.unwrap_or_else(|| "/module-surface-window".to_string()).into()),
@@ -238,17 +244,9 @@ async fn create_surface_window(
     .min_inner_size(min_width, min_height)
     .maximized(maximized)
     .visible(false)
+    .center()
     .build()
     .map_err(|e| format!("Failed to create surface window: {}", e))?;
-
-    if !maximized {
-        window
-            .set_position(tauri::Position::Physical(tauri::PhysicalPosition {
-                x: main_position.x + 120,
-                y: main_position.y + 120,
-            }))
-            .map_err(|e| format!("Failed to set surface window position: {}", e))?;
-    }
 
     Ok(())
 }

--- a/src-tauri/src/module_runtime/mod.rs
+++ b/src-tauri/src/module_runtime/mod.rs
@@ -23,6 +23,7 @@ pub struct ModuleRuntime {
     pub modules_dir: PathBuf,
     pub registry: Arc<Mutex<Registry>>,
     pub http_client: Client,
+    pub manifest_cache: Mutex<HashMap<String, ModuleManifest>>,
 }
 
 impl ModuleRuntime {
@@ -55,7 +56,24 @@ impl ModuleRuntime {
             modules_dir: data_dir,
             registry: Arc::new(Mutex::new(registry)),
             http_client,
+            manifest_cache: Mutex::new(HashMap::new()),
         })
+    }
+
+    fn cached_manifest(&self, module_id: &str, path: &std::path::Path) -> Result<ModuleManifest, String> {
+        let mut cache = self.manifest_cache.lock().map_err(|e| e.to_string())?;
+        if let Some(manifest) = cache.get(module_id) {
+            return Ok(manifest.clone());
+        }
+        let manifest = manifest::load_manifest(path)?;
+        cache.insert(module_id.to_string(), manifest.clone());
+        Ok(manifest)
+    }
+
+    fn invalidate_manifest_cache(&self, module_id: &str) {
+        if let Ok(mut cache) = self.manifest_cache.lock() {
+            cache.remove(module_id);
+        }
     }
 }
 
@@ -76,7 +94,7 @@ pub fn module_list_installed(
 
     let mut result = Vec::new();
     for entry in entries {
-        match manifest::load_manifest(&entry.path) {
+        match runtime.cached_manifest(&entry.id, &entry.path) {
             Ok(manifest) => {
                 result.push(InstalledModule {
                     manifest,
@@ -126,6 +144,8 @@ pub fn module_install(
         enabled: true,
     };
 
+    runtime.invalidate_manifest_cache(&installed.manifest.id);
+
     let _ = app.emit("module:installed", &installed);
 
     Ok(installed)
@@ -141,7 +161,7 @@ pub fn module_get(app: AppHandle, id: String) -> Result<Option<InstalledModule>,
         return Ok(None);
     };
 
-    let manifest = manifest::load_manifest(&entry.path)?;
+    let manifest = runtime.cached_manifest(&id, &entry.path)?;
     Ok(Some(InstalledModule {
         manifest,
         source: entry.source,
@@ -181,6 +201,10 @@ pub fn module_uninstall(app: AppHandle, id: String) -> Result<(), String> {
     }
 
     reg.remove(&id).map_err(|e| e.to_string())?;
+
+    drop(reg);
+
+    runtime.invalidate_manifest_cache(&id);
 
     let _ = app.emit("module:uninstalled", &id);
 

--- a/src/app/_layout/presentation.tsx
+++ b/src/app/_layout/presentation.tsx
@@ -158,7 +158,7 @@ function PresentationPreviewRenderer({
     <div
       ref={containerRef}
       aria-hidden="true"
-      className="pointer-events-none fixed left-[-10000px] top-0 h-[180px] w-[320px] overflow-hidden opacity-0"
+      className="pointer-events-none fixed left-[-10000px] top-0 h-45 w-[320px] overflow-hidden opacity-0"
     />
   );
 }

--- a/src/app/module-surface-window.tsx
+++ b/src/app/module-surface-window.tsx
@@ -16,14 +16,8 @@ interface SurfaceProjectState {
 }
 
 async function waitForSurfaceState(label: string): Promise<SurfaceProjectState | null> {
-  for (let i = 0; i < 150; i++) {
-    const json = await invoke<string | null>('get_surface_state', { label }).catch(() => null);
-    if (json) {
-      return JSON.parse(json) as SurfaceProjectState;
-    }
-    await new Promise((r) => setTimeout(r, 50));
-  }
-  return null;
+  const json = await invoke<string | null>('get_surface_state', { label }).catch(() => null);
+  return json ? (JSON.parse(json) as SurfaceProjectState) : null;
 }
 
 export const Route = createFileRoute('/module-surface-window')({

--- a/src/app/module-surface-window.tsx
+++ b/src/app/module-surface-window.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router';
-import { emit } from '@tauri-apps/api/event';
 import { invoke } from '@tauri-apps/api/core';
+import { emit } from '@tauri-apps/api/event';
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Toaster } from '@/components/ui/sonner';
@@ -41,7 +41,7 @@ function ModuleSurfaceWindow() {
     } catch {
       return;
     }
-    emit('module:surface-ready', { label }).catch(() => {});
+    emit('module:surface-ready', { label }).catch(() => { });
   }, []);
 
   const closeWindow = useCallback(async () => {
@@ -65,14 +65,14 @@ function ModuleSurfaceWindow() {
           emit('module:surface-window-closed', {
             moduleId,
             panelId: state?.panelId,
-          }).catch(() => {});
-        }),
+          }).catch(() => { });
+        })
       )
       .then((unlisten) => {
         if (!cancelled) detachCloseListener = unlisten;
         else unlisten();
       })
-      .catch(() => {});
+      .catch(() => { });
 
     return () => {
       cancelled = true;
@@ -97,12 +97,9 @@ function ModuleSurfaceWindow() {
           return;
         }
 
-        useModuleStore.getState().openSurfaceWindow(
-          state.moduleId,
-          state.panelId,
-          state.props,
-          state.options,
-        );
+        useModuleStore
+          .getState()
+          .openSurfaceWindow(state.moduleId, state.panelId, state.props, state.options);
 
         await bootSingleModule(state.moduleId, 'surface');
         if (cancelled) {
@@ -142,13 +139,13 @@ function ModuleSurfaceWindow() {
           useModuleStore.getState().clearSurfaceWindow(event.payload.moduleId);
           setActiveModuleId(null);
           void closeWindow();
-        }),
+        })
       )
       .then((fn) => {
         if (!cancelled) detachClearListener = fn;
         else fn();
       })
-      .catch(() => {});
+      .catch(() => { });
 
     return () => {
       cancelled = true;

--- a/src/app/module-surface-window.tsx
+++ b/src/app/module-surface-window.tsx
@@ -3,6 +3,7 @@ import { emit } from '@tauri-apps/api/event';
 import { invoke } from '@tauri-apps/api/core';
 import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { Toaster } from '@/components/ui/sonner';
 import { SurfaceWindowSlot } from '@/modules/components/SurfaceWindowSlot';
 import { bootSingleModule } from '@/modules/presenter-injector';
 import { useModuleStore } from '@/modules/store';
@@ -157,5 +158,10 @@ function ModuleSurfaceWindow() {
 
   if (!activeModuleId) return null;
 
-  return <SurfaceWindowSlot moduleId={activeModuleId} />;
+  return (
+    <>
+      <SurfaceWindowSlot moduleId={activeModuleId} />
+      <Toaster />
+    </>
+  );
 }

--- a/src/components/aside-panel.tsx
+++ b/src/components/aside-panel.tsx
@@ -88,8 +88,8 @@ import { thumbnailService } from '@/services/thumbnail-service';
 import type { FileInfo } from '@/services/types';
 import { usePlayerStore } from '@/stores/player-store';
 import { useProfileStore } from '@/stores/profile-store';
+import { queueDbService } from '@/services/queue-db-service';
 import {
-  type ListEntry,
   type TriggerInstance,
   useQueueEntriesStore,
 } from '@/stores/queue-entries-store';
@@ -130,7 +130,6 @@ export function AsidePanel() {
     loadFromDb,
     clearQueue,
     shuffleQueue,
-    reorderQueue,
   } = useQueueStore();
   const loadFile = usePlayerStore((s) => s.loadFile);
 
@@ -172,7 +171,6 @@ export function AsidePanel() {
             onTogglePlayed={togglePlayed}
             onClear={clearQueue}
             onShuffle={shuffleQueue}
-            onReorder={reorderQueue}
             onPlay={(item) => {
               loadFile(item.file.path);
               markPlayed(item.id);
@@ -205,7 +203,6 @@ function QueueTab({
   onTogglePlayed,
   onClear,
   onShuffle,
-  onReorder,
   onPlay,
 }: {
   queue: QueueItem[];
@@ -213,19 +210,24 @@ function QueueTab({
   onTogglePlayed: (id: number) => void;
   onClear: () => Promise<void>;
   onShuffle: () => Promise<void>;
-  onReorder: (orderedIds: number[]) => Promise<void>;
   onPlay: (item: QueueItem) => void;
 }) {
   const currentFilePath = usePlayerStore((s) => s.currentFilePath);
   const triggerSpecsMap = useModuleStore((s) => s.queueTriggerSpecs);
   const triggerSpecs = Array.from(triggerSpecsMap.values());
+  const actionSpecsMap = useModuleStore((s) => s.queueActionSpecs);
+  const actionSpecs = Array.from(actionSpecsMap.values());
 
   const entries = useQueueEntriesStore((s) => s.entries);
   const dropTargetIndex = useQueueEntriesStore((s) => s.dropTargetIndex);
-  const { syncQueue, setEntries } = useQueueEntriesStore.getState();
+  const { syncQueue, setEntries, loadFromDb, persistOrder } = useQueueEntriesStore.getState();
 
   const [triggerDialog, setTriggerDialog] = useState<TriggerDialog>(null);
   const [contextTargetItem, setContextTargetItem] = useState<QueueItem | null>(null);
+
+  useEffect(() => {
+    loadFromDb();
+  }, [loadFromDb]);
 
   useEffect(() => {
     syncQueue(queue);
@@ -244,10 +246,9 @@ function QueueTab({
     if (oldIdx === -1 || newIdx === -1) return;
     const next = arrayMove(entries, oldIdx, newIdx);
     setEntries(next);
-    const orderedQueueIds = next
-      .filter((e): e is Extract<ListEntry, { kind: 'item' }> => e.kind === 'item')
-      .map((e) => e.item.id);
-    onReorder(orderedQueueIds);
+    persistOrder().then(() => {
+      useQueueStore.getState().loadFromDb();
+    }).catch(() => {});
   }
 
   function openAddTrigger(triggerId: string) {
@@ -275,6 +276,7 @@ function QueueTab({
         triggerId,
         config,
         showLabel: false,
+        played: false,
       };
       setEntries([...entries, { kind: 'trigger', id: newInst.id, inst: newInst }]);
     }
@@ -283,6 +285,7 @@ function QueueTab({
 
   function removeTriggerInstance(entryId: string) {
     setEntries(entries.filter((e) => e.id !== entryId));
+    queueDbService.removeTriggerEntry(entryId).catch(() => {});
   }
 
   const dialogSpec = triggerDialog
@@ -295,7 +298,7 @@ function QueueTab({
   const itemPositions = new Map<string, number>();
   let pos = 0;
   for (const entry of entries) {
-    if (entry.kind === 'item') itemPositions.set(entry.id, pos++);
+    itemPositions.set(entry.id, pos++);
   }
 
   const { setNodeRef: setQueueDropRef } = useDroppable({ id: 'queue-drop-zone' });
@@ -326,8 +329,8 @@ function QueueTab({
           </div>
         </ContextMenuTrigger>
       </ContextMenu>
-    );
-  }
+  );
+}
 
   return (
     <>
@@ -382,24 +385,102 @@ function QueueTab({
                                   onContextMenu={() => setContextTargetItem(entry.item)}
                                   formatDuration={formatDuration}
                                 />
-                              ) : (() => {
-                                const spec = triggerSpecs.find((s) => s.id === entry.inst.triggerId);
-                                if (!spec) return null;
-                                return (
-                                  <SortableTriggerItem
-                                    inst={entry.inst}
-                                    spec={spec}
-                                    onEdit={() => openEditTrigger(entry.inst)}
-                                    onRemove={() => removeTriggerInstance(entry.id)}
-                                    onToggleLabel={() =>
-                                      setEntries(
-                                        entries.map((e) =>
-                                          e.id === entry.id && e.kind === 'trigger'
-                                            ? { ...e, inst: { ...e.inst, showLabel: !e.inst.showLabel } }
-                                            : e
+                              ) : entry.kind === 'trigger' && (() => {
+                                const triggerSpec = triggerSpecs.find((s) => s.id === entry.inst.triggerId);
+                                if (triggerSpec) {
+                                  return (
+                                    <SortableTriggerItem
+                                      inst={entry.inst}
+                                      spec={triggerSpec}
+                                      onEdit={() => openEditTrigger(entry.inst)}
+                                      onRemove={() => removeTriggerInstance(entry.id)}
+                                      onToggleLabel={() =>
+                                        setEntries(
+                                          entries.map((e) =>
+                                            e.id === entry.id && e.kind === 'trigger'
+                                              ? { ...e, inst: { ...e.inst, showLabel: !e.inst.showLabel } }
+                                              : e
+                                          )
                                         )
-                                      )
-                                    }
+                                      }
+                                    />
+                                  );
+                                }
+                                const foundSpec = actionSpecs.find((s) => s.id === entry.inst.triggerId);
+                                if (!triggerSpec && foundSpec) {
+                                  const cfg = entry.inst.config as Record<string, unknown> | undefined;
+                                  const title =
+                                    cfg?.bookName != null && cfg?.chapter != null && cfg?.verse != null
+                                      ? `${cfg.bookName} ${cfg.chapter}:${cfg.verse}`
+                                      : entry.inst.triggerId;
+                                  const tag = cfg?.versionDisplayName != null
+                                    ? String(cfg.versionDisplayName)
+                                    : '';
+                                  const actionQueueItem: QueueItem = {
+                                    id: 1000000 + idx,
+                                    file: {
+                                      name: tag,
+                                      path: `action://${entry.id}`,
+                                      size: 0,
+                                      modifiedAt: new Date(),
+                                      extension: '',
+                                      title,
+                                    },
+                                    played: entry.inst.played,
+                                  };
+                                  return (
+                                    <SortableQueueItem
+                                      sortableId={entry.id}
+                                      item={actionQueueItem}
+                                      isCurrent={false}
+                                      index={itemPositions.get(entry.id) ?? 0}
+                                      onPlay={() => {
+                                        const spec = actionSpecs.find((s) => s.id === entry.inst.triggerId);
+                                        if (spec) {
+                                          setEntries(
+                                            entries.map((e) =>
+                                              e.id === entry.id && e.kind === 'trigger'
+                                                ? { ...e, inst: { ...e.inst, played: true } }
+                                                : e
+                                            )
+                                          );
+                                          spec.onFire(entry.inst.config);
+                                        }
+                                      }}
+                                      onContextMenu={() => setContextTargetItem(actionQueueItem)}
+                                      formatDuration={() => ''}
+                                    />
+                                  );
+                                }
+                                const cfg = entry.inst.config as Record<string, unknown> | undefined;
+                                const title =
+                                  cfg?.bookName != null && cfg?.chapter != null && cfg?.verse != null
+                                    ? `${cfg.bookName} ${cfg.chapter}:${cfg.verse}`
+                                    : entry.inst.triggerId;
+                                const tag = cfg?.versionDisplayName != null
+                                  ? String(cfg.versionDisplayName)
+                                  : '';
+                                const fallbackItem: QueueItem = {
+                                  id: 1000000 + idx,
+                                  file: {
+                                    name: tag,
+                                    path: `action://${entry.id}`,
+                                    size: 0,
+                                    modifiedAt: new Date(),
+                                    extension: '',
+                                    title,
+                                  },
+                                  played: entry.inst.played,
+                                };
+                                return (
+                                  <SortableQueueItem
+                                    sortableId={entry.id}
+                                    item={fallbackItem}
+                                    isCurrent={false}
+                                    index={itemPositions.get(entry.id) ?? 0}
+                                    onPlay={() => {}}
+                                    onContextMenu={() => setContextTargetItem(fallbackItem)}
+                                    formatDuration={() => ''}
                                   />
                                 );
                               })()}
@@ -426,18 +507,46 @@ function QueueTab({
         </ContextMenuTrigger>
 
         <ContextMenuContent>
-          {contextTargetItem && (
-            <>
-              <ContextMenuItem onClick={() => onTogglePlayed(contextTargetItem.id)}>
-                <CheckCircle2 className="h-4 w-4" />
-                {contextTargetItem.played ? 'Mark as unplayed' : 'Mark as played'}
-              </ContextMenuItem>
-              <ContextMenuItem onClick={() => onRemove(contextTargetItem.id)} variant="destructive">
-                <ListX className="h-4 w-4" />
-                Remove from queue
-              </ContextMenuItem>
-            </>
-          )}
+          {contextTargetItem && (() => {
+            const isAction = contextTargetItem.file.path.startsWith('action://');
+            const actionEntryId = isAction ? contextTargetItem.file.path.slice('action://'.length) : null;
+            return (
+              <>
+                <ContextMenuItem
+                  onClick={() => {
+                    if (isAction && actionEntryId) {
+                      setEntries(
+                        entries.map((e) =>
+                          e.id === actionEntryId && e.kind === 'trigger'
+                            ? { ...e, inst: { ...e.inst, played: !e.inst.played } }
+                            : e
+                        )
+                      );
+                      queueDbService.toggleTriggerPlayed(actionEntryId).catch(() => {});
+                    } else {
+                      onTogglePlayed(contextTargetItem.id);
+                    }
+                  }}
+                >
+                  <CheckCircle2 className="h-4 w-4" />
+                  {contextTargetItem.played ? 'Mark as unplayed' : 'Mark as played'}
+                </ContextMenuItem>
+                <ContextMenuItem
+                  onClick={() => {
+                    if (isAction && actionEntryId) {
+                      removeTriggerInstance(actionEntryId);
+                    } else {
+                      onRemove(contextTargetItem.id);
+                    }
+                  }}
+                  variant="destructive"
+                >
+                  <ListX className="h-4 w-4" />
+                  Remove from queue
+                </ContextMenuItem>
+              </>
+            );
+          })()}
           {!contextTargetItem && triggerSpecs.length > 0 && triggerSpecs.length <= 6 && (
             <ContextMenuGroup>
               <ContextMenuLabel>Queue Triggers</ContextMenuLabel>

--- a/src/components/presenter-controls.tsx
+++ b/src/components/presenter-controls.tsx
@@ -10,7 +10,7 @@ import {
   SkipForward,
 } from 'lucide-react';
 import type React from 'react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useEventListener, useIsomorphicLayoutEffect, useResizeObserver } from 'usehooks-ts';
 import { Button } from '@/components/ui/button';
 import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area';
@@ -27,7 +27,7 @@ import { usePresentationStore } from '@/stores/presentation-store';
 import { useProfileStore } from '@/stores/profile-store';
 import { Card } from './ui/card';
 
-type PresenterKind = 'lyrics' | 'image' | 'presentation';
+type PresenterKind = 'lyrics' | 'image' | 'presentation' | 'module';
 
 type Translate = (key: string, params?: Record<string, string | number>) => string;
 
@@ -49,6 +49,37 @@ interface FallbackSlide {
   active: boolean;
   image: boolean;
   source?: string | null;
+}
+
+interface ModuleSlideData {
+  text?: string;
+  bookName?: string;
+  chapter?: number;
+  verses?: number[];
+  fontColor?: string;
+  fontSize?: number;
+  fontFamily?: string;
+  fontWeight?: string;
+  fontStyle?: string;
+  background?: { src?: string; type?: string; name?: string } | null;
+  profileBackground?: { src?: string; type?: string; name?: string } | null;
+  backgroundOpacity?: number;
+  showReferenceOnly?: boolean;
+  showVersion?: boolean;
+  uppercase?: boolean;
+  version?: string;
+}
+
+function buildModuleSlideRef(data: ModuleSlideData | null | undefined): string | null {
+  if (!data) return null;
+  const book = data.bookName?.trim();
+  if (book && typeof data.chapter === 'number' && Array.isArray(data.verses) && data.verses.length > 0) {
+    return `${book} ${data.chapter}:${data.verses.join('-')}`;
+  }
+  if (data.text) {
+    return data.text.split('\n')[0]?.slice(0, 60) || null;
+  }
+  return null;
 }
 
 interface PresenterDisplayState {
@@ -97,10 +128,11 @@ function getInitialPresenterState(): PresenterState {
   }
 
   if (moduleStore.presenterViewId) {
+    const slideData = (moduleStore.presenterProps as { data?: ModuleSlideData } | undefined)?.data;
     return {
       active: true,
-      kind: 'presentation',
-      name: 'Presentation',
+      kind: 'module',
+      name: buildModuleSlideRef(slideData) ?? 'Presentation',
     };
   }
 
@@ -137,7 +169,7 @@ function stateFromBackdrop(detail: StageBackdropChangeDetail): PresenterState {
   return { active: false, kind: null };
 }
 
-function getKindMeta(kind: PresenterKind | null, t: Translate) {
+function getKindMeta(kind: PresenterKind | null, t: Translate, moduleLabel?: string | null) {
   if (kind === 'image') {
     return {
       icon: ImageIcon,
@@ -151,6 +183,15 @@ function getKindMeta(kind: PresenterKind | null, t: Translate) {
     return {
       icon: Presentation,
       label: t('PPT'),
+      title: t('Presentation'),
+      subtitle: t('Slides'),
+    };
+  }
+
+  if (kind === 'module') {
+    return {
+      icon: Presentation,
+      label: moduleLabel ?? t('Module'),
       title: t('Presentation'),
       subtitle: t('Slides'),
     };
@@ -243,7 +284,11 @@ function useBackgroundSrc(path?: string) {
   return src;
 }
 
-function usePresenterStageState(lyricPath: string | null, presenterViewId: string | null) {
+function usePresenterStageState(
+  lyricPath: string | null,
+  presenterViewId: string | null,
+  presenterProps: unknown
+) {
   const [presenter, setPresenter] = useState<PresenterState>(() => getInitialPresenterState());
 
   useEffect(() => {
@@ -252,7 +297,12 @@ function usePresenterStageState(lyricPath: string | null, presenterViewId: strin
     });
 
     const unlistenProject = listen('module:presenter-project', () => {
-      setPresenter({ active: true, kind: 'presentation', name: 'Presentation' });
+      const slideData = (useModuleStore.getState().presenterProps as { data?: ModuleSlideData } | undefined)?.data;
+      setPresenter({
+        active: true,
+        kind: 'module',
+        name: buildModuleSlideRef(slideData) ?? 'Presentation',
+      });
     });
 
     const unlistenClear = listen('module:presenter-clear', () => {
@@ -278,9 +328,14 @@ function usePresenterStageState(lyricPath: string | null, presenterViewId: strin
 
   useEffect(() => {
     if (presenterViewId) {
-      setPresenter({ active: true, kind: 'presentation', name: 'Presentation' });
+      const slideData = (presenterProps as { data?: ModuleSlideData } | undefined)?.data;
+      setPresenter({
+        active: true,
+        kind: 'module',
+        name: buildModuleSlideRef(slideData) ?? 'Presentation',
+      });
     }
-  }, [presenterViewId]);
+  }, [presenterViewId, presenterProps]);
 
   return presenter;
 }
@@ -571,24 +626,24 @@ function FallbackSequenceThumbnail({
       ref={ref}
       type="button"
       className={cn(
-        'relative h-[90px] w-40 shrink-0 overflow-hidden rounded-lg border bg-muted/30 text-left transition-colors',
+        'relative h-22.5 w-40 shrink-0 overflow-hidden rounded-lg border bg-muted/30 text-left transition-colors',
         slide.active
           ? 'border-primary shadow-[0_0_0_1px_hsl(var(--primary)/0.45)]'
           : 'border-border/60 hover:border-border'
       )}
       onClick={onClick}
     >
-        {slide.image ? (
-          imageSrc ? (
-            <img
-              src={imageSrc}
-              alt=""
-              className="absolute inset-0 h-full w-full bg-black object-contain"
-            />
-          ) : (
-            <div className="absolute inset-0 animate-pulse bg-muted opacity-60" />
-          )
+      {slide.image ? (
+        imageSrc ? (
+          <img
+            src={imageSrc}
+            alt=""
+            className="absolute inset-0 h-full w-full bg-black object-contain"
+          />
         ) : (
+          <div className="absolute inset-0 animate-pulse bg-muted opacity-60" />
+        )
+      ) : (
         <div className="flex h-full items-center justify-center px-3 text-center text-[10px] font-semibold text-muted-foreground">
           {slide.label}
         </div>
@@ -596,6 +651,172 @@ function FallbackSequenceThumbnail({
     </button>
   );
 }
+
+const VERSION_PREFIX = /^[a-z]{2}_/;
+
+function displayModuleVersion(id?: string): string {
+  if (!id) return '';
+  return id.replace(VERSION_PREFIX, '').toUpperCase();
+}
+
+const FONT_WEIGHT_MAP: Record<string, number> = {
+  Thin: 100,
+  Light: 300,
+  Regular: 400,
+  Medium: 500,
+  Bold: 700,
+  Black: 900,
+};
+
+const ModuleSequenceThumbnail = memo(function ModuleSequenceThumbnail({
+  data,
+  isSelected,
+  onClick,
+}: {
+  data: ModuleSlideData;
+  isSelected: boolean;
+  onClick: () => void;
+}) {
+  const containerRef = useRef<HTMLDivElement>(null!);
+  const textRef = useRef<HTMLDivElement>(null);
+  const { width: containerWidth = 0 } = useResizeObserver({ ref: containerRef });
+  const scale = containerWidth / THUMB_VIRTUAL_W;
+
+  const bgPath = data.background?.src ?? data.profileBackground?.src ?? undefined;
+  const bgSrc = useBackgroundSrc(bgPath);
+  const color = data.fontColor || '#FFFFFF';
+  const overlayOpacity = (data.backgroundOpacity ?? 30) / 100;
+
+  const verseStr =
+    data.verses && data.verses.length > 0
+      ? data.verses.length === 1
+        ? String(data.verses[0])
+        : `${data.verses[0]}-${data.verses[data.verses.length - 1]}`
+      : null;
+
+  const versionLabel = data.showVersion ? displayModuleVersion(data.version) : null;
+  const lines = data.text ? data.text.split('\n').filter(Boolean) : [];
+  const fontWeight = FONT_WEIGHT_MAP[data.fontWeight ?? 'Regular'] ?? 400;
+  const fontStyle = data.fontStyle === 'Italic' ? 'italic' : 'normal';
+  const uppercaseStyle = data.uppercase ? { textTransform: 'uppercase' as const } : undefined;
+  const hi = data.fontSize ?? 120;
+
+  useIsomorphicLayoutEffect(() => {
+    const text = textRef.current;
+    if (!text) return;
+
+    if (data.showReferenceOnly) {
+      text.style.fontSize = '';
+      return;
+    }
+
+    let lo = 1;
+    let best = 1;
+    let upper = hi;
+
+    while (upper - lo > 1) {
+      const mid = Math.floor((lo + upper) / 2);
+      text.style.fontSize = `${mid}px`;
+      if (text.scrollHeight <= THUMB_AVAILABLE_H) {
+        best = mid;
+        lo = mid;
+      } else {
+        upper = mid;
+      }
+    }
+
+    text.style.fontSize = `${best}px`;
+    if (text.scrollHeight > THUMB_AVAILABLE_H) {
+      text.style.fontSize = `${Math.max(best - 1, 1)}px`;
+    }
+  }, [data.text, data.uppercase, data.showReferenceOnly, hi, containerWidth]);
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'shrink-0 w-40 rounded-lg overflow-hidden transition-all outline-none',
+        isSelected ? 'ring-2 ring-primary' : 'ring-1 ring-border/40 hover:ring-border/70'
+      )}
+    >
+      <div ref={containerRef} className="relative aspect-video bg-black">
+        {bgSrc && (
+          <img
+            src={bgSrc}
+            alt=""
+            className="absolute inset-0 h-full w-full object-cover"
+            aria-hidden
+          />
+        )}
+        <div className="absolute inset-0 bg-black" style={{ opacity: overlayOpacity }} />
+
+        {data.showReferenceOnly ? (
+          <div
+            className="absolute inset-0 flex items-center justify-center"
+            style={{
+              transform: `scale(${scale * 2.5})`,
+              opacity: scale > 0 ? 1 : 0,
+            }}
+          >
+            <div
+              className="flex items-center gap-3"
+              style={{ fontFamily: data.fontFamily, color }}
+            >
+              <div className="flex min-w-0 flex-col items-center leading-tight">
+                <span className="text-2xl font-bold" style={uppercaseStyle}>
+                  {data.bookName} {data.chapter}
+                </span>
+                {versionLabel && (
+                  <span className="text-sm self-start opacity-60">{versionLabel}</span>
+                )}
+              </div>
+              <div
+                className="h-10 w-px shrink-0 opacity-25"
+                style={{ backgroundColor: color }}
+              />
+              <span className="shrink-0 text-4xl font-bold">{verseStr}</span>
+            </div>
+          </div>
+        ) : (
+          <div
+            className="absolute left-1/2 top-1/2 flex items-center justify-center overflow-hidden pointer-events-none"
+            style={{
+              width: `${THUMB_VIRTUAL_W}px`,
+              height: `${THUMB_VIRTUAL_H}px`,
+              padding: '5%',
+              transform: `translate(-50%, -50%) scale(${scale})`,
+              opacity: scale > 0 ? 1 : 0,
+            }}
+          >
+            <div
+              ref={textRef}
+              className="w-full text-center"
+              style={{
+                fontFamily: data.fontFamily,
+                color,
+                fontWeight,
+                fontStyle,
+                ...uppercaseStyle,
+              }}
+            >
+              <div
+                className="font-medium"
+                style={{ fontSize: '0.25em', opacity: 0.6, marginBottom: '0.5em' }}
+              >
+                {data.bookName} {data.chapter}:{verseStr}
+                {versionLabel ? ` ${versionLabel}` : ''}
+              </div>
+              {lines.map((line, index) => (
+                <div key={`${index}-${line}`}>{line}</div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </button>
+  );
+});
 
 function PresenterHeader({
   meta,
@@ -796,6 +1017,7 @@ function PresenterSequence({
   lyricSlideIndex,
   profileBackground,
   fallbackSlides,
+  moduleData,
   sequenceRef,
   sequenceContentRef,
   isMinimized,
@@ -809,6 +1031,7 @@ function PresenterSequence({
   lyricSlideIndex: number;
   profileBackground?: string;
   fallbackSlides: FallbackSlide[];
+  moduleData: ModuleSlideData | null;
   sequenceRef: React.RefObject<HTMLDivElement | null>;
   sequenceContentRef: React.RefObject<HTMLDivElement | null>;
   isMinimized: boolean;
@@ -845,13 +1068,21 @@ function PresenterSequence({
                   }}
                 />
               ))
-              : fallbackSlides.map((slide, index) => (
-                <FallbackSequenceThumbnail
-                  key={slide.id}
-                  slide={slide}
-                  onClick={() => onSelectSlide?.(index)}
-                />
-              ))}
+              : kind === 'module' && moduleData
+                ? (
+                  <ModuleSequenceThumbnail
+                    data={moduleData}
+                    isSelected={true}
+                    onClick={() => onSelectSlide?.(0)}
+                  />
+                )
+                : fallbackSlides.map((slide, index) => (
+                  <FallbackSequenceThumbnail
+                    key={slide.id}
+                    slide={slide}
+                    onClick={() => onSelectSlide?.(index)}
+                  />
+                ))}
           </div>
           <ScrollBar orientation="horizontal" />
         </ScrollArea>
@@ -873,7 +1104,22 @@ export function PresenterControls({ className }: PresenterControlsProps) {
   const lyricPath = usePlayerStore((s) => s.currentLyricPath);
   const imagePath = usePlayerStore((s) => s.currentImagePath);
   const presenterViewId = useModuleStore((s) => s.presenterViewId);
-  const presenter = usePresenterStageState(lyricPath, presenterViewId);
+  const presenterProps = useModuleStore((s) => s.presenterProps);
+  const moduleName = useModuleStore((s) => {
+    if (!s.presenterViewId) return null;
+    for (const [moduleId, specs] of s.panels.entries()) {
+      if (specs.some((p) => p.id === s.presenterViewId && p.slot === 'presenter.content')) {
+        return s.modules.get(moduleId)?.manifest.name ?? null;
+      }
+    }
+    return null;
+  });
+  const moduleData = useMemo<ModuleSlideData | null>(() => {
+    if (!presenterProps) return null;
+    const p = presenterProps as { data?: ModuleSlideData } | undefined;
+    return p?.data ?? null;
+  }, [presenterProps]);
+  const presenter = usePresenterStageState(lyricPath, presenterViewId, presenterProps);
   const lyricData = usePresentedLyricData(lyricPath, presenter.kind);
   const profileBackground = useProfileBackground();
   const { isMinimized, sequenceRef, sequenceContentRef, toggle } = usePresenterCollapseAnimation();
@@ -910,7 +1156,9 @@ export function PresenterControls({ className }: PresenterControlsProps) {
       ? lyricData?.slides.length || lyricTotalSlides || 0
       : presenter.kind === 'presentation'
         ? presentationState.totalSlides
-        : fallbackSlides.length;
+        : presenter.kind === 'module'
+          ? 1
+          : fallbackSlides.length;
   const currentIndex =
     presenter.kind === 'lyrics'
       ? lyricSlideIndex
@@ -932,6 +1180,10 @@ export function PresenterControls({ className }: PresenterControlsProps) {
 
       if (presenter.kind === 'presentation') {
         usePresentationStore.getState().setSlide(nextIndex);
+        return;
+      }
+
+      if (presenter.kind === 'module') {
         return;
       }
 
@@ -978,8 +1230,13 @@ export function PresenterControls({ className }: PresenterControlsProps) {
     { capture: true }
   );
 
-  const meta = getKindMeta(presenter.kind, t);
-  const presenterName = presenter.name === 'Presentation' ? (presentationState.fileName ?? t('Presentation')) : presenter.name;
+  const meta = getKindMeta(presenter.kind, t, moduleName);
+  const presenterName =
+    presenter.name === 'Presentation'
+      ? (presenter.kind === 'module'
+        ? moduleName ?? t('Presentation')
+        : presentationState.fileName ?? t('Presentation'))
+      : presenter.name;
   const displayTitle =
     presenterName ??
     lyricData?.metadata.name ??
@@ -1025,6 +1282,7 @@ export function PresenterControls({ className }: PresenterControlsProps) {
         lyricSlideIndex={lyricSlideIndex}
         profileBackground={profileBackground}
         fallbackSlides={fallbackSlides}
+        moduleData={moduleData}
         sequenceRef={sequenceRef}
         sequenceContentRef={sequenceContentRef}
         isMinimized={isMinimized}

--- a/src/modules/apis/domain.ts
+++ b/src/modules/apis/domain.ts
@@ -125,6 +125,16 @@ export function createQueueHostAPI(): QueueHostAPI {
       const dispose = useModuleStore.getState().registerQueueTrigger(spec);
       return { dispose };
     },
+    addTrigger(triggerId, config) {
+      const id = crypto.randomUUID();
+      const entry = {
+        kind: 'trigger' as const,
+        id,
+        inst: { id, triggerId, config, showLabel: true },
+      };
+      const store = useQueueEntriesStore.getState();
+      store.setEntries([...store.entries, entry]);
+    },
     async addUrl(input) {
       if (input.position === 'next') {
         await useQueueStore.getState().playUrlNext(input.url, input.duration);

--- a/src/modules/apis/domain.ts
+++ b/src/modules/apis/domain.ts
@@ -125,12 +125,16 @@ export function createQueueHostAPI(): QueueHostAPI {
       const dispose = useModuleStore.getState().registerQueueTrigger(spec);
       return { dispose };
     },
+    registerAction(spec) {
+      const dispose = useModuleStore.getState().registerQueueAction(spec);
+      return { dispose };
+    },
     addTrigger(triggerId, config) {
       const id = crypto.randomUUID();
       const entry = {
         kind: 'trigger' as const,
         id,
-        inst: { id, triggerId, config, showLabel: true },
+        inst: { id, triggerId, config, showLabel: true, played: false },
       };
       const store = useQueueEntriesStore.getState();
       store.setEntries([...store.entries, entry]);
@@ -690,5 +694,7 @@ export function createThemesHostAPI(): ThemesHostAPI {
     },
   };
 }
+
+
 
 

--- a/src/modules/components/PresenterControlsSlot.tsx
+++ b/src/modules/components/PresenterControlsSlot.tsx
@@ -5,7 +5,7 @@ import type { PanelSpec } from '../types';
 import { ModuleErrorBoundary } from './ModuleErrorBoundary';
 
 export interface PresenterControlsSlotProps {
-  kind: 'lyrics' | 'image' | 'presentation' | null;
+  kind: 'lyrics' | 'image' | 'presentation' | 'module' | null;
   active: boolean;
   slideIndex: number;
   totalSlides: number;

--- a/src/modules/components/SurfaceWindowSlot.tsx
+++ b/src/modules/components/SurfaceWindowSlot.tsx
@@ -1,5 +1,5 @@
 import { emit } from '@tauri-apps/api/event';
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import { useModuleStore } from '../store';
 import type { PanelSpec } from '../types';
 import { ModuleErrorBoundary } from './ModuleErrorBoundary';
@@ -9,7 +9,8 @@ interface SurfaceWindowSlotProps {
 }
 
 export function SurfaceWindowSlot({ moduleId }: SurfaceWindowSlotProps) {
-  const state = useModuleStore((s) => s.surfaceWindows.get(moduleId) ?? null);
+  const panelId = useModuleStore((s) => s.surfaceWindows.get(moduleId)?.panelId ?? null);
+  const props = useModuleStore((s) => s.surfaceWindows.get(moduleId)?.props ?? null);
 
   const spec = useModuleStore<PanelSpec | null>((s) => {
     const active = s.surfaceWindows.get(moduleId);
@@ -20,11 +21,14 @@ export function SurfaceWindowSlot({ moduleId }: SurfaceWindowSlotProps) {
 
   const clearSurfaceWindow = useModuleStore((s) => s.clearSurfaceWindow);
 
+  const panelIdRef = useRef(panelId);
+  panelIdRef.current = panelId;
+
   const close = useCallback(async () => {
     clearSurfaceWindow(moduleId);
     await emit('module:surface-window-closed', {
       moduleId,
-      panelId: state?.panelId,
+      panelId: panelIdRef.current,
     }).catch(() => {});
 
     try {
@@ -33,18 +37,17 @@ export function SurfaceWindowSlot({ moduleId }: SurfaceWindowSlotProps) {
     } catch (error) {
       console.error('Failed to close surface window:', error);
     }
-  }, [clearSurfaceWindow, moduleId, state?.panelId]);
+  }, [clearSurfaceWindow, moduleId]);
 
-  if (!state || !spec) return null;
+  if (!panelId || !spec) return null;
 
   const Component = spec.component;
-  const props = (state.props ?? {}) as Record<string, unknown>;
 
   return (
     <div className="fixed inset-0 h-dvh w-dvw overflow-hidden bg-background text-foreground">
       <ModuleErrorBoundary moduleId={moduleId} panelId={spec.id}>
         <div data-module-scope={moduleId} className="h-full w-full overflow-hidden">
-          <Component {...props} close={close} onClose={close} />
+          <Component {...(props as Record<string, unknown>)} close={close} onClose={close} />
         </div>
       </ModuleErrorBoundary>
     </div>

--- a/src/modules/host.ts
+++ b/src/modules/host.ts
@@ -1,4 +1,5 @@
 import { getVersion } from '@tauri-apps/api/app';
+import { listen } from '@tauri-apps/api/event';
 import { createBusAPI, createEventsAPI } from './apis/bus';
 import { createCommandsAPI } from './apis/commands';
 import { createMenusAPI } from './apis/menus';
@@ -22,7 +23,68 @@ import { createPanelsAPI } from './apis/panels';
 import { createSettingsAPI } from './apis/settings';
 import { createUIAPI } from './apis/ui';
 import { useI18nStore } from '@/lib/i18n';
+import { useQueueEntriesStore } from '@/stores/queue-entries-store';
+import { useQueueStore } from '@/stores/queue-store';
+import { queueDbService } from '@/services/queue-db-service';
 import type { LumenHost, ModuleManifest } from './types';
+
+listen<{ triggerId: string; config: unknown }>('module:queue-add-trigger', (event) => {
+  const { triggerId, config } = event.payload;
+  const cfg = config as Record<string, unknown> | undefined;
+  const title =
+    cfg?.bookName != null && cfg?.chapter != null && cfg?.verse != null
+      ? `${cfg.bookName} ${cfg.chapter}:${cfg.verse}`
+      : triggerId;
+  const tag = cfg?.versionDisplayName != null ? String(cfg.versionDisplayName) : '';
+  const configStr = JSON.stringify(config);
+  const entryId = hashString(triggerId + ':' + configStr);
+
+  const entriesStore = useQueueEntriesStore.getState();
+  const existing = entriesStore.entries.find((e) => e.id === entryId);
+  if (!existing) {
+    entriesStore.setEntries([
+      ...entriesStore.entries,
+      {
+        kind: 'trigger' as const,
+        id: entryId,
+        inst: {
+          id: entryId,
+          triggerId,
+          config,
+          showLabel: true,
+          played: false,
+        },
+      },
+    ]);
+  }
+
+  queueDbService.addTriggerEntry(entryId, triggerId, configStr, title, tag).catch(() => {});
+}).catch(() => {});
+
+function hashString(input: string): string {
+  let h1 = 0xdeadbeef;
+  let h2 = 0x41c6ce57;
+  for (let i = 0; i < input.length; i++) {
+    const ch = input.charCodeAt(i);
+    h1 = Math.imul(h1 ^ ch, 2654435761);
+    h2 = Math.imul(h2 ^ ch, 1597334677);
+  }
+  h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^ Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+  h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^ Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+  return (h2 >>> 0).toString(36) + (h1 >>> 0).toString(36);
+}
+
+listen<{ url: string; position?: 'end' | 'next'; duration?: number }>(
+  'module:queue-add-url',
+  (event) => {
+    const { url, position, duration } = event.payload;
+    if (position === 'next') {
+      void useQueueStore.getState().playUrlNext(url, duration);
+      return;
+    }
+    void useQueueStore.getState().addUrlToQueue(url, duration);
+  }
+).catch(() => {});
 
 export async function createHost(
   manifest: ModuleManifest,

--- a/src/modules/injector.ts
+++ b/src/modules/injector.ts
@@ -136,7 +136,7 @@ export async function loadModule(manifest: ModuleManifest) {
   try {
     let mod: unknown;
     if (import.meta.env.DEV) {
-      const res = await fetch(`/__modules/${manifest.id}/${manifest.entry}?t=${Date.now()}`);
+      const res = await fetch(`/__modules/${manifest.id}/${manifest.entry}`);
       if (!res.ok) throw new Error(`module fetch failed: ${res.status}`);
       const code = await res.text();
       const blob = new Blob([code], { type: 'application/javascript' });

--- a/src/modules/presenter-host.ts
+++ b/src/modules/presenter-host.ts
@@ -105,6 +105,14 @@ export async function createPresenterHost(
       previous: noop,
       goTo: noop,
       registerTrigger: () => noopDisposable,
+      registerAction: () => noopDisposable,
+      addTrigger: (triggerId: string, config: unknown) => {
+        emit('module:queue-add-trigger', { triggerId, config }).catch(() => {});
+      },
+      addUrl: (input: { url: string; position?: 'end' | 'next'; duration?: number }) => {
+        emit('module:queue-add-url', input).catch(() => {});
+        return Promise.resolve();
+      },
     },
     library: {
       list: stub(Promise.resolve([])),

--- a/src/modules/presenter-injector.ts
+++ b/src/modules/presenter-injector.ts
@@ -22,22 +22,21 @@ export async function bootPresenterModules(window: 'presenter' | 'surface' = 'pr
 }
 
 export async function bootSingleModule(moduleId: string, window: 'presenter' | 'surface' = 'surface') {
-  let manifests: Array<{ manifest: ModuleManifest }> = [];
+  let installed: { manifest: ModuleManifest; source: string; enabled: boolean } | null = null;
 
   try {
-    manifests = await invoke<Array<{ manifest: ModuleManifest; source: string }>>('module_list_installed');
+    installed = await invoke<{ manifest: ModuleManifest; source: string; enabled: boolean } | null>('module_get', { id: moduleId });
   } catch (err) {
-    console.error('[surface] failed to list modules:', err);
+    console.error('[surface] failed to get module:', err);
     return;
   }
 
-  const target = manifests.find((m) => m.manifest.id === moduleId);
-  if (!target) {
+  if (!installed) {
     console.error(`[surface] module not found: ${moduleId}`);
     return;
   }
 
-  await loadAndBootModule(target.manifest, window);
+  await loadAndBootModule(installed.manifest, window);
 }
 
 async function loadAndBootModule(manifest: ModuleManifest, window: 'presenter' | 'surface') {

--- a/src/modules/presenter-injector.ts
+++ b/src/modules/presenter-injector.ts
@@ -40,7 +40,7 @@ export async function bootSingleModule(moduleId: string, window: 'presenter' | '
 }
 
 async function loadAndBootModule(manifest: ModuleManifest, window: 'presenter' | 'surface') {
-  const res = await fetch(`/__modules/${manifest.id}/${manifest.entry}?t=${Date.now()}`);
+  const res = await fetch(`/__modules/${manifest.id}/${manifest.entry}`);
   if (!res.ok) return;
 
   const code = await res.text();

--- a/src/modules/store.ts
+++ b/src/modules/store.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import type { ModuleRecord, ModuleStatus, PanelSpec, QueueTriggerSpec, SurfaceWindowOptions } from './types';
+import type { ModuleRecord, ModuleStatus, PanelSpec, QueueActionSpec, QueueTriggerSpec, SurfaceWindowOptions } from './types';
 
 export interface ModuleSurfaceState {
   moduleId: string;
@@ -12,6 +12,7 @@ interface ModuleStore {
   modules: Map<string, ModuleRecord>;
   panels: Map<string, PanelSpec[]>;
   queueTriggerSpecs: Map<string, QueueTriggerSpec>;
+  queueActionSpecs: Map<string, QueueActionSpec>;
   openDialogId: string | null;
   presenterViewId: string | null;
   presenterProps: unknown;
@@ -29,6 +30,8 @@ interface ModuleStore {
 
   registerQueueTrigger(spec: QueueTriggerSpec): () => void;
   getQueueTriggerSpecs(): QueueTriggerSpec[];
+  registerQueueAction(spec: QueueActionSpec): () => void;
+  getQueueActionSpecs(): QueueActionSpec[];
 
   openDialog(id: string): void;
   closeDialog(): void;
@@ -43,6 +46,7 @@ export const useModuleStore = create<ModuleStore>((set, get) => ({
   modules: new Map(),
   panels: new Map(),
   queueTriggerSpecs: new Map(),
+  queueActionSpecs: new Map(),
   openDialogId: null,
   presenterViewId: null,
   presenterProps: undefined,
@@ -136,6 +140,25 @@ export const useModuleStore = create<ModuleStore>((set, get) => ({
 
   getQueueTriggerSpecs() {
     return Array.from(get().queueTriggerSpecs.values());
+  },
+
+  registerQueueAction(spec) {
+    set((s) => {
+      const next = new Map(s.queueActionSpecs);
+      next.set(spec.id, spec);
+      return { queueActionSpecs: next };
+    });
+    return () => {
+      set((s) => {
+        const next = new Map(s.queueActionSpecs);
+        next.delete(spec.id);
+        return { queueActionSpecs: next };
+      });
+    };
+  },
+
+  getQueueActionSpecs() {
+    return Array.from(get().queueActionSpecs.values());
   },
 
   openDialog(id) {

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -257,6 +257,7 @@ export interface QueueHostAPI {
   previous(): void;
   goTo(index: number): void;
   registerTrigger(spec: QueueTriggerSpec): Disposable;
+  addTrigger(triggerId: string, config: unknown): void;
   addUrl?(input: { url: string; position?: 'end' | 'next'; duration?: number }): Promise<void>;
 }
 

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -243,6 +243,11 @@ export interface QueueTriggerSpec {
   onFire(config: unknown): void;
 }
 
+export interface QueueActionSpec {
+  id: string;
+  onFire(config: unknown): void;
+}
+
 export interface QueueHostAPI {
   items(): QueueItem[];
   currentIndex(): number;
@@ -257,6 +262,7 @@ export interface QueueHostAPI {
   previous(): void;
   goTo(index: number): void;
   registerTrigger(spec: QueueTriggerSpec): Disposable;
+  registerAction(spec: QueueActionSpec): Disposable;
   addTrigger(triggerId: string, config: unknown): void;
   addUrl?(input: { url: string; position?: 'end' | 'next'; duration?: number }): Promise<void>;
 }

--- a/src/services/queue-db-service.ts
+++ b/src/services/queue-db-service.ts
@@ -93,6 +93,55 @@ class QueueDbService {
     return rows.map(rowToItem);
   }
 
+  async loadAllRows(): Promise<QueueRow[]> {
+    const db = await this.ready();
+    return db.select<QueueRow[]>('SELECT * FROM queue ORDER BY position ASC');
+  }
+
+  async addTriggerEntry(entryId: string, triggerId: string, configJson: string, title: string, tag: string): Promise<number> {
+    const db = await this.ready();
+    const filePath = `trigger://${entryId}`;
+    const existing = await db.select<{ id: number }[]>(
+      'SELECT id FROM queue WHERE file_path = $1',
+      [filePath]
+    );
+    if (existing.length > 0) {
+      return existing[0].id;
+    }
+    const [{ max_pos }] = await db.select<[{ max_pos: number | null }]>(
+      'SELECT MAX(position) as max_pos FROM queue'
+    );
+    const position = (max_pos ?? -1) + 1;
+    const result = await db.execute(
+      `INSERT INTO queue (
+         position, file_path, file_name, file_size, file_modified_at, file_extension,
+         played, title, artist, original_url, download_status
+       )
+       VALUES ($1, $2, $3, 0, 0, '', 0, $4, $5, $6, 'downloaded')`,
+      [position, filePath, triggerId, title, tag, configJson]
+    );
+    console.log('[db] addTriggerEntry inserted id=', result.lastInsertId);
+    return result.lastInsertId!;
+  }
+
+  async removeTriggerEntry(entryId: string): Promise<void> {
+    const db = await this.ready();
+    await db.execute("DELETE FROM queue WHERE file_path = $1", [`trigger://${entryId}`]);
+  }
+
+  async toggleTriggerPlayed(entryId: string): Promise<void> {
+    const db = await this.ready();
+    await db.execute(
+      "UPDATE queue SET played = CASE WHEN played = 0 THEN 1 ELSE 0 END WHERE file_path = $1",
+      [`trigger://${entryId}`]
+    );
+  }
+
+  async loadTriggerEntries(): Promise<QueueRow[]> {
+    const db = await this.ready();
+    return db.select<QueueRow[]>("SELECT * FROM queue WHERE file_path LIKE 'trigger://%' ORDER BY position ASC");
+  }
+
   async exists(filePath: string): Promise<boolean> {
     const db = await this.ready();
     const parsed = urlMediaService.parseYouTubeUrl(filePath);
@@ -203,6 +252,19 @@ class QueueDbService {
     }
   }
 
+  async updateAllPositions(
+    idUpdates: { id: number; position: number }[],
+    pathUpdates: { path: string; position: number }[]
+  ): Promise<void> {
+    const db = await this.ready();
+    for (const { id, position } of idUpdates) {
+      await db.execute('UPDATE queue SET position = $1 WHERE id = $2', [position, id]);
+    }
+    for (const { path, position } of pathUpdates) {
+      await db.execute('UPDATE queue SET position = $1 WHERE file_path = $2', [position, path]);
+    }
+  }
+
   async shuffleQueue(): Promise<void> {
     const db = await this.ready();
     const rows = await db.select<QueueRow[]>('SELECT * FROM queue ORDER BY position ASC');
@@ -261,7 +323,7 @@ function isDownloadStatus(value: string | null): value is NonNullable<FileInfo['
   return value === 'not_downloaded' || value === 'downloaded' || value === 'missing';
 }
 
-function rowToItem(row: QueueRow): QueueDbItem {
+export function rowToItem(row: QueueRow): QueueDbItem {
   return {
     id: row.id,
     name: row.title ?? row.file_name,

--- a/src/stores/queue-entries-store.ts
+++ b/src/stores/queue-entries-store.ts
@@ -1,11 +1,11 @@
 import { toast } from 'sonner';
 import { create } from 'zustand';
 import { useModuleStore } from '@/modules/store';
-import { queueDbService } from '@/services/queue-db-service';
+import { queueDbService, rowToItem } from '@/services/queue-db-service';
 import type { FileInfo } from '@/services/types';
 import { useQueueStore, type QueueItem } from './queue-store';
 
-export type TriggerInstance = { id: string; triggerId: string; config: unknown; showLabel: boolean };
+export type TriggerInstance = { id: string; triggerId: string; config: unknown; showLabel: boolean; played: boolean };
 
 export type ListEntry =
   | { kind: 'item'; id: string; item: QueueItem }
@@ -21,8 +21,10 @@ interface QueueEntriesStore {
   pendingIndex: number;
   dropTargetIndex: number | null;
   dragFileInfo: FileInfo | null;
+  loadFromDb: () => Promise<void>;
   syncQueue: (queue: QueueItem[]) => void;
   setEntries: (entries: ListEntry[]) => void;
+  persistOrder: () => Promise<void>;
   setDropTargetIndex: (index: number | null) => void;
   setDragFileInfo: (file: FileInfo | null) => void;
   insertFileAtItemIndex: (file: FileInfo, itemIndex: number) => Promise<void>;
@@ -34,6 +36,44 @@ export const useQueueEntriesStore = create<QueueEntriesStore>((set, get) => ({
   pendingIndex: -1,
   dropTargetIndex: null,
   dragFileInfo: null,
+
+  loadFromDb: async () => {
+    try {
+      const rows = await queueDbService.loadAllRows();
+      const entries: ListEntry[] = [];
+      const seenPaths = new Set<string>();
+      const seenIds = new Set<string>();
+      for (const row of rows) {
+        if (seenPaths.has(row.file_path)) continue;
+        if (seenIds.has(String(row.id)) && !row.file_path.startsWith('trigger://')) continue;
+        seenPaths.add(row.file_path);
+        if (row.file_path.startsWith('trigger://')) {
+          const config = row.original_url ? JSON.parse(row.original_url) : {};
+          entries.push({
+            kind: 'trigger' as const,
+            id: row.file_path.slice('trigger://'.length),
+            inst: {
+              id: row.file_path.slice('trigger://'.length),
+              triggerId: row.file_name,
+              config,
+              showLabel: true,
+              played: row.played === 1,
+            },
+          });
+          seenIds.add(row.file_path);
+        } else {
+          const item = rowToItem(row);
+          entries.push({
+            kind: 'item' as const,
+            id: String(item.id),
+            item: { id: item.id, file: item, played: item.played },
+          });
+          seenIds.add(String(item.id));
+        }
+      }
+      set({ entries });
+    } catch {}
+  },
 
   syncQueue: (queue) => {
     set((state) => {
@@ -63,6 +103,21 @@ export const useQueueEntriesStore = create<QueueEntriesStore>((set, get) => ({
   },
 
   setEntries: (entries) => set({ entries }),
+
+  persistOrder: () => {
+    const { entries } = get();
+    const pathUpdates: { path: string; position: number }[] = [];
+    const idUpdates: { id: number; position: number }[] = [];
+    for (let i = 0; i < entries.length; i++) {
+      const e = entries[i];
+      if (e.kind === 'trigger') {
+        pathUpdates.push({ path: `trigger://${e.id}`, position: i });
+      } else {
+        idUpdates.push({ id: e.item.id, position: i });
+      }
+    }
+    return queueDbService.updateAllPositions(idUpdates, pathUpdates);
+  },
 
   setDropTargetIndex: (index) => set({ dropTargetIndex: index }),
   setDragFileInfo: (file) => set({ dragFileInfo: file }),
@@ -112,6 +167,19 @@ export const useQueueEntriesStore = create<QueueEntriesStore>((set, get) => ({
   advanceQueue: (currentFilePath) => {
     const { entries, pendingIndex } = get();
 
+    const markTriggerPlayed = (index: number) => {
+      const entry = entries[index];
+      if (entry.kind !== 'trigger') return;
+      set({
+        entries: entries.map((e, idx) =>
+          idx === index && e.kind === 'trigger'
+            ? { ...e, inst: { ...e.inst, played: true } }
+            : e
+        ),
+      });
+      queueDbService.toggleTriggerPlayed(entry.id).catch(() => {});
+    };
+
     let startIdx: number;
     if (pendingIndex >= 0) {
       startIdx = pendingIndex;
@@ -129,11 +197,20 @@ export const useQueueEntriesStore = create<QueueEntriesStore>((set, get) => ({
         return { type: 'play', path: entry.item.file.path };
       }
       if (entry.kind === 'trigger') {
-        const specs = useModuleStore.getState().getQueueTriggerSpecs();
-        const spec = specs.find((s) => s.id === entry.inst.triggerId);
-        if (spec) {
+        const triggerSpecs = useModuleStore.getState().getQueueTriggerSpecs();
+        const triggerSpec = triggerSpecs.find((s) => s.id === entry.inst.triggerId);
+        if (triggerSpec) {
+          markTriggerPlayed(i);
           set({ pendingIndex: i });
-          spec.onFire(entry.inst.config);
+          triggerSpec.onFire(entry.inst.config);
+          return { type: 'triggered' };
+        }
+        const actionSpecs = useModuleStore.getState().getQueueActionSpecs();
+        const actionSpec = actionSpecs.find((s) => s.id === entry.inst.triggerId);
+        if (actionSpec) {
+          markTriggerPlayed(i);
+          set({ pendingIndex: i });
+          actionSpec.onFire(entry.inst.config);
           return { type: 'triggered' };
         }
       }

--- a/src/stores/queue-store.ts
+++ b/src/stores/queue-store.ts
@@ -42,7 +42,11 @@ export const useQueueStore = create<QueueStore>((set, get) => ({
 
   loadFromDb: async () => {
     const items = await queueDbService.loadQueue();
-    set({ queue: items.map((item) => ({ id: item.id, file: item, played: item.played })) });
+    set({
+      queue: items
+        .filter((item) => !item.path.startsWith('trigger://'))
+        .map((item) => ({ id: item.id, file: item, played: item.played })),
+    });
   },
 
   addToQueue: async (file) => {


### PR DESCRIPTION
## 📋 Description

Refactor of the module system covering surface window reliability, module loading performance, and module API extensions (queue triggers and projected slide preview).

### What was changed?
- `src/app/module-surface-window.tsx` and `SurfaceWindowSlot`: stable close callback, added `Toaster`, primary-monitor default sizing, avoid maximized windows for WebView2 GPU performance.
- Module loading: `waitForSurfaceState` single-read (removes up to 7.5s polling delay), manifest cache in Rust `ModuleRuntime`, `module_get` single-module lookup, removed cache-buster query param.
- Module API: `addTrigger`, `QueueActionSpec`/registerAction infrastructure, queue action rendering with item parity, projected slide preview.

### Why?
- Reduce surface window open/load latency and duplicated side effects; remove wasteful polling/disk reads; expose queue trigger/action and slide preview capabilities to modules.

## 🔗 Related Issues

- Fixes #85

## 🧪 How to Test

**Before:**
1. Open a module surface window and measure delay.
2. Observe repeated disk reads / polling during module boot.

**After:**
1. Open a module surface window - opens near-instantly.
2. Verify module boots once with cached manifests and no polling.
3. Exercise queue triggers and actions from a module.
4. Verify projected slide preview in presenter controls.

## 📸 Screenshots / Recording

<!-- Logs, screenshots, or GIFs that demonstrate the fix. -->

## ✅ Checklist

- [x] Main flow tested manually
- [x] Checked for regressions in adjacent areas
- [ ] Behavior differences between dev and prod documented (if any)
- [ ] Tests added or updated
- [x] Self-reviewed

## 📝 Additional Notes

<!-- Known risks, trade-offs, follow-ups, or out-of-scope items. -->